### PR TITLE
plutosdr: grab the RF bandwidth range from the device

### DIFF
--- a/devices/plutosdr/deviceplutosdrbox.cpp
+++ b/devices/plutosdr/deviceplutosdrbox.cpp
@@ -755,6 +755,49 @@ void DevicePlutoSDRBox::getTxLORange(uint64_t& minLimit, uint64_t& maxLimit)
     }
 }
 
+void DevicePlutoSDRBox::getbbLPRxRange(uint32_t& minLimit, uint32_t& maxLimit)
+{
+    // values are returned in Hz of RF (complex channel) bandwidth
+    qint32 stepLimit;
+    std::string rangeStr;
+
+    char buff[50];
+    snprintf(buff, sizeof(buff), "in_voltage_rf_bandwidth_available");
+
+    if (get_param(DEVICE_PHY, buff, rangeStr))
+    {
+	std::istringstream instream(rangeStr.substr(1, rangeStr.size() - 2));
+	instream >> minLimit >> stepLimit >> maxLimit;
+    }
+    else
+    {
+	minLimit = DevicePlutoSDR::bbLPRxLowLimitFreq;
+	maxLimit = DevicePlutoSDR::bbLPRxHighLimitFreq;
+    }
+}
+
+void DevicePlutoSDRBox::getbbLPTxRange(uint32_t& minLimit, uint32_t& maxLimit)
+{
+    // values are returned in Hz
+    qint32 stepLimit;
+    std::string rangeStr;
+
+    char buff[50];
+    snprintf(buff, sizeof(buff), "out_voltage_rf_bandwidth_available");
+
+    if (get_param(DEVICE_PHY, buff, rangeStr))
+    {
+        std::istringstream instream(rangeStr.substr(1, rangeStr.size() - 2));
+        instream >> minLimit >> stepLimit >> maxLimit;
+    }
+    else
+    {
+	minLimit = DevicePlutoSDR::bbLPTxLowLimitFreq;
+	maxLimit = DevicePlutoSDR::bbLPTxHighLimitFreq;
+    }
+}
+
+
 bool DevicePlutoSDRBox::fetchTemp()
 {
     std::string temp_mC_str;

--- a/devices/plutosdr/deviceplutosdrbox.h
+++ b/devices/plutosdr/deviceplutosdrbox.h
@@ -107,6 +107,8 @@ public:
     bool getTxRSSI(std::string& rssiStr, unsigned int chan);
     void getRxLORange(uint64_t& minLimit, uint64_t& maxLimit);
     void getTxLORange(uint64_t& minLimit, uint64_t& maxLimit);
+    void getbbLPRxRange(uint32_t& minLimit, uint32_t& maxLimit);
+    void getbbLPTxRange(uint32_t& minLimit, uint32_t& maxLimit);
     bool fetchTemp();
     float getTemp() const { return m_temp; }
     bool getRateGovernors(std::string& rateGovernors);

--- a/plugins/samplesink/plutosdroutput/plutosdroutput.cpp
+++ b/plugins/samplesink/plutosdroutput/plutosdroutput.cpp
@@ -600,6 +600,16 @@ void PlutoSDROutput::getLORange(qint64& minLimit, qint64& maxLimit)
     maxLimit = max;
 }
 
