### PR TITLE
force 24h time format and uniform date format

### DIFF
--- a/logging/filelogger.cpp
+++ b/logging/filelogger.cpp
@@ -52,7 +52,7 @@ void FileLogger::refreshQtSettings()
     maxSize = settings->value("maxSize", 0).toLongLong();
     maxBackups = settings->value("maxBackups", 0).toInt();
     msgFormat = settings->value("msgFormat", "{timestamp} {type} {msg}").toString();
-    timestampFormat = settings->value("timestampFormat", "yyyy-MM-dd hh:mm:ss.zzz").toString();
+    timestampFormat = settings->value("timestampFormat", "yyyy-MM-dd HH:mm:ss.zzz").toString();
     minLevel = static_cast<QtMsgType>(settings->value("minLevel", 0).toInt());
     bufferSize = settings->value("bufferSize", 0).toInt();
 

--- a/logging/filelogger.h
+++ b/logging/filelogger.h
@@ -30,7 +30,7 @@ namespace qtwebapp {
   maxBackups=2
   minLevel=0
   msgformat={timestamp} {typeNr} {type} thread={thread}: {msg}
-  timestampFormat=dd.MM.yyyy hh:mm:ss.zzz
+  timestampFormat=yyyy-MM-dd HH:mm:ss.zzz
   bufferSize=0
   </pre></code>
 
@@ -43,7 +43,7 @@ namespace qtwebapp {
   - maxBackups defines the number of backup files to keep. Default is 0=unlimited.
   - minLevel defines the minimum type of messages that are written (together with buffered messages) into the file. Defaults is 0=debug.
   - msgFormat defines the decoration of log messages, see LogMessage class. Default is "{timestamp} {type} {msg}".
-  - timestampFormat defines the format of timestamps, see QDateTime::toString(). Default is "yyyy-MM-dd hh:mm:ss.zzz".
+  - timestampFormat defines the format of timestamps, see QDateTime::toString(). Default is "yyyy-MM-dd HH:mm:ss.zzz".
   - bufferSize defines the size of the buffer. Default is 0=disabled.
 
   @see set() describes how to set logger variables

--- a/logging/fileloggersettings.h
+++ b/logging/fileloggersettings.h
@@ -31,7 +31,7 @@ struct FileLoggerSettings
         maxSize = 1000000;
         maxBackups = 2;
         msgFormat = "{timestamp} {type} {msg}";
-        timestampFormat = "dd.MM.yyyy hh:mm:ss.zzz";
+        timestampFormat = "yyyy-MM-dd HH:mm:ss.zzz";
         minLevel = QtDebugMsg;
         bufferSize = 100;
     }

--- a/logging/logger.cpp
+++ b/logging/logger.cpp
@@ -25,7 +25,7 @@ QMutex Logger::mutex;
 Logger::Logger(QObject* parent)
     : QObject(parent),
     msgFormat("{timestamp} {type} {msg}"),
-    timestampFormat("dd.MM.yyyy hh:mm:ss.zzz"),
+    timestampFormat("yyyy-MM-dd HH:mm:ss.zzz"),
     minLevel(QtDebugMsg),
     bufferSize(0)
     {}

--- a/logging/logger.h
+++ b/logging/logger.h
@@ -65,13 +65,13 @@ public:
     /**
       Constructor.
       @param msgFormat Format of the decoration, e.g. "{timestamp} {type} thread={thread}: {msg}"
-      @param timestampFormat Format of timestamp, e.g. "dd.MM.yyyy hh:mm:ss.zzz"
+      @param timestampFormat Format of timestamp, e.g. "yyyy-MM-dd HH:mm:ss.zzz"
       @param minLevel Minimum severity that genertes an output (0=debug, 1=warning, 2=critical, 3=fatal).
       @param bufferSize Size of the backtrace buffer, number of messages per thread. 0=disabled.
       @param parent Parent object
       @see LogMessage for a description of the message decoration.
     */
-    Logger(const QString msgFormat="{timestamp} {type} {msg}", const QString timestampFormat="dd.MM.yyyy hh:mm:ss.zzz", const QtMsgType minLevel=QtDebugMsg, const int bufferSize=0, QObject* parent = 0);
+    Logger(const QString msgFormat="{timestamp} {type} {msg}", const QString timestampFormat="yyyy-MM-dd HH:mm:ss.zzz", const QtMsgType minLevel=QtDebugMsg, const int bufferSize=0, QObject* parent = 0);
 
     /** Destructor */
     virtual ~Logger();

--- a/logging/logmessage.h
+++ b/logging/logmessage.h
@@ -56,7 +56,7 @@ public:
       Returns the log message as decorated string.
       @param msgFormat Format of the decoration. May contain variables and static text,
           e.g. "{timestamp} {type} thread={thread}: {msg}".
-      @param timestampFormat Format of timestamp, e.g. "dd.MM.yyyy hh:mm:ss.zzz", see QDateTime::toString().
+      @param timestampFormat Format of timestamp, e.g. "yyyy-MM-dd HH:mm:ss.zzz", see QDateTime::toString().
       @see QDatetime for a description of the timestamp format pattern
     */
     QString toString(const QString& msgFormat, const QString& timestampFormat) const;

--- a/plugins/channelrx/demodbfm/bfmdemodgui.cpp
+++ b/plugins/channelrx/demodbfm/bfmdemodgui.cpp
@@ -671,8 +671,8 @@ void BFMDemodGUI::rdsUpdate(bool force)
 	{
 		ui->g04Label->setStyleSheet("QLabel { background-color : green; }");
 		ui->g04CountText->setNum((int) m_bfmDemod->getRDSParser().m_g4_count);
-		std::string time = str(boost::format("%02i.%02i.%4i, %02i:%02i (%+.1fh)")\
-			% m_bfmDemod->getRDSParser().m_g4_day % m_bfmDemod->getRDSParser().m_g4_month % (1900 + m_bfmDemod->getRDSParser().m_g4_year) % m_bfmDemod->getRDSParser().m_g4_hours % m_bfmDemod->getRDSParser().m_g4_minutes % m_bfmDemod->getRDSParser().m_g4_local_time_offset);
+		std::string time = str(boost::format("%4i-%02i-%02i %02i:%02i (%+.1fh)")\
+			% (1900 + m_bfmDemod->getRDSParser().m_g4_year) % m_bfmDemod->getRDSParser().m_g4_month % m_bfmDemod->getRDSParser().m_g4_day % m_bfmDemod->getRDSParser().m_g4_hours % m_bfmDemod->getRDSParser().m_g4_minutes % m_bfmDemod->getRDSParser().m_g4_local_time_offset);
 	    ui->g04Time->setText(QString(time.c_str()));
 	}
 	else

--- a/plugins/channelrx/demoddsd/dsdstatustextdialog.cpp
+++ b/plugins/channelrx/demoddsd/dsdstatustextdialog.cpp
@@ -41,7 +41,7 @@ void DSDStatusTextDialog::addLine(const QString& line)
     if ((line.size() > 0) && (line != m_lastLine))
     {
         QDateTime dt = QDateTime::currentDateTime();
-        QString dateStr = dt.toString("hh:mm:ss");
+        QString dateStr = dt.toString("HH:mm:ss");
         QTextCursor cursor = ui->logEdit->textCursor();
         cursor.movePosition(QTextCursor::End, QTextCursor::MoveAnchor);
         cursor.insertText(tr("%1 %2\n").arg(dateStr).arg(line));

--- a/plugins/channeltx/modam/ammodgui.cpp
+++ b/plugins/channeltx/modam/ammodgui.cpp
@@ -463,7 +463,7 @@ void AMModGUI::updateWithStreamData()
 {
     QTime recordLength(0, 0, 0, 0);
     recordLength = recordLength.addSecs(m_recordLength);
-    QString s_time = recordLength.toString("hh:mm:ss");
+    QString s_time = recordLength.toString("HH:mm:ss");
     ui->recordLengthText->setText(s_time);
     updateWithStreamTime();
 }
@@ -482,8 +482,8 @@ void AMModGUI::updateWithStreamTime()
     QTime t(0, 0, 0, 0);
     t = t.addSecs(t_sec);
     t = t.addMSecs(t_msec);
-    QString s_timems = t.toString("hh:mm:ss.zzz");
-    QString s_time = t.toString("hh:mm:ss");
+    QString s_timems = t.toString("HH:mm:ss.zzz");
+    QString s_time = t.toString("HH:mm:ss");
     ui->relTimeText->setText(s_timems);
 
     if (!m_enableNavTime)

--- a/plugins/channeltx/modatv/atvmodgui.cpp
+++ b/plugins/channeltx/modatv/atvmodgui.cpp
@@ -797,7 +797,7 @@ void ATVModGUI::updateWithStreamData()
 {
     QTime recordLength(0, 0, 0, 0);
     recordLength = recordLength.addSecs(m_videoLength / m_videoFrameRate);
-    QString s_time = recordLength.toString("hh:mm:ss");
+    QString s_time = recordLength.toString("HH:mm:ss");
     ui->recordLengthText->setText(s_time);
     updateWithStreamTime();
 }
@@ -817,8 +817,8 @@ void ATVModGUI::updateWithStreamTime()
     QTime t(0, 0, 0, 0);
     t = t.addSecs(t_sec);
     t = t.addMSecs(t_msec);
-    QString s_timems = t.toString("hh:mm:ss.zzz");
-    QString s_time = t.toString("hh:mm:ss");
+    QString s_timems = t.toString("HH:mm:ss.zzz");
+    QString s_time = t.toString("HH:mm:ss");
     ui->relTimeText->setText(s_timems);
 
     if (!m_enableNavTime)

--- a/plugins/channeltx/modnfm/nfmmodgui.cpp
+++ b/plugins/channeltx/modnfm/nfmmodgui.cpp
@@ -498,7 +498,7 @@ void NFMModGUI::updateWithStreamData()
 {
     QTime recordLength(0, 0, 0, 0);
     recordLength = recordLength.addSecs(m_recordLength);
-    QString s_time = recordLength.toString("hh:mm:ss");
+    QString s_time = recordLength.toString("HH:mm:ss");
     ui->recordLengthText->setText(s_time);
     updateWithStreamTime();
 }
@@ -517,8 +517,8 @@ void NFMModGUI::updateWithStreamTime()
     QTime t(0, 0, 0, 0);
     t = t.addSecs(t_sec);
     t = t.addMSecs(t_msec);
-    QString s_timems = t.toString("hh:mm:ss.zzz");
-    QString s_time = t.toString("hh:mm:ss");
+    QString s_timems = t.toString("HH:mm:ss.zzz");
+    QString s_time = t.toString("HH:mm:ss");
     ui->relTimeText->setText(s_timems);
 
     if (!m_enableNavTime)

--- a/plugins/channeltx/modssb/ssbmodgui.cpp
+++ b/plugins/channeltx/modssb/ssbmodgui.cpp
@@ -748,7 +748,7 @@ void SSBModGUI::updateWithStreamData()
 {
     QTime recordLength(0, 0, 0, 0);
     recordLength = recordLength.addSecs(m_recordLength);
-    QString s_time = recordLength.toString("hh:mm:ss");
+    QString s_time = recordLength.toString("HH:mm:ss");
     ui->recordLengthText->setText(s_time);
     updateWithStreamTime();
 }
@@ -767,8 +767,8 @@ void SSBModGUI::updateWithStreamTime()
     QTime t(0, 0, 0, 0);
     t = t.addSecs(t_sec);
     t = t.addMSecs(t_msec);
-    QString s_timems = t.toString("hh:mm:ss.zzz");
-    QString s_time = t.toString("hh:mm:ss");
+    QString s_timems = t.toString("HH:mm:ss.zzz");
+    QString s_time = t.toString("HH:mm:ss");
     ui->relTimeText->setText(s_timems);
 
     if (!m_enableNavTime)

--- a/plugins/channeltx/modwfm/wfmmodgui.cpp
+++ b/plugins/channeltx/modwfm/wfmmodgui.cpp
@@ -483,7 +483,7 @@ void WFMModGUI::updateWithStreamData()
 {
     QTime recordLength(0, 0, 0, 0);
     recordLength = recordLength.addSecs(m_recordLength);
-    QString s_time = recordLength.toString("hh:mm:ss");
+    QString s_time = recordLength.toString("HH:mm:ss");
     ui->recordLengthText->setText(s_time);
     updateWithStreamTime();
 }
@@ -502,8 +502,8 @@ void WFMModGUI::updateWithStreamTime()
     QTime t(0, 0, 0, 0);
     t = t.addSecs(t_sec);
     t = t.addMSecs(t_msec);
-    QString s_timems = t.toString("hh:mm:ss.zzz");
-    QString s_time = t.toString("hh:mm:ss");
+    QString s_timems = t.toString("HH:mm:ss.zzz");
+    QString s_time = t.toString("HH:mm:ss");
     ui->relTimeText->setText(s_timems);
 
     if (!m_enableNavTime)

--- a/plugins/samplesink/filesink/filesinkgui.cpp
+++ b/plugins/samplesink/filesink/filesinkgui.cpp
@@ -322,7 +322,7 @@ void FileSinkGui::updateWithStreamTime()
 	QTime t(0, 0, 0, 0);
 	t = t.addSecs(t_sec);
 	t = t.addMSecs(t_msec);
-	QString s_timems = t.toString("hh:mm:ss.zzz");
+	QString s_timems = t.toString("HH:mm:ss.zzz");
 	ui->relTimeText->setText(s_timems);
 }
 

--- a/plugins/samplesink/sdrdaemonsink/readme.md
+++ b/plugins/samplesink/sdrdaemonsink/readme.md
@@ -95,7 +95,7 @@ This counter counts the unrecoverable error conditions found (i.e. 6.4 between 1
 
 <h4>6.8: events counters timer</h4>
 
-This hh:mm:ss time display shows the time since the reset events counters button (4.6) was pushed.
+This HH:mm:ss time display shows the time since the reset events counters button (4.6) was pushed.
 
 <h3>7: Network parameters</h3>
 

--- a/plugins/samplesink/sdrdaemonsink/sdrdaemonsinkgui.cpp
+++ b/plugins/samplesink/sdrdaemonsink/sdrdaemonsinkgui.cpp
@@ -544,7 +544,7 @@ void SDRdaemonSinkGui::displayEventTimer()
     int elapsedTimeMillis = m_time.elapsed();
     QTime recordLength(0, 0, 0, 0);
     recordLength = recordLength.addSecs(elapsedTimeMillis/1000);
-    QString s_time = recordLength.toString("hh:mm:ss");
+    QString s_time = recordLength.toString("HH:mm:ss");
     ui->eventCountsTimeText->setText(s_time);
 }
 
@@ -561,7 +561,7 @@ void SDRdaemonSinkGui::updateWithStreamTime()
 	QTime t(0, 0, 0, 0);
 	t = t.addSecs(t_sec);
 	t = t.addMSecs(t_msec);
-	QString s_timems = t.toString("hh:mm:ss.zzz");
+	QString s_timems = t.toString("HH:mm:ss.zzz");
 	//ui->relTimeText->setText(s_timems); TODO with absolute time
 }
 

