### PR TITLE
modified unique file name

### DIFF
--- a/plugins/samplesource/airspy/airspyinput.cpp
+++ b/plugins/samplesource/airspy/airspyinput.cpp
@@ -308,7 +308,7 @@ bool AirspyInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/airspyhf/airspyhfinput.cpp
+++ b/plugins/samplesource/airspyhf/airspyhfinput.cpp
@@ -325,7 +325,7 @@ bool AirspyHFInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/bladerfinput/bladerfinput.cpp
+++ b/plugins/samplesource/bladerfinput/bladerfinput.cpp
@@ -280,7 +280,7 @@ bool BladerfInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/fcdpro/fcdproinput.cpp
+++ b/plugins/samplesource/fcdpro/fcdproinput.cpp
@@ -250,7 +250,7 @@ bool FCDProInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/fcdproplus/fcdproplusinput.cpp
+++ b/plugins/samplesource/fcdproplus/fcdproplusinput.cpp
@@ -244,7 +244,7 @@ bool FCDProPlusInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/hackrfinput/hackrfinput.cpp
+++ b/plugins/samplesource/hackrfinput/hackrfinput.cpp
@@ -263,7 +263,7 @@ bool HackRFInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/limesdrinput/limesdrinput.cpp
+++ b/plugins/samplesource/limesdrinput/limesdrinput.cpp
@@ -692,7 +692,7 @@ bool LimeSDRInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/perseus/perseusinput.cpp
+++ b/plugins/samplesource/perseus/perseusinput.cpp
@@ -197,7 +197,7 @@ bool PerseusInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
@@ -195,7 +195,7 @@ bool PlutoSDRInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
@@ -309,7 +309,7 @@ bool RTLSDRInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/sdrdaemonsource/sdrdaemonsourceinput.cpp
+++ b/plugins/samplesource/sdrdaemonsource/sdrdaemonsourceinput.cpp
@@ -190,7 +190,7 @@ bool SDRdaemonSourceInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/sdrplay/sdrplayinput.cpp
+++ b/plugins/samplesource/sdrplay/sdrplayinput.cpp
@@ -304,7 +304,7 @@ bool SDRPlayInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/plugins/samplesource/testsource/testsourceinput.cpp
+++ b/plugins/samplesource/testsource/testsourceinput.cpp
@@ -182,7 +182,7 @@ bool TestSourceInput::handleMessage(const Message& message)
             if (m_settings.m_fileRecordName.size() != 0) {
                 m_fileSink->setFileName(m_settings.m_fileRecordName);
             } else {
-                m_fileSink->setFileName(QString("rec%1_%2.sdriq").arg(m_deviceAPI->getDeviceUID()).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss")));
+                m_fileSink->genUniqueFileName(m_deviceAPI->getDeviceUID());
             }
 
             m_fileSink->startRecording();

--- a/sdrbase/dsp/filerecord.cpp
+++ b/sdrbase/dsp/filerecord.cpp
@@ -4,6 +4,7 @@
 #include "util/message.h"
 
 #include <QDebug>
+#include <QDateTime>
 
 FileRecord::FileRecord() :
 	BasebandSampleSink(),
@@ -40,6 +41,11 @@ void FileRecord::setFileName(const QString& filename)
     {
         m_fileName = filename;
     }
+}
+
+void FileRecord::genUniqueFileName(uint deviceUID)
+{
+    setFileName(QString("rec%1_%2.sdriq").arg(deviceUID).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddTHH_mm_ss_zzz")));
 }
 
 void FileRecord::feed(const SampleVector::const_iterator& begin, const SampleVector::const_iterator& end, bool positiveOnly __attribute__((unused)))

--- a/sdrbase/dsp/filerecord.h
+++ b/sdrbase/dsp/filerecord.h
@@ -29,6 +29,7 @@ public:
     quint64 getByteCount() const { return m_byteCount; }
 
     void setFileName(const QString& filename);
+    void genUniqueFileName(uint deviceUID);
 
 	virtual void feed(const SampleVector::const_iterator& begin, const SampleVector::const_iterator& end, bool positiveOnly);
 	virtual void start();


### PR DESCRIPTION
i changed the file name to be compatible to Microsoft Windows file systems.
i also moved the generation of those file names to a method `genUniqueFileName` in `FileRecord`, then it is easier to maintain FileName generation.

BTW: on other places, i saw, that there is often "**hh**:mm:ss" used to format QTime/QDateTime to a QString.
maybe it is better to use "**HH**:mm:ss" to force **24**h format instead of only **12**h format in some cases.
[Format QTime to QString](http://doc.qt.io/qt-5/qtime.html#toString-2)