### PR TITLE
Fix the Flatpak

### DIFF
--- a/flatpak/org.sdrangel.SDRangel.appdata.xml
+++ b/flatpak/org.sdrangel.SDRangel.appdata.xml
@@ -1,33 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component type="desktop">
   <id>org.sdrangel.SDRangel</id>
-  <launchable type="desktop-id">org.sdrangel.SDRangel</launchable>
-  <metadata_license></metadata_license>
+  <launchable type="desktop-id">org.sdrangel.SDRangel.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
   <name>SDRangel</name>
-  <summary>SDRangel</summary>
+  <summary>SDR and signal analyzer frontend to various hardware</summary>
   <description>
-    <p>SDRangel</p>
-    <p xml:lang="en-GB">SDRangel</p>
-    <p xml:lang="de-DE">SDRangel</p>
+    <p>
+      SDRangel is an Open Source Qt5 / OpenGL 3.0+ SDR and signal analyzer frontend to various hardware.
+    </p>
   </description>
   <releases>
-    <release version="1.0.0" date="2019-05-03"/>
+    <release version="4.11.9" date="2019-09-11"/>
   </releases>
+<!--
   <screenshots>
     <screenshot type="default">
-      <!--image type="source">https://github.com/f4exb/sdrangel/.../screenshot.png</image-->
+      <image type="source">https://raw.githubusercontent.com/f4exb/sdrangel/master/flatpak/screenshot.png</image>
     </screenshot>
   </screenshots>
-  <categories>
-    <category>Documentation</category>
-    <category>Development</category>
-    <category>Qt</category>
-  </categories>
+-->
   <url type="homepage">https://github.com/f4exb/sdrangel</url>
   <url type="bugtracker">https://github.com/f4exb/sdrangel/issues</url>
   <project_group>SDRangel</project_group>
-  <update_contact></update_contact>
   <provides>
     <binary>sdrangel</binary>
   </provides>

--- a/flatpak/org.sdrangel.SDRangel.json
+++ b/flatpak/org.sdrangel.SDRangel.json
@@ -4,17 +4,179 @@
   "runtime-version": "5.12",
   "sdk": "org.kde.Sdk",
   "command": "sdrangel",