--- a/plugins/samplesource/filesource/filesourcegui.cpp
+++ b/plugins/samplesource/filesource/filesourcegui.cpp
@@ -317,7 +317,7 @@ void FileSourceGui::updateWithStreamData()
 	ui->play->setEnabled(m_acquisition);
 	QTime recordLength(0, 0, 0, 0);
 	recordLength = recordLength.addSecs(m_recordLength);
-	QString s_time = recordLength.toString("hh:mm:ss");
+	QString s_time = recordLength.toString("HH:mm:ss");
 	ui->recordLengthText->setText(s_time);
 	updateWithStreamTime(); // TODO: remove when time data is implemented
 }
@@ -335,15 +335,15 @@ void FileSourceGui::updateWithStreamTime()
 	QTime t(0, 0, 0, 0);
 	t = t.addSecs(t_sec);
 	t = t.addMSecs(t_msec);
-	QString s_timems = t.toString("hh:mm:ss.zzz");
-	QString s_time = t.toString("hh:mm:ss");
+	QString s_timems = t.toString("HH:mm:ss.zzz");
+	QString s_time = t.toString("HH:mm:ss");
 	ui->relTimeText->setText(s_timems);
 
     quint64 startingTimeStampMsec = (quint64) m_startingTimeStamp * 1000LL;
 	QDateTime dt = QDateTime::fromMSecsSinceEpoch(startingTimeStampMsec);
     dt = dt.addSecs((quint64) t_sec);
     dt = dt.addMSecs((quint64) t_msec);
