### PR TITLE
Use correct encoding for file names in FileSource plugin

### DIFF
--- a/plugins/samplesource/filesource/filesourceinput.cpp
+++ b/plugins/samplesource/filesource/filesourceinput.cpp
@@ -94,7 +94,11 @@ void FileSourceInput::openFileStream()
 		m_ifstream.close();
 	}
 
+#ifdef Q_OS_WIN
+	m_ifstream.open(m_fileName.toStdWString().c_str(), std::ios::binary | std::ios::ate);
+#else
 	m_ifstream.open(m_fileName.toStdString().c_str(), std::ios::binary | std::ios::ate);
+#endif
 	quint64 fileSize = m_ifstream.tellg();
 
 	if (fileSize > sizeof(FileRecord::Header))


### PR DESCRIPTION
Opening of file named `Ы.sdriq` with FileSource plugin on Windows platform results in error.
To fix this either `std::wstring` should be used in `m_ifstream.open()` call or code should be rewritten to use `QFile` instead of `std::ifstream`.
This PR implements `wstring` solution. Hope it will not break other platforms' build.

Fixes #205.