### PR TITLE
Fix build on current Arch Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,8 @@ set(CMAKE_AUTOMOC ON)
 find_package(Qt5Core 5.0 REQUIRED)
 find_package(Qt5Widgets 5.0 REQUIRED)
 find_package(Qt5Multimedia 5.0 REQUIRED)
-#find_package(QT5OpenGL 5.0 REQUIRED)
+find_package(Qt5MultimediaWidgets 5.0 REQUIRED)
+find_package(Qt5OpenGL 5.0 REQUIRED)
 find_package(OpenGL REQUIRED)
 find_package(PkgConfig)
 find_package(Boost REQUIRED)
@@ -276,7 +277,7 @@ if(WIN32)
     set_target_properties(sdrangel PROPERTIES LINK_FLAGS_MINSIZEREL "/SUBSYSTEM:windows /ENTRY:mainCRTStartup")
 endif(WIN32)
 
-qt5_use_modules(sdrangel Widgets Multimedia)
+target_link_libraries(sdrangel Qt5::Widgets Qt5::Multimedia)
 
 ##############################################################################
 # main server application
@@ -300,7 +301,7 @@ target_link_libraries(sdrangelsrv
     ${QT_LIBRARIES}
 )
 
-qt5_use_modules(sdrangelsrv Multimedia)
+target_link_libraries(sdrangelsrv Qt5::Multimedia)
 
 ##############################################################################
 # main benchmark application
@@ -324,7 +325,7 @@ target_link_libraries(sdrangelbench
 )
 
 target_compile_features(sdrangelbench PRIVATE cxx_generalized_initializers) # cmake >= 3.1.0
-qt5_use_modules(sdrangelbench Multimedia)
+target_link_libraries(sdrangelbench Qt5::Multimedia)
 
 ##############################################################################
 

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -50,6 +50,6 @@ target_link_libraries(httpserver
 	${QT_LIBRARIES}
 )
 
-qt5_use_modules(httpserver Core Network)
+target_link_libraries(httpserver Qt5::Core Qt5::Network)
 
 install(TARGETS httpserver DESTINATION lib)

--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -36,6 +36,6 @@ target_link_libraries(logging
 	${QT_LIBRARIES}
 )
 
-qt5_use_modules(logging Core Network)
+target_link_libraries(logging Qt5::Core Qt5::Network)
 
 install(TARGETS logging DESTINATION lib)

--- a/plugins/channelrx/chanalyzer/CMakeLists.txt
+++ b/plugins/channelrx/chanalyzer/CMakeLists.txt
@@ -41,6 +41,6 @@ target_link_libraries(chanalyzer
 	sdrgui
 )
 