-	QString s_date = dt.toString("yyyy-MM-dd hh:mm:ss.zzz");
+	QString s_date = dt.toString("yyyy-MM-dd HH:mm:ss.zzz");
 	ui->absTimeText->setText(s_date);
 
 	if (!m_enableNavTime)

--- a/plugins/samplesource/sdrdaemonsource/readme.md
+++ b/plugins/samplesource/sdrdaemonsource/readme.md
@@ -122,7 +122,7 @@ This counter counts the unrecoverable error conditions found (i.e. 4.4 between 1
 
 <h4>4.9: events counters timer</h4>
 
-This hh:mm:ss time display shows the time since the reset events counters button (4.6) was pushed.
+This HH:mm:ss time display shows the time since the reset events counters button (4.6) was pushed.
 
 <h3>5: Network parameters</h3>
 

--- a/plugins/samplesource/sdrdaemonsource/sdrdaemonsourcegui.cpp
+++ b/plugins/samplesource/sdrdaemonsource/sdrdaemonsourcegui.cpp
@@ -519,7 +519,7 @@ void SDRdaemonSourceGui::displayEventTimer()
     int elapsedTimeMillis = m_eventsTime.elapsed();
     QTime recordLength(0, 0, 0, 0);
     recordLength = recordLength.addSecs(elapsedTimeMillis/1000);
-    QString s_time = recordLength.toString("hh:mm:ss");
+    QString s_time = recordLength.toString("HH:mm:ss");
     ui->eventCountsTimeText->setText(s_time);
 }
 
