### PR TITLE
Fixing CMake PkgConfig for the SoapySDR Module 

### DIFF
--- a/cmake/Modules/FindSoapySDR.cmake
+++ b/cmake/Modules/FindSoapySDR.cmake
@@ -9,7 +9,7 @@ if(NOT SOAPYSDR_FOUND)
     set(${VERSION} "${CMAKE_MATCH_1}" PARENT_SCOPE)
   endfunction(_SOAPY_SDR_GET_ABI_VERSION)
 
-  pkg_check_modules (LIBSOAPYSDR_PKG soapysdr>=0.4.0)
+  pkg_check_modules (LIBSOAPYSDR_PKG soapysdr>=0.4.0 SoapySDR>0.4.0)
 
   if(LIBSOAPYSDR_PKG_FOUND OR (DEFINED SOAPYSDR_DIR))
 

--- a/cmake/Modules/FindSoapySDR.cmake
+++ b/cmake/Modules/FindSoapySDR.cmake
@@ -9,7 +9,7 @@ if(NOT SOAPYSDR_FOUND)
     set(${VERSION} "${CMAKE_MATCH_1}" PARENT_SCOPE)
   endfunction(_SOAPY_SDR_GET_ABI_VERSION)
 
-  pkg_check_modules (LIBSOAPYSDR_PKG soapysdr>=0.4.0 SoapySDR>0.4.0)
+  pkg_check_modules (LIBSOAPYSDR_PKG soapysdr>=0.4.0 SoapySDR>=0.4.0)
 
   if(LIBSOAPYSDR_PKG_FOUND OR (DEFINED SOAPYSDR_DIR))
 


### PR DESCRIPTION
This Pull Request adds a case-sensitive alternative to the CMake's `pkg_check_modules` function (`SoapySDR` and `soapysdr`). The current code couldn't find the current version of SoapySDR automatically.