### PR TITLE
re-enable fcdpro/fcdproplus on macOS and perseus fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.1.0)
-cmake_policy(SET CMP0043 OLD)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
     message(FATAL_ERROR "SDRangel requires GCC version 4.9 or higher!")
@@ -425,9 +424,7 @@ target_link_libraries(sdrangel
 
 if(WIN32)
     set_target_properties(sdrangel PROPERTIES LINK_FLAGS_DEBUG "/SUBSYSTEM:CONSOLE")
-    set_target_properties(sdrangel PROPERTIES COMPILE_DEFINITIONS_DEBUG "_CONSOLE")
     set_target_properties(sdrangel PROPERTIES LINK_FLAGS_RELWITHDEBINFO "/SUBSYSTEM:CONSOLE")
-    set_target_properties(sdrangel PROPERTIES COMPILE_DEFINITIONS_RELWITHDEBINFO "_CONSOLE")
     set_target_properties(sdrangel PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:windows /ENTRY:mainCRTStartup")
     set_target_properties(sdrangel PROPERTIES LINK_FLAGS_MINSIZEREL "/SUBSYSTEM:windows /ENTRY:mainCRTStartup")
 endif(WIN32)

--- a/devices/perseus/deviceperseusscan.cpp
+++ b/devices/perseus/deviceperseusscan.cpp
@@ -29,33 +29,24 @@ bool DevicePerseusScan::scan(int nbDevices)
 		return true;
 	}
 
-    bool done = true;
+        bool done = true;
 	perseus_descr *descr;
 	eeprom_prodid prodid;
 
 	for (int deviceIndex = 0; deviceIndex < nbDevices; deviceIndex++)
 	{
-		if ((descr = perseus_open(deviceIndex)) == 0)
+	if ((descr = perseus_open(deviceIndex)) == 0)
         {
-			qCritical("DevicePerseusScan::scan: device #%d open error: %s", deviceIndex, perseus_errorstr());
-			perseus_close(descr);
-			continue;
-		}
-
-        if (descr->firmware_downloaded)
-        {
-            qDebug("DevicePerseusScan::scan: device #%d firmware is already downloaded", deviceIndex);
-        }
-        else
-        {
-            qDebug("DevicePerseusScan::scan: device #%d firmware is not yet downloaded", deviceIndex);
-            done = false;
-        }
+	    qCritical("DevicePerseusScan::scan: device #%d open error: %s", deviceIndex, perseus_errorstr());
+	    perseus_close(descr);
+	    continue;
+	}
 
         if (perseus_firmware_download(descr, 0) < 0)
         {
             qCritical("DevicePerseusScan::scan: device #%d firmware download error: %s", deviceIndex, perseus_errorstr());
             perseus_close(descr);
+            done = false;
             continue;
         }
         else

--- a/plugins/samplesource/CMakeLists.txt
+++ b/plugins/samplesource/CMakeLists.txt
@@ -29,10 +29,10 @@ if(LIBUSB_FOUND AND LIBBLADERF_FOUND)
     add_subdirectory(bladerf2input)
 endif(LIBUSB_FOUND AND LIBBLADERF_FOUND)
 
-if(LIBUSB_FOUND AND NOT APPLE)
+if(LIBUSB_FOUND)
     add_subdirectory(fcdpro)
     add_subdirectory(fcdproplus)
-endif(LIBUSB_FOUND AND NOT APPLE)
+endif(LIBUSB_FOUND)
 
 find_package(LibHACKRF)
 if(LIBUSB_FOUND AND LIBHACKRF_FOUND)

--- a/plugins/samplesource/fcdpro/CMakeLists.txt
+++ b/plugins/samplesource/fcdpro/CMakeLists.txt
@@ -46,7 +46,6 @@ add_library(inputfcdpro SHARED
 
 target_link_libraries(inputfcdpro
 	${QT_LIBRARIES}
-	asound
 	fcdhid
 	fcdlib
 	sdrbase

--- a/plugins/samplesource/fcdproplus/CMakeLists.txt
+++ b/plugins/samplesource/fcdproplus/CMakeLists.txt
@@ -25,7 +25,7 @@ set(fcdproplus_FORMS
 include_directories(
 	.
 	${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_SOURCE_DIR}/swagger/sdrangel/code/qt5/client    
+        ${CMAKE_SOURCE_DIR}/swagger/sdrangel/code/qt5/client    
 	${CMAKE_SOURCE_DIR}/fcdhid
 	${CMAKE_SOURCE_DIR}/fcdlib
 )
@@ -46,7 +46,6 @@ add_library(inputfcdproplus SHARED
 
 target_link_libraries(inputfcdproplus
 	${QT_LIBRARIES}
-	asound
 	fcdhid
 	fcdlib
 	sdrbase


### PR DESCRIPTION
I checked and now seems to works and no more error from alsa. Probably the error was library_include dependant.