+  "rename-desktop-file": "sdrangel.desktop",
+  "rename-icon": "sdrangel_icon",
+  "copy-icon": true,
   "finish-args": [
-    "--filesystem=host",
     "--filesystem=xdg-documents",
-    "--device=dri",
+    "--device=all",
     "--share=network",
-    "--socket=ipc",
+    "--share=ipc",
     "--socket=pulseaudio",
     "--socket=x11",
     "--socket=wayland"
   ],
   "modules": [
+    {
+      "name": "boost",
+      "buildsystem": "simple",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2",
+          "sha256": "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee"
+        }
+      ],
+      "build-commands": [
+        "./bootstrap.sh --prefix=/app",
+        "./b2 -j $FLATPAK_BUILDER_N_JOBS",
+        "./b2 install"
+      ]
+    },
+    {
+      "name" : "libusb",
+      "config-opts" : [
+        "--disable-udev"
+      ],
+      "sources" : [
+        {
+          "type" : "archive",
+          "url" : "https://github.com/libusb/libusb/releases/download/v1.0.23/libusb-1.0.23.tar.bz2",
+          "sha256" : "db11c06e958a82dac52cf3c65cb4dd2c3f339c8a988665110e0d24d19312ad8d"
+        }
+      ]
+    },
+    {
+      "name": "libxml2",
+      "config-opts": [
+        "--with-python=no"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/GNOME/libxml2/archive/v2.9.9.tar.gz",
+          "sha256": "d673f0284cec867ee00872a8152e0c3c09852f17fd9aa93f07579a37534f0bfe"
+        }
+      ]
+    },
+    {
+      "name": "fftw3",
+      "config-opts" : [
+        "--enable-shared",
+        "--disable-static",
+        "--enable-threads",
+        "--enable-float"
+      ],
+      "sources" : [
+        {
+          "type" : "archive",
+          "url" : "http://www.fftw.org/fftw-3.3.8.tar.gz",
+          "md5": "8aac833c943d8e90d51b697b27d4384d"
+        }
+      ]
+    },
+    {
+      "name": "xxd",
+      "build-options": {
+        "env": {
+          "LIBS": "-lm"
+        }
+      },
+      "cleanup": [
+        "/bin/vim*",
+        "/bin/rvim",
+        "/bin/view",
+        "/bin/rview",
+        "/bin/ex",
+        "/share"
+      ],
+      "config-opts": [
+        "--disable-gui",
+        "--disable-gtk3",
+        "--disable-luainterp",
+        "--disable-python3interp",
+        "--disable-xim",
+        "--disable-xsmp",
+        "--disable-xsmp-interact",
+        "--disable-desktop-database-update",
+        "--disable-icon-cache-update",
+        "--disable-gnome-check",
+        "--disable-motif-check",
+        "--disable-athena-check",
+        "--disable-fontset"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/vim/vim",
+          "tag": "v8.1.2102",
+          "commit": "d17a57a43330977b8f4eb36f1f7a4a66a7bb26c8"
+        }
+      ]
+    },
+    {
+      "name": "python-cheetah",
+      "buildsystem": "simple",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://files.pythonhosted.org/packages/4e/72/e6a7d92279e3551db1b68fd336fd7a6e3d2f2ec742bf486486e6150d77d2/Cheetah3-3.2.4.tar.gz",
+          "sha256": "caabb9c22961a3413ac85cd1e5525ec9ca80daeba6555f4f60802b6c256e252b"
+        }
+      ],
+      "build-commands": [
+        "python setup.py install --prefix=/app --root=/"
+      ]
+    },
+    {
+      "name": "python-mako",
+      "buildsystem": "simple",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://files.pythonhosted.org/packages/b0/3c/8dcd6883d009f7cae0f3157fb53e9afb05a0d3d33b3db1268ec2e6f4a56b/Mako-1.1.0.tar.gz",
+          "sha256": "a36919599a9b7dc5d86a7a8988f23a9a3a3d083070023bab23d64f7f1d1e0a4b"
+        }
+      ],
+      "build-commands": [
+        "python setup.py install --prefix=/app --root=/"
+      ]
+    },
+    {
+      "name": "opencv",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/opencv/opencv/archive/3.4.6.tar.gz",
+          "sha256": "e7d311ff97f376b8ee85112e2b536dbf4bdf1233673500175ed7cf21a0089f6d"
+        }
+      ]
+    },
+    {
+      "name": "libpostproc",
+      "config-opts": [
+        "--disable-debug",
+        "--disable-doc",
+        "--disable-static",
+        "--enable-shared",
+        "--enable-gpl",
+        "--disable-libvpx",
+        "--disable-ffplay",
+        "--disable-ffprobe",
+        "--disable-ffserver",
+        "--disable-everything",
+        "--enable-postproc"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://ffmpeg.org/releases/ffmpeg-3.4.1.tar.xz",
+          "sha256": "5a77278a63741efa74e26bf197b9bb09ac6381b9757391b922407210f0f991c0"
+        }
+      ]
+    },
     {
       "name": "cm256cc",
       "buildsystem": "cmake-ninja",
@@ -75,6 +237,7 @@
     {
       "name": "codec2",
       "buildsystem": "cmake-ninja",
+      "builddir": true,
       "config-opts": [
         "-Wno-dev"
       ],
@@ -83,16 +246,6 @@
           "type": "git",
           "url": "https://github.com/drowe67/codec2.git",
           "commit": "76a20416d715ee06f8b36a9953506876689a3bd2"
-        }
-      ]
-    },
-    {
-      "name": "sdrplay",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://www.sdrplay.com/software/SDRplay_RSP_API-Linux-2.13.1.run",
-          "sha256": "e2320b9eafffa3cb5d49e956207af2521ccf098aacc1fd9abecc8fb96b364522"
         }
       ]
     },
@@ -107,6 +260,21 @@
           "type": "git",
           "url": "https://github.com/airspy/host.git",
           "commit": "5c86e53"
+        }
+      ]
+    },
+    {
+      "name": "airspyhf",
+      "buildsystem": "cmake-ninja",
+      "config-opts": [
+        "-Wno-dev",
+        "-DINSTALL_UDEV_RULES=OFF"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/airspy/airspyhf.git",
+          "commit": "99b1d38"
         }
       ]
     },