+void PlutoSDROutput::getbbLPRange(quint32& minLimit, quint32& maxLimit)
+{
+    uint32_t min, max;
+    DevicePlutoSDRBox *plutoBox =  m_deviceShared.m_deviceParams->getBox();
+
+    plutoBox->getbbLPTxRange(min, max);
+    minLimit = min;
+    maxLimit = max;
+}
+
 bool PlutoSDROutput::fetchTemperature()
 {
     DevicePlutoSDRBox *plutoBox =  m_deviceShared.m_deviceParams->getBox();

--- a/plugins/samplesink/plutosdroutput/plutosdroutput.h
+++ b/plugins/samplesink/plutosdroutput/plutosdroutput.h
@@ -123,6 +123,7 @@ public:
     uint32_t getFIRSampleRate() const { return m_deviceSampleRates.m_hb1Rate; }
     void getRSSI(std::string& rssiStr);
     void getLORange(qint64& minLimit, qint64& maxLimit);
+    void getbbLPRange(quint32& minLimit, quint32& maxLimit);
     bool fetchTemperature();
     float getTemperature();
 

--- a/plugins/samplesink/plutosdroutput/plutosdroutputgui.cpp
+++ b/plugins/samplesink/plutosdroutput/plutosdroutputgui.cpp
@@ -53,7 +53,10 @@ PlutoSDROutputGUI::PlutoSDROutputGUI(DeviceUISet *deviceUISet, QWidget* parent) 
     ui->sampleRate->setValueRange(8, DevicePlutoSDR::srLowLimitFreq, DevicePlutoSDR::srHighLimitFreq);
 
     ui->lpf->setColorMapper(ColorMapper(ColorMapper::GrayYellow));
-    ui->lpf->setValueRange(5, DevicePlutoSDR::bbLPTxLowLimitFreq/1000, DevicePlutoSDR::bbLPTxHighLimitFreq/1000);
+
+    quint32 minLimit, maxLimit;
+    ((PlutoSDROutput *) m_sampleSink)->getbbLPRange(minLimit, maxLimit);
+    ui->lpf->setValueRange(5, minLimit/1000, maxLimit/1000);
 
     ui->lpFIR->setColorMapper(ColorMapper(ColorMapper::GrayYellow));
     ui->lpFIR->setValueRange(5, 1U, 56000U); // will be dynamically recalculated

--- a/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
@@ -685,6 +685,16 @@ void PlutoSDRInput::getLORange(qint64& minLimit, qint64& maxLimit)
     maxLimit = max;
 }
 
+void PlutoSDRInput::getbbLPRange(quint32& minLimit, quint32& maxLimit)
+{
+    uint32_t min, max;
+    DevicePlutoSDRBox *plutoBox =  m_deviceShared.m_deviceParams->getBox();
+
+    plutoBox->getbbLPRxRange(min, max);
+    minLimit = min;
+    maxLimit = max;
+}
+
 void PlutoSDRInput::getGain(int& gaindB)
 {
     DevicePlutoSDRBox *plutoBox =  m_deviceShared.m_deviceParams->getBox();

--- a/plugins/samplesource/plutosdrinput/plutosdrinput.h
+++ b/plugins/samplesource/plutosdrinput/plutosdrinput.h
@@ -144,6 +144,7 @@ public:
     uint32_t getFIRSampleRate() const { return m_deviceSampleRates.m_hb1Rate; }
     void getRSSI(std::string& rssiStr);
     void getLORange(qint64& minLimit, qint64& maxLimit);
+    void getbbLPRange(quint32& minLimit, quint32& maxLimit);
     void getGain(int& gainStr);
     bool fetchTemperature();
     float getTemperature();

--- a/plugins/samplesource/plutosdrinput/plutosdrinputgui.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinputgui.cpp
@@ -53,7 +53,10 @@ PlutoSDRInputGui::PlutoSDRInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
     ui->sampleRate->setValueRange(8, DevicePlutoSDR::srLowLimitFreq, DevicePlutoSDR::srHighLimitFreq);
 
     ui->lpf->setColorMapper(ColorMapper(ColorMapper::GrayYellow));
-    ui->lpf->setValueRange(5, DevicePlutoSDR::bbLPRxLowLimitFreq/1000, DevicePlutoSDR::bbLPRxHighLimitFreq/1000);
+
+    quint32 minLimit, maxLimit;
+    ((PlutoSDRInput *) m_sampleSource)->getbbLPRange(minLimit, maxLimit);
+    ui->lpf->setValueRange(5, minLimit/1000, maxLimit/1000);
 
     ui->lpFIR->setColorMapper(ColorMapper(ColorMapper::GrayYellow));
     ui->lpFIR->setValueRange(5, 1U, 56000U); // will be dynamically recalculated


### PR DESCRIPTION
This will use the RF bandwidth from the device, which is different
between AD9363 and AD9364.

Things are now managed like the device likes - analog low pass bandwidth
is RF (complex) bandwidth, not baseband single I or Q bandwidth.

Signed-off-by: Robin Getz <robin.getz@analog.com>