-qt5_use_modules(chanalyzer Core Widgets )
+target_link_libraries(chanalyzer Qt5::Core Qt5::Widgets )
 
 install(TARGETS chanalyzer DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/chanalyzerng/CMakeLists.txt
+++ b/plugins/channelrx/chanalyzerng/CMakeLists.txt
@@ -43,6 +43,6 @@ target_link_libraries(chanalyzerng
 	sdrgui
 )
 
-qt5_use_modules(chanalyzerng Core Widgets )
+target_link_libraries(chanalyzerng Qt5::Core Qt5::Widgets )
 
 install(TARGETS chanalyzerng DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/demodam/CMakeLists.txt
+++ b/plugins/channelrx/demodam/CMakeLists.txt
@@ -49,6 +49,6 @@ target_link_libraries(demodam
 	sdrgui
 )
 
-qt5_use_modules(demodam Core Widgets)
+target_link_libraries(demodam Qt5::Core Qt5::Widgets)
 
 install(TARGETS demodam DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/demodatv/CMakeLists.txt
+++ b/plugins/channelrx/demodatv/CMakeLists.txt
@@ -43,6 +43,6 @@ target_link_libraries(demodatv
 	sdrgui
 )
 
-qt5_use_modules(demodatv Core Widgets)
+target_link_libraries(demodatv Qt5::Core Qt5::Widgets)
 
 install(TARGETS demodatv DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/demodbfm/CMakeLists.txt
+++ b/plugins/channelrx/demodbfm/CMakeLists.txt
@@ -56,6 +56,6 @@ target_link_libraries(demodbfm
 	sdrgui
 )
 
-qt5_use_modules(demodbfm Core Widgets)
+target_link_libraries(demodbfm Qt5::Core Qt5::Widgets)
 
 install(TARGETS demodbfm DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/demoddatv/CMakeLists.txt
+++ b/plugins/channelrx/demoddatv/CMakeLists.txt
@@ -51,6 +51,6 @@ target_link_libraries(demoddatv
 	${SWSCALE_LIBRARIES}
 )
 
-qt5_use_modules(demoddatv Core Widgets Multimedia MultimediaWidgets)
+target_link_libraries(demoddatv Qt5::Core Qt5::Widgets Qt5::Multimedia Qt5::MultimediaWidgets)
 
 install(TARGETS demoddatv DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/demoddatv/datvideorender.cpp
+++ b/plugins/channelrx/demoddatv/datvideorender.cpp
@@ -341,7 +341,7 @@ bool DATVideoRender::OpenStream(DATVideostream *objDevice)
         return false;
     }
 
-    ptrIOBuffer = (unsigned char *)av_malloc(intIOBufferSize+ FF_INPUT_BUFFER_PADDING_SIZE);
+    ptrIOBuffer = (unsigned char *)av_malloc(intIOBufferSize+ AV_INPUT_BUFFER_PADDING_SIZE);
 
     objIOCtx = avio_alloc_context(  ptrIOBuffer,
                                     intIOBufferSize,

--- a/plugins/channelrx/demoddsd/CMakeLists.txt
+++ b/plugins/channelrx/demoddsd/CMakeLists.txt
@@ -75,6 +75,6 @@ target_link_libraries(demoddsd
 endif (BUILD_DEBIAN)
 
 
-qt5_use_modules(demoddsd Core Widgets)
+target_link_libraries(demoddsd Qt5::Core Qt5::Widgets)
 
 install(TARGETS demoddsd DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/demodlora/CMakeLists.txt
+++ b/plugins/channelrx/demodlora/CMakeLists.txt
@@ -43,6 +43,6 @@ target_link_libraries(demodlora
 	sdrgui
 )
 
-qt5_use_modules(demodlora Core Widgets)
+target_link_libraries(demodlora Qt5::Core Qt5::Widgets)
 
 install(TARGETS demodlora DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/demodnfm/CMakeLists.txt
+++ b/plugins/channelrx/demodnfm/CMakeLists.txt
@@ -47,6 +47,6 @@ target_link_libraries(demodnfm
 	swagger
 )
 
-qt5_use_modules(demodnfm Core Widgets)
+target_link_libraries(demodnfm Qt5::Core Qt5::Widgets)
 
 install(TARGETS demodnfm DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/demodssb/CMakeLists.txt
+++ b/plugins/channelrx/demodssb/CMakeLists.txt
@@ -45,6 +45,6 @@ target_link_libraries(demodssb
 	sdrgui
 )
 
-qt5_use_modules(demodssb Core Widgets)
+target_link_libraries(demodssb Qt5::Core Qt5::Widgets)
 
 install(TARGETS demodssb DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/demodwfm/CMakeLists.txt
+++ b/plugins/channelrx/demodwfm/CMakeLists.txt
@@ -45,6 +45,6 @@ target_link_libraries(demodwfm
 	sdrgui
 )
 
-qt5_use_modules(demodwfm Core Widgets)
+target_link_libraries(demodwfm Qt5::Core Qt5::Widgets)
 
 install(TARGETS demodwfm DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/tcpsrc/CMakeLists.txt
+++ b/plugins/channelrx/tcpsrc/CMakeLists.txt
@@ -43,6 +43,6 @@ target_link_libraries(demodtcpsrc
 	sdrgui
 )
 
-qt5_use_modules(demodtcpsrc Core Widgets Network)
+target_link_libraries(demodtcpsrc Qt5::Core Qt5::Widgets Qt5::Network)
 
 install(TARGETS demodtcpsrc DESTINATION lib/plugins/channelrx)

--- a/plugins/channelrx/udpsrc/CMakeLists.txt
+++ b/plugins/channelrx/udpsrc/CMakeLists.txt
@@ -42,6 +42,6 @@ target_link_libraries(demodudpsrc
 	sdrgui
 )
 
-qt5_use_modules(demodudpsrc Core Widgets Network)
+target_link_libraries(demodudpsrc Qt5::Core Qt5::Widgets Qt5::Network)
 
 install(TARGETS demodudpsrc DESTINATION lib/plugins/channelrx)

--- a/plugins/channeltx/modam/CMakeLists.txt
+++ b/plugins/channeltx/modam/CMakeLists.txt
@@ -45,6 +45,6 @@ target_link_libraries(modam
 	swagger
 )
 
-qt5_use_modules(modam Core Widgets)
+target_link_libraries(modam Qt5::Core Qt5::Widgets)
 
 install(TARGETS modam DESTINATION lib/plugins/channeltx)

--- a/plugins/channeltx/modatv/CMakeLists.txt
+++ b/plugins/channeltx/modatv/CMakeLists.txt
@@ -49,6 +49,6 @@ target_link_libraries(modatv
 	swagger
 )
 
-qt5_use_modules(modatv Core Widgets)
+target_link_libraries(modatv Qt5::Core Qt5::Widgets)
 
 install(TARGETS modatv DESTINATION lib/plugins/channeltx)

--- a/plugins/channeltx/modnfm/CMakeLists.txt
+++ b/plugins/channeltx/modnfm/CMakeLists.txt
@@ -45,6 +45,6 @@ target_link_libraries(modnfm
 	swagger
 )
 
-qt5_use_modules(modnfm Core Widgets)
+target_link_libraries(modnfm Qt5::Core Qt5::Widgets)
 
 install(TARGETS modnfm DESTINATION lib/plugins/channeltx)

--- a/plugins/channeltx/modssb/CMakeLists.txt
+++ b/plugins/channeltx/modssb/CMakeLists.txt
@@ -45,6 +45,6 @@ target_link_libraries(modssb
 	swagger    
 )
 
-qt5_use_modules(modssb Core Widgets)
+target_link_libraries(modssb Qt5::Core Qt5::Widgets)
 
 install(TARGETS modssb DESTINATION lib/plugins/channeltx)

--- a/plugins/channeltx/modwfm/CMakeLists.txt
+++ b/plugins/channeltx/modwfm/CMakeLists.txt
@@ -45,6 +45,6 @@ target_link_libraries(modwfm
 	swagger
 )
 
-qt5_use_modules(modwfm Core Widgets)
+target_link_libraries(modwfm Qt5::Core Qt5::Widgets)
 
 install(TARGETS modwfm DESTINATION lib/plugins/channeltx)

--- a/plugins/channeltx/udpsink/CMakeLists.txt
+++ b/plugins/channeltx/udpsink/CMakeLists.txt
@@ -50,6 +50,6 @@ target_link_libraries(modudpsink
 	swagger
 )
 
-qt5_use_modules(modudpsink Core Widgets Network)
+target_link_libraries(modudpsink Qt5::Core Qt5::Widgets Qt5::Network)
 
 install(TARGETS modudpsink DESTINATION lib/plugins/channeltx)

--- a/plugins/samplesink/bladerfoutput/CMakeLists.txt
+++ b/plugins/samplesink/bladerfoutput/CMakeLists.txt
@@ -75,6 +75,6 @@ target_link_libraries(outputbladerf
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(outputbladerf Core Widgets)
+target_link_libraries(outputbladerf Qt5::Core Qt5::Widgets)
 
 install(TARGETS outputbladerf DESTINATION lib/plugins/samplesink)

--- a/plugins/samplesink/filesink/CMakeLists.txt
+++ b/plugins/samplesink/filesink/CMakeLists.txt
@@ -47,6 +47,6 @@ target_link_libraries(outputfilesink
 	swagger
 )
 
-qt5_use_modules(outputfilesink Core Widgets)
+target_link_libraries(outputfilesink Qt5::Core Qt5::Widgets)
 
 install(TARGETS outputfilesink DESTINATION lib/plugins/samplesink)

--- a/plugins/samplesink/hackrfoutput/CMakeLists.txt
+++ b/plugins/samplesink/hackrfoutput/CMakeLists.txt
@@ -76,6 +76,6 @@ target_link_libraries(outputhackrf
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(outputhackrf Core Widgets)
+target_link_libraries(outputhackrf Qt5::Core Qt5::Widgets)
 
 install(TARGETS outputhackrf DESTINATION lib/plugins/samplesink)

--- a/plugins/samplesink/limesdroutput/CMakeLists.txt
+++ b/plugins/samplesink/limesdroutput/CMakeLists.txt
@@ -82,6 +82,6 @@ target_link_libraries(outputlimesdr
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(outputlimesdr Core Widgets)
+target_link_libraries(outputlimesdr Qt5::Core Qt5::Widgets)
 
 install(TARGETS outputlimesdr DESTINATION lib/plugins/samplesink)

--- a/plugins/samplesink/plutosdroutput/CMakeLists.txt
+++ b/plugins/samplesink/plutosdroutput/CMakeLists.txt
@@ -74,6 +74,6 @@ target_link_libraries(outputplutosdr
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(outputplutosdr Core Widgets)
+target_link_libraries(outputplutosdr Qt5::Core Qt5::Widgets)
 
 install(TARGETS outputplutosdr DESTINATION lib/plugins/samplesink)

--- a/plugins/samplesink/sdrdaemonsink/CMakeLists.txt
+++ b/plugins/samplesink/sdrdaemonsink/CMakeLists.txt
@@ -86,6 +86,6 @@ target_link_libraries(outputsdrdaemonsink
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(outputsdrdaemonsink Core Widgets)
+target_link_libraries(outputsdrdaemonsink Qt5::Core Qt5::Widgets)
 
 install(TARGETS outputsdrdaemonsink DESTINATION lib/plugins/samplesink)

--- a/plugins/samplesource/airspy/CMakeLists.txt
+++ b/plugins/samplesource/airspy/CMakeLists.txt
@@ -73,6 +73,6 @@ target_link_libraries(inputairspy
 endif (BUILD_DEBIAN)
 
 
-qt5_use_modules(inputairspy Core Widgets)
+target_link_libraries(inputairspy Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputairspy DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/airspyhf/CMakeLists.txt
+++ b/plugins/samplesource/airspyhf/CMakeLists.txt
@@ -73,6 +73,6 @@ target_link_libraries(inputairspyhf
 endif (BUILD_DEBIAN)
 
 
-qt5_use_modules(inputairspyhf Core Widgets)
+target_link_libraries(inputairspyhf Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputairspyhf DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/bladerfinput/CMakeLists.txt
+++ b/plugins/samplesource/bladerfinput/CMakeLists.txt
@@ -75,6 +75,6 @@ target_link_libraries(inputbladerf
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(inputbladerf Core Widgets)
+target_link_libraries(inputbladerf Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputbladerf DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/fcdpro/CMakeLists.txt
+++ b/plugins/samplesource/fcdpro/CMakeLists.txt
@@ -54,6 +54,6 @@ target_link_libraries(inputfcdpro
 	swagger
 )
 
-qt5_use_modules(inputfcdpro Core Widgets)
+target_link_libraries(inputfcdpro Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputfcdpro DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/fcdproplus/CMakeLists.txt
+++ b/plugins/samplesource/fcdproplus/CMakeLists.txt
@@ -54,6 +54,6 @@ target_link_libraries(inputfcdproplus
 	swagger
 )
 
-qt5_use_modules(inputfcdproplus Core Widgets)
+target_link_libraries(inputfcdproplus Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputfcdproplus DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/filesource/CMakeLists.txt
+++ b/plugins/samplesource/filesource/CMakeLists.txt
@@ -49,6 +49,6 @@ target_link_libraries(inputfilesource
 	swagger
 )
 
-qt5_use_modules(inputfilesource Core Widgets)
+target_link_libraries(inputfilesource Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputfilesource DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/hackrfinput/CMakeLists.txt
+++ b/plugins/samplesource/hackrfinput/CMakeLists.txt
@@ -76,6 +76,6 @@ target_link_libraries(inputhackrf
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(inputhackrf Core Widgets)
+target_link_libraries(inputhackrf Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputhackrf DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/limesdrinput/CMakeLists.txt
+++ b/plugins/samplesource/limesdrinput/CMakeLists.txt
@@ -82,6 +82,6 @@ target_link_libraries(inputlimesdr
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(inputlimesdr Core Widgets)
+target_link_libraries(inputlimesdr Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputlimesdr DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/perseus/CMakeLists.txt
+++ b/plugins/samplesource/perseus/CMakeLists.txt
@@ -77,6 +77,6 @@ target_link_libraries(inputperseus
 endif (BUILD_DEBIAN)
 
 
-qt5_use_modules(inputperseus Core Widgets)
+target_link_libraries(inputperseus Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputperseus DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/plutosdrinput/CMakeLists.txt
+++ b/plugins/samplesource/plutosdrinput/CMakeLists.txt
@@ -74,6 +74,6 @@ target_link_libraries(inputplutosdr
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(inputplutosdr Core Widgets)
+target_link_libraries(inputplutosdr Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputplutosdr DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/rtlsdr/CMakeLists.txt
+++ b/plugins/samplesource/rtlsdr/CMakeLists.txt
@@ -72,6 +72,6 @@ target_link_libraries(inputrtlsdr
 endif (BUILD_DEBIAN)
 
 
-qt5_use_modules(inputrtlsdr Core Widgets)
+target_link_libraries(inputrtlsdr Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputrtlsdr DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/sdrdaemonsource/CMakeLists.txt
+++ b/plugins/samplesource/sdrdaemonsource/CMakeLists.txt
@@ -85,6 +85,6 @@ target_link_libraries(inputsdrdaemonsource
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(inputsdrdaemonsource Core Widgets)
+target_link_libraries(inputsdrdaemonsource Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputsdrdaemonsource DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/sdrplay/CMakeLists.txt
+++ b/plugins/samplesource/sdrplay/CMakeLists.txt
@@ -68,6 +68,6 @@ target_link_libraries(inputsdrplay
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(inputsdrplay Core Widgets)
+target_link_libraries(inputsdrplay Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputsdrplay DESTINATION lib/plugins/samplesource)

--- a/plugins/samplesource/testsource/CMakeLists.txt
+++ b/plugins/samplesource/testsource/CMakeLists.txt
@@ -49,6 +49,6 @@ target_link_libraries(inputtestsource
 	swagger
 )
 
-qt5_use_modules(inputtestsource Core Widgets)
+target_link_libraries(inputtestsource Qt5::Core Qt5::Widgets)
 
 install(TARGETS inputtestsource DESTINATION lib/plugins/samplesource)

--- a/pluginssrv/channelrx/demodam/CMakeLists.txt
+++ b/pluginssrv/channelrx/demodam/CMakeLists.txt
@@ -37,6 +37,6 @@ target_link_libraries(demodamsrv
 	swagger
 )
 
-qt5_use_modules(demodamsrv Core)
+target_link_libraries(demodamsrv Qt5::Core)
 
 install(TARGETS demodamsrv DESTINATION lib/pluginssrv/channelrx)

--- a/pluginssrv/channelrx/demodnfm/CMakeLists.txt
+++ b/pluginssrv/channelrx/demodnfm/CMakeLists.txt
@@ -37,6 +37,6 @@ target_link_libraries(demodnfmsrv
 	swagger
 )
 
-qt5_use_modules(demodnfmsrv Core)
+target_link_libraries(demodnfmsrv Qt5::Core)
 
 install(TARGETS demodnfmsrv DESTINATION lib/pluginssrv/channelrx)

--- a/pluginssrv/channeltx/modam/CMakeLists.txt
+++ b/pluginssrv/channeltx/modam/CMakeLists.txt
@@ -36,6 +36,6 @@ target_link_libraries(modamsrv
 	swagger
 )
 
-qt5_use_modules(modamsrv Core)
+target_link_libraries(modamsrv Qt5::Core)
 
 install(TARGETS modamsrv DESTINATION lib/pluginssrv/channeltx)

--- a/pluginssrv/channeltx/modatv/CMakeLists.txt
+++ b/pluginssrv/channeltx/modatv/CMakeLists.txt
@@ -40,6 +40,6 @@ target_link_libraries(modatvsrv
 	swagger
 )
 
-qt5_use_modules(modatvsrv Core)
+target_link_libraries(modatvsrv Qt5::Core)
 
 install(TARGETS modatvsrv DESTINATION lib/pluginssrv/channeltx)

--- a/pluginssrv/channeltx/modnfm/CMakeLists.txt
+++ b/pluginssrv/channeltx/modnfm/CMakeLists.txt
@@ -36,6 +36,6 @@ target_link_libraries(modnfmsrv
 	swagger
 )
 
-qt5_use_modules(modnfmsrv Core)
+target_link_libraries(modnfmsrv Qt5::Core)
 
 install(TARGETS modnfmsrv DESTINATION lib/pluginssrv/channeltx)

--- a/pluginssrv/channeltx/modssb/CMakeLists.txt
+++ b/pluginssrv/channeltx/modssb/CMakeLists.txt
@@ -36,6 +36,6 @@ target_link_libraries(modssbsrv
 	swagger    
 )
 
-qt5_use_modules(modssbsrv Core)
+target_link_libraries(modssbsrv Qt5::Core)
 
 install(TARGETS modssbsrv DESTINATION lib/pluginssrv/channeltx)

--- a/pluginssrv/channeltx/modwfm/CMakeLists.txt
+++ b/pluginssrv/channeltx/modwfm/CMakeLists.txt
@@ -36,6 +36,6 @@ target_link_libraries(modwfmsrv
 	swagger
 )
 
-qt5_use_modules(modwfmsrv Core)
+target_link_libraries(modwfmsrv Qt5::Core)
 
 install(TARGETS modwfmsrv DESTINATION lib/pluginssrv/channeltx)

--- a/pluginssrv/channeltx/udpsink/CMakeLists.txt
+++ b/pluginssrv/channeltx/udpsink/CMakeLists.txt
@@ -40,6 +40,6 @@ target_link_libraries(modudpsinksrv
 	swagger
 )
 
-qt5_use_modules(modudpsinksrv Core Network)
+target_link_libraries(modudpsinksrv Qt5::Core Qt5::Network)
 
 install(TARGETS modudpsinksrv DESTINATION lib/pluginssrv/channeltx)

--- a/pluginssrv/samplesink/bladerfoutput/CMakeLists.txt
+++ b/pluginssrv/samplesink/bladerfoutput/CMakeLists.txt
@@ -63,6 +63,6 @@ target_link_libraries(outputbladerfsrv
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(outputbladerfsrv Core)
+target_link_libraries(outputbladerfsrv Qt5::Core)
 
 install(TARGETS outputbladerfsrv DESTINATION lib/pluginssrv/samplesink)

--- a/pluginssrv/samplesink/filesink/CMakeLists.txt
+++ b/pluginssrv/samplesink/filesink/CMakeLists.txt
@@ -39,6 +39,6 @@ target_link_libraries(outputfilesinksrv
 	swagger
 )
 
-qt5_use_modules(outputfilesinksrv Core)
+target_link_libraries(outputfilesinksrv Qt5::Core)
 
 install(TARGETS outputfilesinksrv DESTINATION lib/pluginssrv/samplesink)

--- a/pluginssrv/samplesink/hackrfoutput/CMakeLists.txt
+++ b/pluginssrv/samplesink/hackrfoutput/CMakeLists.txt
@@ -65,6 +65,6 @@ target_link_libraries(outputhackrfsrv
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(outputhackrfsrv Core)
+target_link_libraries(outputhackrfsrv Qt5::Core)
 
 install(TARGETS outputhackrfsrv DESTINATION lib/pluginssrv/samplesink)

--- a/pluginssrv/samplesink/limesdroutput/CMakeLists.txt
+++ b/pluginssrv/samplesink/limesdroutput/CMakeLists.txt
@@ -73,6 +73,6 @@ target_link_libraries(outputlimesdrsrv
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(outputlimesdrsrv Core)
+target_link_libraries(outputlimesdrsrv Qt5::Core)
 
 install(TARGETS outputlimesdrsrv DESTINATION lib/pluginssrv/samplesink)

--- a/pluginssrv/samplesource/airspyhf/CMakeLists.txt
+++ b/pluginssrv/samplesource/airspyhf/CMakeLists.txt
@@ -59,6 +59,6 @@ target_link_libraries(inputairspyhfsrv
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(inputairspyhfsrv Core)
+target_link_libraries(inputairspyhfsrv Qt5::Core)
 
 install(TARGETS inputairspyhfsrv DESTINATION lib/pluginssrv/samplesource)

--- a/pluginssrv/samplesource/bladerfinput/CMakeLists.txt
+++ b/pluginssrv/samplesource/bladerfinput/CMakeLists.txt
@@ -63,6 +63,6 @@ target_link_libraries(inputbladerfsrv
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(inputbladerfsrv Core)
+target_link_libraries(inputbladerfsrv Qt5::Core)
 
 install(TARGETS inputbladerfsrv DESTINATION lib/pluginssrv/samplesource)

--- a/pluginssrv/samplesource/filesource/CMakeLists.txt
+++ b/pluginssrv/samplesource/filesource/CMakeLists.txt
@@ -40,6 +40,6 @@ target_link_libraries(inputfilesourcesrv
 	swagger
 )
 
-qt5_use_modules(inputfilesourcesrv Core)
+target_link_libraries(inputfilesourcesrv Qt5::Core)
 
 install(TARGETS inputfilesourcesrv DESTINATION lib/pluginssrv/samplesource)

--- a/pluginssrv/samplesource/hackrfinput/CMakeLists.txt
+++ b/pluginssrv/samplesource/hackrfinput/CMakeLists.txt
@@ -65,6 +65,6 @@ target_link_libraries(inputhackrfsrv
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(inputhackrfsrv Core)
+target_link_libraries(inputhackrfsrv Qt5::Core)
 
 install(TARGETS inputhackrfsrv DESTINATION lib/pluginssrv/samplesource)

--- a/pluginssrv/samplesource/limesdrinput/CMakeLists.txt
+++ b/pluginssrv/samplesource/limesdrinput/CMakeLists.txt
@@ -73,6 +73,6 @@ target_link_libraries(inputlimesdrsrv
 )
 endif (BUILD_DEBIAN)
 
-qt5_use_modules(inputlimesdrsrv Core)
+target_link_libraries(inputlimesdrsrv Qt5::Core)
 
 install(TARGETS inputlimesdrsrv DESTINATION lib/pluginssrv/samplesource)

--- a/pluginssrv/samplesource/rtlsdr/CMakeLists.txt
+++ b/pluginssrv/samplesource/rtlsdr/CMakeLists.txt
@@ -63,6 +63,6 @@ target_link_libraries(inputrtlsdrsrv
 endif (BUILD_DEBIAN)
 
 
-qt5_use_modules(inputrtlsdrsrv Core)
+target_link_libraries(inputrtlsdrsrv Qt5::Core)
 
 install(TARGETS inputrtlsdrsrv DESTINATION lib/pluginssrv/samplesource)

--- a/qrtplib/CMakeLists.txt
+++ b/qrtplib/CMakeLists.txt
@@ -90,6 +90,6 @@ target_link_libraries(qrtplib
     ${QT_LIBRARIES}
 )
 
-qt5_use_modules(qrtplib Core Network)
+target_link_libraries(qrtplib Qt5::Core Qt5::Network)
 
 install(TARGETS qrtplib DESTINATION lib)

--- a/sdrbase/CMakeLists.txt
+++ b/sdrbase/CMakeLists.txt
@@ -301,7 +301,7 @@ endif (BUILD_DEBIAN)
 set_target_properties(sdrbase PROPERTIES DEFINE_SYMBOL "sdrbase_EXPORTS")
 target_compile_features(sdrbase PRIVATE cxx_generalized_initializers) # cmake >= 3.1.0
 
-qt5_use_modules(sdrbase Core Multimedia)
+target_link_libraries(sdrbase Qt5::Core Qt5::Multimedia)
 
 install(TARGETS sdrbase DESTINATION lib)
 

--- a/sdrbench/CMakeLists.txt
+++ b/sdrbench/CMakeLists.txt
@@ -41,7 +41,7 @@ target_link_libraries(sdrbench
 
 target_compile_features(sdrbench PRIVATE cxx_generalized_initializers) # cmake >= 3.1.0
 
-qt5_use_modules(sdrbench Core Gui)
+target_link_libraries(sdrbench Qt5::Core Qt5::Gui)
 
 install(TARGETS sdrbench DESTINATION lib)
 

--- a/sdrgui/CMakeLists.txt
+++ b/sdrgui/CMakeLists.txt
@@ -190,7 +190,7 @@ target_link_libraries(sdrgui
 set_target_properties(sdrgui PROPERTIES DEFINE_SYMBOL "sdrgui_EXPORTS")
 target_compile_features(sdrgui PRIVATE cxx_generalized_initializers) # cmake >= 3.1.0
 
-qt5_use_modules(sdrgui Core Widgets OpenGL Multimedia)
+target_link_libraries(sdrgui Qt5::Core Qt5::Widgets Qt5::OpenGL Qt5::Multimedia)
 
 install(TARGETS sdrgui DESTINATION lib)
 

--- a/sdrsrv/CMakeLists.txt
+++ b/sdrsrv/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(sdrsrv
 
 target_compile_features(sdrsrv PRIVATE cxx_generalized_initializers) # cmake >= 3.1.0
 
-qt5_use_modules(sdrsrv Core Multimedia)
+target_link_libraries(sdrsrv Qt5::Core Qt5::Multimedia)
 
 install(TARGETS sdrsrv DESTINATION lib)
 

--- a/swagger/CMakeLists.txt
+++ b/swagger/CMakeLists.txt
@@ -33,6 +33,6 @@ target_link_libraries(swagger
 
 set_target_properties(swagger PROPERTIES DEFINE_SYMBOL "sdrangel_EXPORTS")
 
-qt5_use_modules(swagger Core Network)
+target_link_libraries(swagger Qt5::Core Qt5::Network)
 
 install(TARGETS swagger DESTINATION lib)


### PR DESCRIPTION
After updating my Arch Linux system I was no longer able to compile sdrangel. It seems that the issue is due to updated versions of Qt 5 and ffmpeg. The former has removed a deprecated cmake macro that we are using and the latter has renamed a symbol that we were relying on.

The second patch should probably be rewritten to so that it is compatible with both old and new versions of ffmpeg (and add appropriate cmake requirements), but that's a decision for the maintainer.