### PR TITLE
udev on Linux and libusb fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,12 +532,16 @@ endif()
 install(TARGETS sdrangelbench DESTINATION bin)
 #install(TARGETS sdrbase DESTINATION lib)
 
-#install files and directories
+#install files and directories (linux specific)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 install(DIRECTORY udev-rules DESTINATION share/sdrangel)
 install(FILES udev-rules/install.sh DESTINATION share/sdrangel/udev-rules PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sdrbase.rcc DESTINATION bin)
 install(FILES desktop/sdrangel.desktop DESTINATION share/applications)
 install(FILES desktop/sdrangel_icon.png DESTINATION share/pixmaps)
+endif()
+
+# needed by REST API documentation
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sdrbase.rcc DESTINATION bin)
 
 ##############################################################################
 

--- a/fcdhid/CMakeLists.txt
+++ b/fcdhid/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(
 	.
 	${CMAKE_CURRENT_BINARY_DIR}
         ${LIBUSB_INCLUDE_DIR}
+        ${ICONV_INCLUDE_DIR}
 )
 
 #add_definitions(-DQT_PLUGIN)

--- a/fcdhid/hid-libusb.c
+++ b/fcdhid/hid-libusb.c
@@ -46,7 +46,7 @@
 #include <wchar.h>
 
 /* GNU / LibUSB */
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #include "iconv.h"
 
 #include "../fcdhid/hidapi.h"


### PR DESCRIPTION
* udev fixes 07c1413c
* usb fixes 760e4859

tested on Ubuntu 18.04 and macOS