### PR TITLE
pluto: Get LO range from device

### DIFF
--- a/devices/plutosdr/deviceplutosdrbox.cpp
+++ b/devices/plutosdr/deviceplutosdrbox.cpp
@@ -713,6 +713,25 @@ bool DevicePlutoSDRBox::getTxRSSI(std::string& rssiStr, unsigned int chan)
     return get_param(DEVICE_PHY, buff, rssiStr);
 }
 
+void DevicePlutoSDRBox::getRxLORange(uint64_t& minLimit, uint64_t& maxLimit, unsigned int chan)
+{
+    // values are returned in Hz
+    qint64 stepLimit;
+    std::string rangeStr;
+
+    chan = chan % 2;
+    char buff[50];
+    snprintf(buff, sizeof(buff), "out_altvoltage%i_RX_LO_frequency_available", chan);
+
+    if(get_param(DEVICE_PHY, buff, rangeStr)) {
+        std::istringstream instream(rangeStr.substr(1, rangeStr.size() - 2));
+	instream >> minLimit >> stepLimit >> maxLimit;
+    } else {
+        minLimit = DevicePlutoSDR::loLowLimitFreq;
+	maxLimit = DevicePlutoSDR::loHighLimitFreq;
+    }
+}
+
 bool DevicePlutoSDRBox::fetchTemp()
 {
     std::string temp_mC_str;

--- a/devices/plutosdr/deviceplutosdrbox.h
+++ b/devices/plutosdr/deviceplutosdrbox.h
@@ -105,6 +105,7 @@ public:
     bool getRxGain(int& gaindB, unsigned int chan);
     bool getRxRSSI(std::string& rssiStr, unsigned int chan);
     bool getTxRSSI(std::string& rssiStr, unsigned int chan);
+    void getRxLORange(uint64_t& minLimit, uint64_t& maxLimit, unsigned int chan);
     bool fetchTemp();
     float getTemp() const { return m_temp; }
     bool getRateGovernors(std::string& rateGovernors);

--- a/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
@@ -675,6 +675,16 @@ void PlutoSDRInput::getRSSI(std::string& rssiStr)
     }
 }
 
+void PlutoSDRInput::getLORange(qint64& minLimit, qint64& maxLimit)
+{
+    uint64_t min, max;
+    DevicePlutoSDRBox *plutoBox =  m_deviceShared.m_deviceParams->getBox();
+
+    plutoBox->getRxLORange(min, max, 0);
+    minLimit = min;
+    maxLimit = max;
+}
+
 void PlutoSDRInput::getGain(int& gaindB)
 {
     DevicePlutoSDRBox *plutoBox =  m_deviceShared.m_deviceParams->getBox();

--- a/plugins/samplesource/plutosdrinput/plutosdrinput.h
+++ b/plugins/samplesource/plutosdrinput/plutosdrinput.h
@@ -143,6 +143,7 @@ public:
     uint32_t getADCSampleRate() const { return m_deviceSampleRates.m_addaConnvRate; }
     uint32_t getFIRSampleRate() const { return m_deviceSampleRates.m_hb1Rate; }
     void getRSSI(std::string& rssiStr);
+    void getLORange(qint64& minLimit, qint64& maxLimit);
     void getGain(int& gainStr);
     bool fetchTemperature();
     float getTemperature();

--- a/plugins/samplesource/plutosdrinput/plutosdrinputgui.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinputgui.cpp
@@ -438,10 +438,13 @@ void PlutoSDRInputGui::setSampleRateLimits()
 
 void PlutoSDRInputGui::updateFrequencyLimits()
 {
-    // values in kHz
+    qint64 minLimit, maxLimit;
+    // values should be in kHz
     qint64 deltaFrequency = m_settings.m_transverterMode ? m_settings.m_transverterDeltaFrequency/1000 : 0;
-    qint64 minLimit = DevicePlutoSDR::loLowLimitFreq/1000 + deltaFrequency;
-    qint64 maxLimit = DevicePlutoSDR::loHighLimitFreq/1000 + deltaFrequency;
+    ((PlutoSDRInput *) m_sampleSource)->getLORange(minLimit, maxLimit);
+
+    minLimit = minLimit/1000 + deltaFrequency;
+    maxLimit = maxLimit/1000 + deltaFrequency;
 
     minLimit = minLimit < 0 ? 0 : minLimit > 9999999 ? 9999999 : minLimit;
     maxLimit = maxLimit < 0 ? 0 : maxLimit > 9999999 ? 9999999 : maxLimit;


### PR DESCRIPTION
When updating firmware, the devices which have AD9364s on them, get
reset to the default of a AD9363 (tuning range of 325 to 3800 MHz).
SDRAngel assumes a AD9364, and the GUI allows you to set LO settings
that the firmware doesn't support.

This ensures that does not happen, by going out to the hardware, and
querying the device to set the min/max limits on LO.

Signed-off-by: Robin Getz <robin.getz@analog.com>