### PR TITLE
Fix wrong library name in CMake module for hackrf

### DIFF
--- a/cmake/Modules/FindLibHACKRF.cmake
+++ b/cmake/Modules/FindLibHACKRF.cmake
@@ -1,6 +1,6 @@
 if(NOT LIBHACKRF_FOUND)
 
-  pkg_check_modules (LIBHACKRF_PKG libairspy)
+  pkg_check_modules (LIBHACKRF_PKG libhackrf)
   find_path(LIBHACKRF_INCLUDE_DIR NAMES libhackrf/hackrf.h
     PATHS
     ${LIBHACKRF_PKG_INCLUDE_DIRS}


### PR DESCRIPTION
I was wondering why the CMake configuration step did not find `libhackrf` although it was installed correctly and worked with other application:

```
-- libhackrf not found.
```

After fixing the obviously wrong library name for the CMake find module (probably caused by copy & paste error) the detection of `libhackrf` now worked correctly as seen below:

```
-- Checking for module 'libhackrf'
--   Found libhackrf, version 0.5
-- Found libhackrf: /usr/local/include, /usr/local/lib/libhackrf.dylib
```

Note: I've currently only tested this on macOS - but other systems are affected as well.