### PR TITLE
fix QtWheelEvent propagation in valuedial and valuedialz

### DIFF
--- a/sdrgui/gui/valuedial.cpp
+++ b/sdrgui/gui/valuedial.cpp
@@ -345,7 +345,6 @@ void ValueDial::wheelEvent(QWheelEvent* event)
 		setValue(m_valueNew);
 		emit changed(m_valueNew);
 		event->accept();
-
 	}
 }
 

--- a/sdrgui/gui/valuedial.cpp
+++ b/sdrgui/gui/valuedial.cpp
@@ -344,6 +344,8 @@ void ValueDial::wheelEvent(QWheelEvent* event)
 		}
 		setValue(m_valueNew);
 		emit changed(m_valueNew);
+		event->accept();
+
 	}
 }
 

--- a/sdrgui/gui/valuedialz.cpp
+++ b/sdrgui/gui/valuedialz.cpp
@@ -428,6 +428,7 @@ void ValueDialZ::wheelEvent(QWheelEvent* event)
 
         setValue(m_valueNew);
         emit changed(m_valueNew);
+	event->accept();	
     }
 }
 


### PR DESCRIPTION
Adds termination to QWheelEvent so it wont sent to parent Window.
as described here:
http://www.setnode.com/blog/mouse-wheel-events-event-filters-and-qscrollarea/

I confirm this fixes Issue #132 for me.