### PR TITLE
Improve precision of master timer

### DIFF
--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -175,6 +175,7 @@ MainWindow::MainWindow(qtwebapp::LoggerWithFile *logger, const MainParser& parse
 	connect(&m_statusTimer, SIGNAL(timeout()), this, SLOT(updateStatus()));
 	m_statusTimer.start(1000);
 
+	m_masterTimer.setTimerType(Qt::PreciseTimer);
 	m_masterTimer.start(50);
 
     splash->showStatusMessage("load settings...", Qt::white);


### PR DESCRIPTION
Changing of master timer type to `Qt::PreciseTimer` makes spectrum animation more smooth on Windows platform.

Here is the video with the same record being played.
On the left is original 4.8.2 version, on the right - with this patch applied.
[sdrangel_master_timer_precision.zip](https://github.com/f4exb/sdrangel/files/3244447/sdrangel_master_timer_precision.zip)