@@ -158,6 +326,7 @@
     {
       "name": "hackrf",
       "buildsystem": "cmake-ninja",
+      "subdir": "host",
       "config-opts": [
         "-Wno-dev",
         "-DINSTALL_UDEV_RULE=OFF"
@@ -208,6 +377,7 @@
     {
       "name": "xtrx",
       "buildsystem": "cmake-ninja",
+      "subdir": "sources",
       "config-opts": [
         "-Wno-dev",
         "-DENABLE_SOAPY=NO"
@@ -223,6 +393,7 @@
     {
       "name": "uhd",
       "buildsystem": "cmake-ninja",
+      "subdir": "host",
       "config-opts": [
         "-Wno-dev",
         "-DENABLE_PYTHON_API=OFF",
@@ -233,6 +404,14 @@
           "type": "git",
           "url": "git://github.com/EttusResearch/uhd.git",
           "commit": "e0e61a5"
+        },
+        {
+          "type": "patch",
+          "path": "uhd-disable-ascii-art-dft.patch"
+        },
+        {
+          "type": "patch",
+          "path": "uhd-disable-latency-utils.patch"
         }
       ]
     },
@@ -274,20 +453,6 @@
           "type": "git",
           "url": "git://github.com/pothosware/SoapyRemote.git",
           "commit": "4f5d717"
-        }
-      ]
-    },
-    {
-      "name": "soapy_sdrplay",
-      "buildsystem": "cmake-ninja",
-      "config-opts": [
-        "-Wno-dev"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "git://github.com/pothosware/SoapySDRPlay.git",
-          "commit": "12c3db6"
         }
       ]
     },
@@ -340,7 +505,22 @@
         {
           "type": "dir",
           "path": ".."
+        },
+        {
+          "type": "patch",
+          "path": "sdrangel-set-serialdv-path.patch"
+        },
+        {
+          "type": "patch",
+          "path": "sdrangel-fix-icon-file.patch"
+        },
+        {
+          "type": "file",
+          "path": "org.sdrangel.SDRangel.appdata.xml"
         }
+      ],
+      "post-install": [
+        "install -Dm644 org.sdrangel.SDRangel.appdata.xml /app/share/appdata/org.sdrangel.SDRangel.appdata.xml"
       ]
     }
   ]

--- a/flatpak/sdrangel-fix-icon-file.patch
+++ b/flatpak/sdrangel-fix-icon-file.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a58eef70f..4f75350d6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -574,7 +574,7 @@ endif()
+ #install files and directories (linux specific)
+ if (LINUX)
+   install(FILES ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.desktop DESTINATION share/applications)
+-  install(FILES ${CMAKE_SOURCE_DIR}/cmake/cpack/${CMAKE_PROJECT_NAME}_icon.png DESTINATION share/pixmaps)
++  install(FILES ${CMAKE_SOURCE_DIR}/cmake/cpack/${CMAKE_PROJECT_NAME}_icon.svg DESTINATION share/icons/hicolor/scalable/apps)
+ endif()
+ 
+ ############ uninstall target ################
+diff --git a/cmake/cpack/sdrangel.desktop.in b/cmake/cpack/sdrangel.desktop.in
+index 88aa2b9a5..918c5ff03 100644
+--- a/cmake/cpack/sdrangel.desktop.in
++++ b/cmake/cpack/sdrangel.desktop.in
+@@ -3,7 +3,7 @@ Name=@APPLICATION_NAME@
+ GenericName=SDR/Analyzer frontend
+ Comment=SDR/Analyzer frontend for Airspy, Airspy HF+, BladeRF, HackRF, LimeSDR, PlutoSDR, RTL-SDR, SDRplay RSP1 and FunCube
+ Exec=@CMAKE_PROJECT_NAME@
+-Icon=@CMAKE_PROJECT_NAME@_icon.png
++Icon=@CMAKE_PROJECT_NAME@_icon
+ StartupNotify=true
+ Terminal=false
+ Type=Application

--- a/flatpak/sdrangel-set-serialdv-path.patch
+++ b/flatpak/sdrangel-set-serialdv-path.patch
@@ -1,0 +1,26 @@
+diff --git a/cmake/Modules/FindSerialDV.cmake b/cmake/Modules/FindSerialDV.cmake
+index e4c40b00a..07470e628 100644
+--- a/cmake/Modules/FindSerialDV.cmake
++++ b/cmake/Modules/FindSerialDV.cmake
+@@ -3,8 +3,8 @@
+ find_path(LIBSERIALDV_INCLUDE_DIR
+   NAMES dvcontroller.h
+   HINTS ${SERIALDV_DIR}/include/serialdv
+-  PATHS /usr/include/serialdv
+-        /usr/local/include/serialdv
++  PATHS /app/include/serialdv
++        /app/local/include/serialdv
+ )
+ 
+ set(LIBSERIAL_NAMES ${LIBSERIAL_NAMES} serialdv libserialdv)
+@@ -12,8 +12,8 @@ set(LIBSERIAL_NAMES ${LIBSERIAL_NAMES} serialdv libserialdv)
+ find_library(LIBSERIALDV_LIBRARY
+   NAMES serialdv
+   HINTS ${SERIALDV_DIR}/lib
+-  PATHS /usr/lib
+-        /usr/local/lib
++  PATHS /app/lib
++        /app/local/lib
+ )
+ 
+ if (LIBSERIALDV_INCLUDE_DIR AND LIBSERIALDV_LIBRARY)

