### PR TITLE
added option for test Hold

### DIFF
--- a/sdrgui/gui/glspectrum.cpp
+++ b/sdrgui/gui/glspectrum.cpp
@@ -49,6 +49,7 @@ GLSpectrum::GLSpectrum(QWidget* parent) :
 	m_displayTraceIntensity(50),
 	m_invertedWaterfall(false),
 	m_displayMaxHold(false),
+	m_displayTestHold(false), // test
 	m_currentSpectrum(0),
 	m_displayCurrent(false),
 	m_waterfallBuffer(NULL),
@@ -248,6 +249,15 @@ void GLSpectrum::setDisplayMaxHold(bool display)
 	update();
 }
 
+// test
+void GLSpectrum::setDisplayTestHold(bool value)
+{
+	m_displayTestHold = value;
+	m_changesPending = true;
+	stopDrag();
+	update();
+}
+
 void GLSpectrum::setDisplayCurrent(bool display)
 {
 	m_displayCurrent = display;
@@ -395,14 +405,17 @@ void GLSpectrum::updateHistogram(const std::vector<Real>& spectrum)
 					{
 						*h = *h - sub;
 					}
-					else if(*h > 0)
+					else if(!m_displayTestHold)
 					{
-						*h = *h - 1;
-					}
-					else
-					{
-						*b = *b - 1;
-						*h = m_histogramLateHoldoff;
+						if(*h > 0)
+						{
+							*h = *h - 1;
+						}
+						else
+						{
+							*b = *b - 1;
+							*h = m_histogramLateHoldoff;
+						}
 					}
 				}
 

--- a/sdrgui/gui/glspectrum.h
+++ b/sdrgui/gui/glspectrum.h
@@ -76,6 +76,7 @@ public:
 	void setLsbDisplay(bool lsbDisplay);
 	void setInvertedWaterfall(bool inv);
 	void setDisplayMaxHold(bool display);
+	void setDisplayTestHold(bool value); // test
 	void setDisplayCurrent(bool display);
 	void setDisplayHistogram(bool display);
 	void setDisplayGrid(bool display);
@@ -145,6 +146,7 @@ private:
 
 	std::vector<Real> m_maxHold;
 	bool m_displayMaxHold;
+	bool m_displayTestHold; // test
 	const std::vector<Real> *m_currentSpectrum;
 	bool m_displayCurrent;
 

--- a/sdrgui/gui/glspectrumgui.cpp
+++ b/sdrgui/gui/glspectrumgui.cpp
@@ -24,6 +24,7 @@ GLSpectrumGUI::GLSpectrumGUI(QWidget* parent) :
 	m_displayWaterfall(true),
 	m_invertedWaterfall(false),
 	m_displayMaxHold(false),
+	m_displayTestHold(false), // test
 	m_displayCurrent(false),
 	m_displayHistogram(false),
 	m_displayGrid(false),
@@ -73,6 +74,7 @@ void GLSpectrumGUI::resetToDefaults()
 	m_displayWaterfall = true;
 	m_invertedWaterfall = false;
 	m_displayMaxHold = false;
+	m_displayTestHold = false; // test
 	m_displayHistogram = false;
 	m_displayGrid = false;
 	m_invert = true;
@@ -93,6 +95,7 @@ QByteArray GLSpectrumGUI::serialize() const
 	s.writeBool(6, m_displayWaterfall);
 	s.writeBool(7, m_invertedWaterfall);
 	s.writeBool(8, m_displayMaxHold);
+	//s.writeBool(?, m_displayTestHold); // test
 	s.writeBool(9, m_displayHistogram);
 	s.writeS32(10, m_decay);
 	s.writeBool(11, m_displayGrid);
@@ -129,6 +132,7 @@ bool GLSpectrumGUI::deserialize(const QByteArray& data)
 		d.readBool(6, &m_displayWaterfall, true);
 		d.readBool(7, &m_invertedWaterfall, false);
 		d.readBool(8, &m_displayMaxHold, false);
+		m_displayTestHold = false; // test
 		d.readBool(9, &m_displayHistogram, false);
 		d.readS32(10, &m_decay, 0);
 		d.readBool(11, &m_displayGrid, false);
@@ -175,6 +179,7 @@ void GLSpectrumGUI::applySettings()
 	ui->stroke->setSliderPosition(m_histogramStroke);
 	ui->waterfall->setChecked(m_displayWaterfall);
 	ui->maxHold->setChecked(m_displayMaxHold);
+	ui->testHold->setChecked(m_displayTestHold); // test
 	ui->current->setChecked(m_displayCurrent);
 	ui->histogram->setChecked(m_displayHistogram);
 	ui->invert->setChecked(m_invert);
@@ -190,6 +195,7 @@ void GLSpectrumGUI::applySettings()
 	m_glSpectrum->setDisplayWaterfall(m_displayWaterfall);
 	m_glSpectrum->setInvertedWaterfall(m_invertedWaterfall);
 	m_glSpectrum->setDisplayMaxHold(m_displayMaxHold);
+	m_glSpectrum->setDisplayTestHold(m_displayTestHold); // test
 	m_glSpectrum->setDisplayCurrent(m_displayCurrent);
 	m_glSpectrum->setDisplayHistogram(m_displayHistogram);
 	m_glSpectrum->setDecay(m_decay);
@@ -400,6 +406,15 @@ void GLSpectrumGUI::on_maxHold_toggled(bool checked)
 	m_displayMaxHold = checked;
 	if(m_glSpectrum != 0) {
 	    m_glSpectrum->setDisplayMaxHold(m_displayMaxHold);
+	}
+}
+
+// test
+void GLSpectrumGUI::on_testHold_toggled(bool checked)
+{
+	m_displayTestHold = checked;
+	if(m_glSpectrum != 0) {
+	    m_glSpectrum->setDisplayTestHold(m_displayTestHold);
 	}
 }
 

--- a/sdrgui/gui/glspectrumgui.h
+++ b/sdrgui/gui/glspectrumgui.h
@@ -56,6 +56,7 @@ private:
 	bool m_displayWaterfall;
 	bool m_invertedWaterfall;
 	bool m_displayMaxHold;
+	bool m_displayTestHold; // test
 	bool m_displayCurrent;
 	bool m_displayHistogram;
 	bool m_displayGrid;
@@ -92,6 +93,7 @@ private slots:
 	void on_waterfall_toggled(bool checked);
 	void on_histogram_toggled(bool checked);
 	void on_maxHold_toggled(bool checked);
+	void on_testHold_toggled(bool checked); // test
 	void on_current_toggled(bool checked);
 	void on_invert_toggled(bool checked);
 	void on_grid_toggled(bool checked);

--- a/sdrgui/gui/glspectrumgui.ui
+++ b/sdrgui/gui/glspectrumgui.ui
@@ -704,6 +704,31 @@
        </property>
       </widget>
      </item>
+
+     <item>
+      <widget class="ButtonSwitch" name="testHold">
+       <property name="toolTip">
+        <string>Toggle test Hold</string>
+       </property>
+       <property name="text">
+        <string>Test Hold</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../resources/res.qrc">
+         <normaloff>:/testHold.png</normaloff>:/testHold.png</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">


### PR DESCRIPTION
hello,

after i was reading your posts again, i realized you gave me the hint, that the red Hold line is made in the glspectrum.
i added an option "Test Hold", where you can toggle the Hold to infinite...
like i tried to archive in issue https://github.com/f4exb/sdrangel/issues/207

it is maybe not the best implementation and naming...
but maybe you find it useful.