@@ -532,7 +532,7 @@ void SDRdaemonSourceGui::updateWithStreamTime()
 	bool updateEventCounts = false;
     quint64 startingTimeStampMsec = ((quint64) m_startingTimeStamp.tv_sec * 1000LL) + ((quint64) m_startingTimeStamp.tv_usec / 1000LL);
     QDateTime dt = QDateTime::fromMSecsSinceEpoch(startingTimeStampMsec);
-    QString s_date = dt.toString("yyyy-MM-dd  hh:mm:ss.zzz");
+    QString s_date = dt.toString("yyyy-MM-dd  HH:mm:ss.zzz");
 	ui->absTimeText->setText(s_date);
 
 	if (m_framesDecodingStatus == 2)

--- a/sdrgui/gui/commandoutputdialog.cpp
+++ b/sdrgui/gui/commandoutputdialog.cpp
@@ -46,7 +46,7 @@ void CommandOutputDialog::refresh()
     {
         struct timeval tv = m_command.getLastProcessStartTimestamp();
         QDateTime dt = QDateTime::fromMSecsSinceEpoch(tv.tv_sec * 1000LL + tv.tv_usec / 1000LL);
-        QString dateStr = dt.toString("yyyy-MM-dd hh:mm:ss.zzz");
+        QString dateStr = dt.toString("yyyy-MM-dd HH:mm:ss.zzz");
         ui->startTime->setText(dateStr);
     }
 