--- a/flatpak/uhd-disable-ascii-art-dft.patch
+++ b/flatpak/uhd-disable-ascii-art-dft.patch
@@ -1,0 +1,33 @@
+diff --git a/host/examples/CMakeLists.txt b/host/examples/CMakeLists.txt
+index 5894bb0a2..637a48082 100644
+--- a/host/examples/CMakeLists.txt
++++ b/host/examples/CMakeLists.txt
+@@ -55,18 +55,18 @@ endforeach(example_source)
+ ########################################################################
+ # ASCII Art DFT - requires curses, so this part is optional
+ ########################################################################
+-find_package(Curses)
++#find_package(Curses)
+ 
+-if(CURSES_FOUND)
+-    include_directories(${CURSES_INCLUDE_DIR})
+-    add_executable(rx_ascii_art_dft rx_ascii_art_dft.cpp)
+-    target_link_libraries(rx_ascii_art_dft uhd ${CURSES_LIBRARIES} ${Boost_LIBRARIES})
+-    UHD_INSTALL(TARGETS rx_ascii_art_dft RUNTIME DESTINATION ${PKG_LIB_DIR}/examples COMPONENT examples)
++#if(CURSES_FOUND)
++#    include_directories(${CURSES_INCLUDE_DIR})
++#    add_executable(rx_ascii_art_dft rx_ascii_art_dft.cpp)
++#    target_link_libraries(rx_ascii_art_dft uhd ${CURSES_LIBRARIES} ${Boost_LIBRARIES})
++#    UHD_INSTALL(TARGETS rx_ascii_art_dft RUNTIME DESTINATION ${PKG_LIB_DIR}/examples COMPONENT examples)
+ 
+-    add_executable(twinrx_freq_hopping twinrx_freq_hopping.cpp)
+-    target_link_libraries(twinrx_freq_hopping uhd ${CURSES_LIBRARIES} ${Boost_LIBRARIES})
+-    UHD_INSTALL(TARGETS twinrx_freq_hopping RUNTIME DESTINATION ${PKG_LIB_DIR}/examples COMPONENT examples)
+-endif(CURSES_FOUND)
++#    add_executable(twinrx_freq_hopping twinrx_freq_hopping.cpp)
++#    target_link_libraries(twinrx_freq_hopping uhd ${CURSES_LIBRARIES} ${Boost_LIBRARIES})
++#    UHD_INSTALL(TARGETS twinrx_freq_hopping RUNTIME DESTINATION ${PKG_LIB_DIR}/examples COMPONENT examples)
++#endif(CURSES_FOUND)
+ 
+ ########################################################################
+ # Examples using C API

