### PR TITLE
Don't intentionally disable keyboard commands on application focus change

### DIFF
--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -209,7 +209,6 @@ MainWindow::MainWindow(qtwebapp::LoggerWithFile *logger, const MainParser& parse
 	m_apiServer = new WebAPIServer(m_apiHost, m_apiPort, m_requestMapper);
 	m_apiServer->start();
 
-	connect(qApp, SIGNAL(focusChanged(QWidget *, QWidget *)), this, SLOT(focusHasChanged(QWidget *, QWidget *)));
 	m_commandKeyReceiver = new CommandKeyReceiver();
 	m_commandKeyReceiver->setRelease(true);
 	this->installEventFilter(m_commandKeyReceiver);
@@ -1789,19 +1788,6 @@ void MainWindow::setLoggingOptions()
                 .arg(qApp->applicationPid()));
  #endif
         m_logger->logToFile(QtInfoMsg, appInfoStr);
-    }
-}
-
-void MainWindow::focusHasChanged(QWidget *oldWidget, QWidget *newWidget)
-{
-    (void) oldWidget;
-    // this is the hard way:
-//    if (ui->commandKeyboardConnect->isChecked() && (newWidget != this)) {
-//        setFocus();
-//    }
-    // this is the soft way:
-    if (newWidget != this) {
-        ui->commandKeyboardConnect->setChecked(false);
     }
 }
 

--- a/sdrgui/mainwindow.h
+++ b/sdrgui/mainwindow.h
@@ -391,7 +391,6 @@ private slots:
 	void on_action_removeLastDevice_triggered();
 	void on_action_Exit_triggered();
 	void tabInputViewIndexChanged();
-	void focusHasChanged(QWidget *oldWidget, QWidget *newWidget);
 	void commandKeyPressed(Qt::Key key, Qt::KeyboardModifiers keyModifiers, bool release);
 };
 

--- a/sdrgui/readme.md
+++ b/sdrgui/readme.md
@@ -663,9 +663,9 @@ This will save the commands immediately. The commands will be automatically save
 
 This will delete the currently selected command or if selection is a group this will delete all commands in the group.
 
-<h5>5B.6.8. Activate keyboard binding</h5>
+<h5>5B.6.8. Activate keyboard bindings</h5>
 
-Use this button to activate the keyboard binding. This requires that the focus is set to the main window. On a few occasions the main window looses focus and the button gets unselected. Just click again on this button to reactivate the keyboard binding. Note that you need to have this button selected (its background should be lit in beige/orange) for the key binding to be effective.
+Use this button to activate the keyboard bindings. Note that you need to have this button selected (its background should be lit in beige/orange) for the key bindings to be effective.
 
 <h3>6. Channels</h3>
 


### PR DESCRIPTION
This fixes #297. Keyboard commands stay enabled until explicitly disabled or program closed.