@@ -57,7 +57,7 @@ void CommandOutputDialog::refresh()
     {
         struct timeval tv = m_command.getLastProcessFinishTimestamp();
         QDateTime dt = QDateTime::fromMSecsSinceEpoch(tv.tv_sec * 1000LL + tv.tv_usec / 1000LL);
-        QString dateStr = dt.toString("yyyy-MM-dd hh:mm:ss.zzz");
+        QString dateStr = dt.toString("yyyy-MM-dd HH:mm:ss.zzz");
         ui->endTime->setText(dateStr);
     }
 

--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -1726,7 +1726,7 @@ void MainWindow::tabInputViewIndexChanged()
 
 void MainWindow::updateStatus()
 {
-    m_dateTimeWidget->setText(QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss t"));
+    m_dateTimeWidget->setText(QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm:ss t"));
 }
 
 void MainWindow::setLoggingOptions()

--- a/sdrgui/readme.md
+++ b/sdrgui/readme.md
@@ -70,7 +70,7 @@ Log message will appear as follows:
 (1)                     (2) (3)
 ```
 
-  - 1: Timestamp in `dd.MM.yyyy hh:mm:ss.zzz` format
+  - 1: Timestamp in `yyyy-MM-dd HH:mm:ss.zzz` format
   - 2: Message level: `(D)`: debug, `(I)`: info, `(W)`: warning, `(C)`: critical, `(F)`: fatal
   - 3: Message text
 


### PR DESCRIPTION
changed **hh**:mm to **HH**:mm
changed **dd.MM.yyyy** to **yyyy-MM-dd** to uniform date format

maybe the changed date format will break some logging processing of the **sdrangel.log** file, when it is processed with scripts that are expecting the **dd.MM.yyyy** format.