--- a/flatpak/uhd-disable-latency-utils.patch
+++ b/flatpak/uhd-disable-latency-utils.patch
@@ -1,0 +1,60 @@
+diff --git a/host/utils/latency/CMakeLists.txt b/host/utils/latency/CMakeLists.txt
+index 48a3635a7..4e9f725f1 100644
+--- a/host/utils/latency/CMakeLists.txt
++++ b/host/utils/latency/CMakeLists.txt
+@@ -5,32 +5,32 @@
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #
+ 
+-find_package(Curses)
++#find_package(Curses)
+ 
+-if(CURSES_FOUND)
+-    include_directories(${CURSES_INCLUDE_DIR})
+-    set(latency_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/include)
+-    include_directories(${latency_include_dir})
+-    set(latency_lib_path ${CMAKE_CURRENT_SOURCE_DIR}/lib/Responder.cpp)
++#if(CURSES_FOUND)
++#    include_directories(${CURSES_INCLUDE_DIR})
++#    set(latency_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/include)
++#    include_directories(${latency_include_dir})
++#    set(latency_lib_path ${CMAKE_CURRENT_SOURCE_DIR}/lib/Responder.cpp)
+ 
+-    set(sources
+-        responder.cpp
+-    )
++#    set(sources
++#        responder.cpp
++#    )
+ 
+-    set(latency_comp_name utilities)
+-    set(latency_comp_dest ${PKG_LIB_DIR}/utils/latency)
++#    set(latency_comp_name utilities)
++#    set(latency_comp_dest ${PKG_LIB_DIR}/utils/latency)
+ 
+     #for each source: build an executable and install
+-    foreach(source ${sources})
+-        get_filename_component(name ${source} NAME_WE)
+-        add_executable(${name} ${source} ${latency_lib_path})
+-    	LIBUHD_APPEND_SOURCES(${name})
+-        target_link_libraries(${name} uhd ${Boost_LIBRARIES} ${CURSES_LIBRARIES})
+-    	UHD_INSTALL(TARGETS ${name} RUNTIME DESTINATION ${latency_comp_dest} COMPONENT ${latency_comp_name})
+-    endforeach(source)
++#    foreach(source ${sources})
++#        get_filename_component(name ${source} NAME_WE)
++#        add_executable(${name} ${source} ${latency_lib_path})
++#    	LIBUHD_APPEND_SOURCES(${name})
++#        target_link_libraries(${name} uhd ${Boost_LIBRARIES} ${CURSES_LIBRARIES})
++#    	UHD_INSTALL(TARGETS ${name} RUNTIME DESTINATION ${latency_comp_dest} COMPONENT ${latency_comp_name})
++#    endforeach(source)
+ 
+-    UHD_INSTALL(PROGRAMS run_tests.py graph.py
+-                DESTINATION ${latency_comp_dest}
+-                COMPONENT ${latency_comp_name}
+-    )
+-endif(CURSES_FOUND)
++#    UHD_INSTALL(PROGRAMS run_tests.py graph.py
++#                DESTINATION ${latency_comp_dest}
++#                COMPONENT ${latency_comp_name}
++#    )
++#endif(CURSES_FOUND)


### PR DESCRIPTION
It took me some time, but I finally managed to make the SDRangel Flatpak working! I have also fixed the AppData file to make it pass the validation (feel free to edit the metadata license to the one you want, I have chosen the _CC0-1.0_ one because it is the mostly used metadata license).

SDRangel now builds and runs fine, there is, however, an issue that I was not able to fix:

- Some (optional) dependencies were not found although they are built and properly installed:
```
-- Checking for module 'libbladerf>=2.0'
--   Package 'libbladerf', required by 'virtual:world', not found

-- Checking for module 'libperseus'
--   Package 'libperseus', required by 'virtual:world', not found
-- Found libperseus: /app/include, /app/lib/libperseus-sdr.so

-- Checking for module 'soapysdr>=0.4.0'
--   Package 'soapysdr', required by 'virtual:world', not found
```
(I have tried manually setting the paths in their SDRangel CMake files, but nothing changed.)

There were also some issues that I was able to workaround:

1. The serialDV library was not found by CMake although it was installed (in /app/lib and /app/include). Adding the serialDV paths by patching the CMake file fixed this.

2. SDRangel installs its icon into a legacy share/pixmaps path that is not supported by Flatpak. I manually patched this + used the scalable svg icon instead.

3. Two UHD utilities were impossible to compile with KDE SDK. Fortunately, both were optional so I commented out them in their CMake files.

4. SDRplay seems to only provide closed-source drivers/host utilities that are distributed only as .run file and only for x86 Linux. Unfortunately, using .run files as sources for flatpak-builder is problematic (they can only be used as extra-data) and the SDRplay files are most likely not legally distributable anyway, so I solved this by removing the sdrplay/soapy_sdrplay modules.

Anyway, I tested the Flatpak-ed SDRangel with RTL-SDR and HackRF One and it worked fine. I just had to manually copy udev rules for HackRF and RTL-SDR into the `/etc/udev/rules.d` directory on my system. This is unfortunately a limitation of Flatpak, however I think that there are some SDRs that do not need specific udev rules (Funcube?) and they should work out-of-box in Flatpak.

![sdrangel_flatpak_working](https://user-images.githubusercontent.com/2339930/66337644-d9ee5f00-e93f-11e9-8200-e8ae0d564a35.png)

Feel free to review and merge this PR. :-)