### PR TITLE
ATV Demod: introducing of new analog TV shader

### DIFF
--- a/plugins/channelrx/demodatv/atvdemod.h
+++ b/plugins/channelrx/demodatv/atvdemod.h
@@ -87,7 +87,7 @@ public:
     }
 
 	void setScopeSink(BasebandSampleSink* scopeSink) { m_basebandSink->setScopeSink(scopeSink); }
-    void setTVScreen(TVScreen *tvScreen) { m_basebandSink->setTVScreen(tvScreen); }; //!< set by the GUI
+    void setTVScreen(TVScreenAnalog *tvScreen) { m_basebandSink->setTVScreen(tvScreen); }; //!< set by the GUI
     double getMagSq() const { return m_basebandSink->getMagSq(); } //!< Beware this is scaled to 2^30
     bool getBFOLocked() { return m_basebandSink->getBFOLocked(); }
     void setVideoTabIndex(int videoTabIndex) { m_basebandSink->setVideoTabIndex(videoTabIndex); }

--- a/plugins/channelrx/demodatv/atvdemodbaseband.h
+++ b/plugins/channelrx/demodatv/atvdemodbaseband.h
@@ -64,7 +64,7 @@ public:
     int getChannelSampleRate() const;
     double getMagSq() const { return m_sink.getMagSq(); }
     void setScopeSink(BasebandSampleSink* scopeSink) { m_sink.setScopeSink(scopeSink); }
-    void setTVScreen(TVScreen *tvScreen) { m_sink.setTVScreen(tvScreen); }
+    void setTVScreen(TVScreenAnalog *tvScreen) { m_sink.setTVScreen(tvScreen); }
     bool getBFOLocked() { return m_sink.getBFOLocked(); }
     void setVideoTabIndex(int videoTabIndex) { m_sink.setVideoTabIndex(videoTabIndex); }
     void setBasebandSampleRate(int sampleRate); //!< To be used when supporting thread is stopped

--- a/plugins/channelrx/demodatv/atvdemodgui.cpp
+++ b/plugins/channelrx/demodatv/atvdemodgui.cpp
@@ -242,8 +242,6 @@ ATVDemodGUI::ATVDemodGUI(PluginAPI* objPluginAPI, DeviceUISet *deviceUISet, Base
         m_tvSampleRate(48000)
 {
     ui->setupUi(this);
-    ui->screenTV->setColor(false);
-    ui->screenTV->setExtraColumns(true);
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/channelrx/demodatv/atvdemodgui.ui
+++ b/plugins/channelrx/demodatv/atvdemodgui.ui
@@ -1138,7 +1138,7 @@
        <enum>QLayout::SetMinimumSize</enum>
       </property>
       <item>
-       <widget class="TVScreen" name="screenTV" native="true">
+       <widget class="TVScreenAnalog" name="screenTV" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -1242,9 +1242,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>TVScreen</class>
+   <class>TVScreenAnalog</class>
    <extends>QWidget</extends>
-   <header>gui/tvscreen.h</header>
+   <header>gui/tvscreenanalog.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/plugins/channelrx/demodatv/atvdemodsink.cpp
+++ b/plugins/channelrx/demodatv/atvdemodsink.cpp
@@ -486,6 +486,7 @@ void ATVDemodSink::applyChannelSettings(int channelSampleRate, int channelFreque
             m_samplesPerLine - m_numberSamplesPerLineSignals,
             m_settings.m_nbLines - m_numberOfBlackLines
         );
+		m_tvScreenData = m_registeredTVScreen->getData();
     }
 
     m_fieldIndex = 0;
@@ -579,6 +580,7 @@ void ATVDemodSink::applySettings(const ATVDemodSettings& settings, bool force)
                 m_samplesPerLine - m_numberSamplesPerLineSignals,
                 m_settings.m_nbLines - m_numberOfBlackLines
             );
+			m_tvScreenData = m_registeredTVScreen->getData();
         }
 
         m_fieldIndex = 0;

--- a/plugins/channelrx/demodatv/atvdemodsink.cpp
+++ b/plugins/channelrx/demodatv/atvdemodsink.cpp
@@ -43,14 +43,12 @@ ATVDemodSink::ATVDemodSink() :
     m_ampMin(-1.0f),
     m_ampMax(1.0f),
     m_ampDelta(2.0f),
-    m_colIndex(0),
-    m_sampleIndex(0),
-    m_sampleIndexDetected(0),
-    m_hSyncShiftSum(0.0f),
-    m_hSyncShiftCount(0),
+    m_sampleOffset(0),
+	m_sampleOffsetFrac(0.0f),
+    m_sampleOffsetDetected(0),
+	m_hSyncShift(0.0f),
     m_hSyncErrorCount(0),
     m_amSampleIndex(0),
-    m_rowIndex(0),
     m_lineIndex(0),
     m_ampAverage(4800),
     m_bfoPLL(200/1000000, 100/1000000, 0.01),
@@ -490,8 +488,6 @@ void ATVDemodSink::applyChannelSettings(int channelSampleRate, int channelFreque
     }
 
     m_fieldIndex = 0;
-    m_colIndex = 0;
-    m_rowIndex = 0;
 
     m_channelSampleRate = channelSampleRate;
     m_channelFrequencyOffset = channelFrequencyOffset;
@@ -584,8 +580,6 @@ void ATVDemodSink::applySettings(const ATVDemodSettings& settings, bool force)
         }
 
         m_fieldIndex = 0;
-        m_colIndex = 0;
-        m_rowIndex = 0;
     }
 
     if ((settings.m_topTimeFactor != m_settings.m_topTimeFactor) || force) {

--- a/plugins/channelrx/demodatv/atvdemodsink.cpp
+++ b/plugins/channelrx/demodatv/atvdemodsink.cpp
@@ -359,7 +359,7 @@ void ATVDemodSink::applyStandard(int sampleRate, const ATVDemodSettings& setting
         // what is left in a line for the image
         m_interleaved        = true;
         m_numberOfVSyncLines = 4;
-        m_numberOfBlackLines = 58;
+        m_numberOfBlackLines = 59;
         m_firstVisibleLine   = 27;
         m_numberSamplesHSyncCrop = (int) (0.085f * lineDuration * sampleRate); // 8.5% of full line empirically
         break;

--- a/plugins/channelrx/demodatv/atvdemodsink.h
+++ b/plugins/channelrx/demodatv/atvdemodsink.h
@@ -20,6 +20,7 @@
 
 #include <QElapsedTimer>
 #include <vector>
+#include <memory>
 
 #include "dsp/channelsamplesink.h"
 #include "dsp/basebandsamplesink.h"
@@ -108,6 +109,7 @@ private:
 
     //*************** ATV PARAMETERS  ***************
     TVScreenAnalog *m_registeredTVScreen;
+	std::shared_ptr<TVScreenAnalogData> m_tvScreenData;
 
     //int m_intNumberSamplePerLine;
     int m_numberSamplesPerHTopNom;     //!< number of samples per horizontal synchronization pulse (pulse in ultra-black) - nominal value
@@ -198,7 +200,7 @@ private:
     inline void processSample(float& sample, int& sampleVideo)
     {
         // Filling pixel on the current line - reference index 0 at start of sync pulse
-        m_registeredTVScreen->setDataColor(m_sampleIndex - m_numberSamplesPerHSync, sampleVideo);
+		m_tvScreenData->setSampleValue(m_sampleIndex - m_numberSamplesPerHSync, sampleVideo);
 
         if (m_settings.m_hSync)
         {
@@ -325,7 +327,7 @@ private:
 		float shiftSamples = 0.0f;
 		if (m_hSyncShiftCount != 0)
 			shiftSamples = m_hSyncShiftSum / m_hSyncShiftCount;
-		m_registeredTVScreen->selectRow(rowIndex,
+		m_tvScreenData->selectRow(rowIndex,
 			shiftSamples < -1.0f ? -1.0f : (shiftSamples > 1.0f ? 1.0f : shiftSamples));
 	}
 
@@ -358,7 +360,7 @@ private:
 
 		// TODO: CHANGE
 		float shiftSamples = m_hSyncShiftSum / m_hSyncShiftCount;
-		m_registeredTVScreen->selectRow(m_rowIndex,
+		m_tvScreenData->setSampleValue(m_rowIndex,
 			shiftSamples < -1.0f ? -1.0f : (shiftSamples > 1.0f ? 1.0f : shiftSamples));
     }
 };

--- a/sdrgui/CMakeLists.txt
+++ b/sdrgui/CMakeLists.txt
@@ -51,6 +51,7 @@ set(sdrgui_SOURCES
     gui/transverterbutton.cpp
     gui/transverterdialog.cpp
     gui/tvscreen.cpp
+    gui/tvscreenanalog.cpp
     gui/valuedial.cpp
     gui/valuedialz.cpp
 
@@ -123,6 +124,7 @@ set(sdrgui_HEADERS
     gui/transverterbutton.h
     gui/transverterdialog.h
     gui/tvscreen.h
+    gui/tvscreenanalog.h
     gui/valuedial.h
     gui/valuedialz.h
 

--- a/sdrgui/gui/glshadertvarray.h
+++ b/sdrgui/gui/glshadertvarray.h
@@ -43,8 +43,6 @@ public:
     GLShaderTVArray(bool blnColor);
     ~GLShaderTVArray();
 
-    void setExtraColumns(bool blnExtraColumns) { m_blnExtraColumns = blnExtraColumns; }
-    void setSubsampleShift(float subsampleShift) { m_subsampleShift = subsampleShift; }
     void setColor(bool blnColor) { m_blnColor = blnColor; }
     void setAlphaBlend(bool blnAlphaBlend) { m_blnAlphaBlend = blnAlphaBlend; }
     void setAlphaReset() { m_blnAlphaReset = true; }
@@ -73,7 +71,6 @@ protected:
 
     int m_intCols;
     int m_intRows;
-    float m_subsampleShift;
 
     QRgb * m_objCurrentRow;
 
@@ -81,7 +78,6 @@ protected:
     bool m_blnColor;
     bool m_blnAlphaBlend;
     bool m_blnAlphaReset;
-    bool m_blnExtraColumns;
 };
 
 #endif /* INCLUDE_GUI_GLTVSHADERARRAY_H_ */

--- a/sdrgui/gui/tvscreen.cpp
+++ b/sdrgui/gui/tvscreen.cpp
@@ -37,7 +37,6 @@ TVScreen::TVScreen(bool blnColor, QWidget* parent) :
     m_objTimer.start(40); // capped at 25 FPS
 
     m_chrLastData = NULL;
-    m_subsampleShift = 0.0;
     m_blnConfigChanged = false;
     m_blnDataChanged = false;
     m_blnGLContextInitialized = false;
@@ -59,11 +58,6 @@ void TVScreen::setColor(bool blnColor)
 	m_objGLShaderArray.setColor(blnColor);
 }
 
-void TVScreen::setExtraColumns(bool blnExtraColumns)
-{
-    m_objGLShaderArray.setExtraColumns(blnExtraColumns);
-}
-
 QRgb* TVScreen::getRowBuffer(int intRow)
 {
     if (!m_blnGLContextInitialized)
@@ -74,10 +68,9 @@ QRgb* TVScreen::getRowBuffer(int intRow)
     return m_objGLShaderArray.GetRowBuffer(intRow);
 }
 
-void TVScreen::renderImage(unsigned char * objData, float subsampleShift)
+void TVScreen::renderImage(unsigned char * objData)
 {
     m_chrLastData = objData;
-    m_subsampleShift = subsampleShift;
     m_blnDataChanged = true;
 }
 
@@ -184,7 +177,6 @@ void TVScreen::paintGL()
         m_intAskedRows = 0;
     }
 
-    m_objGLShaderArray.setSubsampleShift(m_subsampleShift);
     m_objGLShaderArray.RenderPixels(m_chrLastData);
 
     m_objMutex.unlock();

--- a/sdrgui/gui/tvscreenanalog.cpp
+++ b/sdrgui/gui/tvscreenanalog.cpp
@@ -31,8 +31,8 @@ static const char* vertexShaderSource =
 "}\n";
 
 static const char* fragmentShaderSource =
-"uniform highp sampler2D uTexture1;\n"
-"uniform highp sampler2D uTexture2;\n"
+"uniform highp sampler2D tex1;\n"
+"uniform highp sampler2D tex2;\n"
 "uniform highp float imw;\n"
 "uniform highp float imh;\n"
 "uniform highp float tlw;\n"
@@ -44,8 +44,8 @@ static const char* fragmentShaderSource =
 "    float tys = (texCoordVar.y + tlhh) * imh;\n"
 "    float p1y = floor(tys) * tlh - tlhh;\n"
 "    float p3y = p1y + tlh;\n"
-"    float tshift1 = texture2D(uTexture2, vec2(0.0, p1y)).r;\n"
-"    float tshift3 = texture2D(uTexture2, vec2(0.0, p3y)).r;\n"
+"    float tshift1 = texture2D(tex2, vec2(0.0, p1y)).r;\n"
+"    float tshift3 = texture2D(tex2, vec2(0.0, p3y)).r;\n"
 "    float shift1 = (1.0 - tshift1 * 2.0) * tlw;\n"
 "    float shift3 = (1.0 - tshift3 * 2.0) * tlw;\n"
 "    float txs1 = (texCoordVar.x + shift1 + tlhw) * imw;\n"
@@ -54,10 +54,10 @@ static const char* fragmentShaderSource =
 "    float p3x = floor(txs3) * tlw - tlhw;\n"
 "    float p2x = p1x + tlw;\n"
 "    float p4x = p3x + tlw;\n"
-"    float p1 = texture2D(uTexture1, vec2(p1x, p1y)).r;\n"
-"    float p2 = texture2D(uTexture1, vec2(p2x, p1y)).r;\n"
-"    float p3 = texture2D(uTexture1, vec2(p3x, p3y)).r;\n"
-"    float p4 = texture2D(uTexture1, vec2(p4x, p3y)).r;\n"
+"    float p1 = texture2D(tex1, vec2(p1x, p1y)).r;\n"
+"    float p2 = texture2D(tex1, vec2(p2x, p1y)).r;\n"
+"    float p3 = texture2D(tex1, vec2(p3x, p3y)).r;\n"
+"    float p4 = texture2D(tex1, vec2(p4x, p3y)).r;\n"
 "    float p12 = mix(p1, p2, fract(txs1));\n"
 "    float p34 = mix(p3, p4, fract(txs3));\n"
 "    float p = mix(p12, p34, fract(tys));\n"
@@ -67,11 +67,8 @@ static const char* fragmentShaderSource =
 TVScreenAnalog::TVScreenAnalog(QWidget *parent)
 	: QGLWidget(parent)
 {
-	m_objCurrentRow = nullptr;
 	m_isDataChanged = false;
-	m_time = 0.0f;
-	m_cols = 1;
-	m_rows = 1;
+	m_data = std::make_shared<TVScreenAnalogData>(5, 1);
 
 	connect(&m_objTimer, SIGNAL(timeout()), this, SLOT(tick()));
 	m_objTimer.start(40); // capped at 25 FPS
@@ -81,15 +78,21 @@ void TVScreenAnalog::cleanup()
 {
 	m_shader = nullptr;
 	m_imageTexture = nullptr;
-	m_objCurrentRow = nullptr;
 	m_lineShiftsTexture = nullptr;
+}
+
+std::shared_ptr<TVScreenAnalogData> TVScreenAnalog::getData()
+{
+	return m_data;
 }
 
 void TVScreenAnalog::resizeTVScreen(int intCols, int intRows)
 {
 	qDebug("TVScreen::resizeTVScreen: cols: %d, rows: %d", intCols, intRows);
-	m_cols = intCols + 4;
-	m_rows = intRows;
+
+	int colsAdj = intCols + 4;
+	if (m_data->getWidth() != colsAdj || m_data->getHeight() != intRows)
+		m_data = std::make_shared<TVScreenAnalogData>(colsAdj, intRows);
 }
 
 void TVScreenAnalog::resizeGL(int intWidth, int intHeight)
@@ -99,7 +102,6 @@ void TVScreenAnalog::resizeGL(int intWidth, int intHeight)
 
 void TVScreenAnalog::initializeGL()
 {
-	m_objMutex.lock();
 	initializeOpenGLFunctions();
 
 	m_shader = std::make_shared<QOpenGLShaderProgram>(this);
@@ -109,31 +111,30 @@ void TVScreenAnalog::initializeGL()
 
 	m_vertexAttribIndex = m_shader->attributeLocation("vertex");
 	m_texCoordAttribIndex = m_shader->attributeLocation("texCoord");
-	m_objTextureLoc1 = m_shader->uniformLocation("uTexture1");
-	m_objTextureLoc2 = m_shader->uniformLocation("uTexture2");
-	m_objImageWidthLoc = m_shader->uniformLocation("imw");
-	m_objImageHeightLoc = m_shader->uniformLocation("imh");
-	m_objTexelWidthLoc = m_shader->uniformLocation("tlw");
-	m_objTexelHeightLoc = m_shader->uniformLocation("tlh");
-	
-
-	initializeTextures();
+	m_textureLoc1 = m_shader->uniformLocation("tex1");
+	m_textureLoc2 = m_shader->uniformLocation("tex2");
+	m_imageWidthLoc = m_shader->uniformLocation("imw");
+	m_imageHeightLoc = m_shader->uniformLocation("imh");
+	m_texelWidthLoc = m_shader->uniformLocation("tlw");
+	m_texelHeightLoc = m_shader->uniformLocation("tlh");
 
 	connect(QOpenGLContext::currentContext(), &QOpenGLContext::aboutToBeDestroyed,
 		this, &TVScreenAnalog::cleanup); // TODO: when migrating to QOpenGLWidget
-
-	m_objMutex.unlock();
 }
 
 void TVScreenAnalog::initializeTextures()
 {
-	m_image = std::make_shared<QImage>(m_cols, m_rows, QImage::Format_ARGB32);
-	m_lineShifts = std::make_shared<QImage>(1, m_rows, QImage::Format_ARGB32);
-	m_image->fill(0);
-	m_lineShifts->fill(127);
+	m_imageTexture = std::make_shared<QOpenGLTexture>(QOpenGLTexture::Target2D);
+	m_lineShiftsTexture = std::make_shared<QOpenGLTexture>(QOpenGLTexture::Target2D);
+	m_imageTexture->setSize(m_data->getWidth(), m_data->getHeight());
+	m_lineShiftsTexture->setSize(1, m_data->getHeight());
+	m_imageTexture->setFormat(QOpenGLTexture::RGBA8_UNorm);
+	m_lineShiftsTexture->setFormat(QOpenGLTexture::RGBA8_UNorm);
+	m_imageTexture->setAutoMipMapGenerationEnabled(false);
+	m_lineShiftsTexture->setAutoMipMapGenerationEnabled(false);
+	m_imageTexture->allocateStorage(QOpenGLTexture::RGBA, QOpenGLTexture::UInt8);
+	m_lineShiftsTexture->allocateStorage(QOpenGLTexture::RGBA, QOpenGLTexture::UInt8);
 
-	m_imageTexture = std::make_shared<QOpenGLTexture>(*m_image, QOpenGLTexture::DontGenerateMipMaps);
-	m_lineShiftsTexture = std::make_shared<QOpenGLTexture>(*m_lineShifts, QOpenGLTexture::DontGenerateMipMaps);
 	m_imageTexture->setMinificationFilter(QOpenGLTexture::Nearest);
 	m_imageTexture->setMagnificationFilter(QOpenGLTexture::Nearest);
 	m_lineShiftsTexture->setMinificationFilter(QOpenGLTexture::Nearest);
@@ -151,69 +152,45 @@ void TVScreenAnalog::renderImage()
 
 void TVScreenAnalog::tick()
 {
-	if (m_isDataChanged) {
+	if (m_isDataChanged)
+	{
 		update();
-	}
-}
-
-void TVScreenAnalog::selectRow(int intLine, float shift)
-{
-	if (!m_image || m_image->height() != m_rows)
-		return;
-
-	if ((intLine < m_rows) && (intLine >= 0))
-	{
-		m_objCurrentRow = (int*)m_image->scanLine(intLine);
-		m_lineShifts->setPixel(0, intLine, (1.0f + shift) * 127.5f);
-	}
-	else
-	{
-		m_objCurrentRow = nullptr;
-	}
-}
-
-void TVScreenAnalog::setDataColor(int intCol, int objColor)
-{
-	if ((intCol < m_cols - 2) &&
-		(intCol >= -2) &&
-		(m_objCurrentRow != nullptr))
-	{
-		m_objCurrentRow[intCol + 2] = objColor;
 	}
 }
 
 void TVScreenAnalog::paintGL()
 {
-	if (!m_objMutex.tryLock(2))
-		return;
-
 	m_isDataChanged = false;
 
-	if (m_image->width() != m_cols || m_image->height() != m_rows)
+	if (!m_imageTexture ||
+		m_imageTexture->width() != m_data->getWidth() ||
+		m_imageTexture->height() != m_data->getHeight())
+	{
 		initializeTextures();
+	}
 
-	float imageWidth = m_image->width();
-	float imageHeight = m_image->height();
+	float imageWidth = m_data->getWidth();
+	float imageHeight = m_data->getHeight();
 	float texelWidth = 1.0f / imageWidth;
 	float texelHeight = 1.0f / imageHeight;
 
 	m_shader->bind();
-	m_shader->setUniformValue(m_objTextureLoc1, 0);
-	m_shader->setUniformValue(m_objTextureLoc2, 1);
-	m_shader->setUniformValue(m_objImageWidthLoc, imageWidth);
-	m_shader->setUniformValue(m_objImageHeightLoc, imageHeight);
-	m_shader->setUniformValue(m_objTexelWidthLoc, texelWidth);
-	m_shader->setUniformValue(m_objTexelHeightLoc, texelHeight);
+	m_shader->setUniformValue(m_textureLoc1, 0);
+	m_shader->setUniformValue(m_textureLoc2, 1);
+	m_shader->setUniformValue(m_imageWidthLoc, imageWidth);
+	m_shader->setUniformValue(m_imageHeightLoc, imageHeight);
+	m_shader->setUniformValue(m_texelWidthLoc, texelWidth);
+	m_shader->setUniformValue(m_texelHeightLoc, texelHeight);
 
 	glActiveTexture(GL_TEXTURE0);
 	m_imageTexture->bind();
 	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
-		m_image->width(), m_image->height(), GL_RGBA, GL_UNSIGNED_BYTE, m_image->constScanLine(0));
+		m_data->getWidth(), m_data->getHeight(), GL_RGBA, GL_UNSIGNED_BYTE, m_data->getImageData());
 
 	glActiveTexture(GL_TEXTURE1);
 	m_lineShiftsTexture->bind();
 	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
-		1, m_image->height(), GL_RGBA, GL_UNSIGNED_BYTE, m_lineShifts->constScanLine(0));
+		1, m_data->getHeight(), GL_RGBA, GL_UNSIGNED_BYTE, m_data->getLineShiftData());
 
 	float rectHalfWidth = 1.0f + 4 * texelWidth;
 	GLfloat vertices[] =
@@ -241,6 +218,4 @@ void TVScreenAnalog::paintGL()
 	glDisableVertexAttribArray(m_texCoordAttribIndex);
 
 	m_shader->release();
-
-	m_objMutex.unlock();
 }

--- a/sdrgui/gui/tvscreenanalog.cpp
+++ b/sdrgui/gui/tvscreenanalog.cpp
@@ -1,0 +1,246 @@
+///////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2020 Vort                                                       //
+// Copyright (C) 2018 F4HKW                                                      //
+// for F4EXB / SDRAngel                                                          //
+//                                                                               //
+// OpenGL interface modernization.                                               //
+//                                                                               //
+// This program is free software; you can redistribute it and/or modify          //
+// it under the terms of the GNU General Public License as published by          //
+// the Free Software Foundation as version 3 of the License, or                  //
+// (at your option) any later version.                                           //
+//                                                                               //
+// This program is distributed in the hope that it will be useful,               //
+// but WITHOUT ANY WARRANTY; without even the implied warranty of                //
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                  //
+// GNU General Public License V3 for more details.                               //
+//                                                                               //
+// You should have received a copy of the GNU General Public License             //
+// along with this program. If not, see <http://www.gnu.org/licenses/>.          //
+///////////////////////////////////////////////////////////////////////////////////
+
+#include "tvscreenanalog.h"
+
+static const char* vertexShaderSource =
+"attribute highp vec4 vertex;\n"
+"attribute highp vec2 texCoord;\n"
+"varying highp vec2 texCoordVar;\n"
+"void main() {\n"
+"    gl_Position = vertex;\n"
+"    texCoordVar = texCoord;\n"
+"}\n";
+
+static const char* fragmentShaderSource =
+"uniform highp sampler2D uTexture1;\n"
+"uniform highp sampler2D uTexture2;\n"
+"uniform highp float imw;\n"
+"uniform highp float imh;\n"
+"uniform highp float tlw;\n"
+"uniform highp float tlh;\n"
+"varying highp vec2 texCoordVar;\n"
+"void main() {\n"
+"    float tlhw = 0.5 * tlw;"
+"    float tlhh = 0.5 * tlh;"
+"    float tys = (texCoordVar.y + tlhh) * imh;\n"
+"    float p1y = floor(tys) * tlh - tlhh;\n"
+"    float p3y = p1y + tlh;\n"
+"    float tshift1 = texture2D(uTexture2, vec2(0.0, p1y)).r;\n"
+"    float tshift3 = texture2D(uTexture2, vec2(0.0, p3y)).r;\n"
+"    float shift1 = (1.0 - tshift1 * 2.0) * tlw;\n"
+"    float shift3 = (1.0 - tshift3 * 2.0) * tlw;\n"
+"    float txs1 = (texCoordVar.x + shift1 + tlhw) * imw;\n"
+"    float txs3 = (texCoordVar.x + shift3 + tlhw) * imw;\n"
+"    float p1x = floor(txs1) * tlw - tlhw;\n"
+"    float p3x = floor(txs3) * tlw - tlhw;\n"
+"    float p2x = p1x + tlw;\n"
+"    float p4x = p3x + tlw;\n"
+"    float p1 = texture2D(uTexture1, vec2(p1x, p1y)).r;\n"
+"    float p2 = texture2D(uTexture1, vec2(p2x, p1y)).r;\n"
+"    float p3 = texture2D(uTexture1, vec2(p3x, p3y)).r;\n"
+"    float p4 = texture2D(uTexture1, vec2(p4x, p3y)).r;\n"
+"    float p12 = mix(p1, p2, fract(txs1));\n"
+"    float p34 = mix(p3, p4, fract(txs3));\n"
+"    float p = mix(p12, p34, fract(tys));\n"
+"    gl_FragColor = vec4(p);\n"
+"}\n";
+
+TVScreenAnalog::TVScreenAnalog(QWidget *parent)
+	: QGLWidget(parent)
+{
+	m_objCurrentRow = nullptr;
+	m_isDataChanged = false;
+	m_time = 0.0f;
+	m_cols = 1;
+	m_rows = 1;
+
+	connect(&m_objTimer, SIGNAL(timeout()), this, SLOT(tick()));
+	m_objTimer.start(40); // capped at 25 FPS
+}
+
+void TVScreenAnalog::cleanup()
+{
+	m_shader = nullptr;
+	m_imageTexture = nullptr;
+	m_objCurrentRow = nullptr;
+	m_lineShiftsTexture = nullptr;
+}
+
+void TVScreenAnalog::resizeTVScreen(int intCols, int intRows)
+{
+	qDebug("TVScreen::resizeTVScreen: cols: %d, rows: %d", intCols, intRows);
+	m_cols = intCols + 4;
+	m_rows = intRows;
+}
+
+void TVScreenAnalog::resizeGL(int intWidth, int intHeight)
+{
+	glViewport(0, 0, intWidth, intHeight);
+}
+
+void TVScreenAnalog::initializeGL()
+{
+	m_objMutex.lock();
+	initializeOpenGLFunctions();
+
+	m_shader = std::make_shared<QOpenGLShaderProgram>(this);
+	m_shader->addShaderFromSourceCode(QOpenGLShader::Fragment, fragmentShaderSource);
+	m_shader->addShaderFromSourceCode(QOpenGLShader::Vertex, vertexShaderSource);
+	m_shader->link();
+
+	m_vertexAttribIndex = m_shader->attributeLocation("vertex");
+	m_texCoordAttribIndex = m_shader->attributeLocation("texCoord");
+	m_objTextureLoc1 = m_shader->uniformLocation("uTexture1");
+	m_objTextureLoc2 = m_shader->uniformLocation("uTexture2");
+	m_objImageWidthLoc = m_shader->uniformLocation("imw");
+	m_objImageHeightLoc = m_shader->uniformLocation("imh");
+	m_objTexelWidthLoc = m_shader->uniformLocation("tlw");
+	m_objTexelHeightLoc = m_shader->uniformLocation("tlh");
+	
+
+	initializeTextures();
+
+	connect(QOpenGLContext::currentContext(), &QOpenGLContext::aboutToBeDestroyed,
+		this, &TVScreenAnalog::cleanup); // TODO: when migrating to QOpenGLWidget
+
+	m_objMutex.unlock();
+}
+
+void TVScreenAnalog::initializeTextures()
+{
+	m_image = std::make_shared<QImage>(m_cols, m_rows, QImage::Format_ARGB32);
+	m_lineShifts = std::make_shared<QImage>(1, m_rows, QImage::Format_ARGB32);
+	m_image->fill(0);
+	m_lineShifts->fill(127);
+
+	m_imageTexture = std::make_shared<QOpenGLTexture>(*m_image, QOpenGLTexture::DontGenerateMipMaps);
+	m_lineShiftsTexture = std::make_shared<QOpenGLTexture>(*m_lineShifts, QOpenGLTexture::DontGenerateMipMaps);
+	m_imageTexture->setMinificationFilter(QOpenGLTexture::Nearest);
+	m_imageTexture->setMagnificationFilter(QOpenGLTexture::Nearest);
+	m_lineShiftsTexture->setMinificationFilter(QOpenGLTexture::Nearest);
+	m_lineShiftsTexture->setMagnificationFilter(QOpenGLTexture::Nearest);
+	m_imageTexture->setWrapMode(QOpenGLTexture::DirectionS, QOpenGLTexture::ClampToBorder);
+	m_imageTexture->setWrapMode(QOpenGLTexture::DirectionT, QOpenGLTexture::ClampToEdge);
+	m_lineShiftsTexture->setWrapMode(QOpenGLTexture::DirectionS, QOpenGLTexture::Repeat);
+	m_lineShiftsTexture->setWrapMode(QOpenGLTexture::DirectionT, QOpenGLTexture::ClampToEdge);
+}
+
+void TVScreenAnalog::renderImage()
+{
+	m_isDataChanged = true;
+}
+
+void TVScreenAnalog::tick()
+{
+	if (m_isDataChanged) {
+		update();
+	}
+}
+
+void TVScreenAnalog::selectRow(int intLine, float shift)
+{
+	if (!m_image || m_image->height() != m_rows)
+		return;
+
+	if ((intLine < m_rows) && (intLine >= 0))
+	{
+		m_objCurrentRow = (int*)m_image->scanLine(intLine);
+		m_lineShifts->setPixel(0, intLine, (1.0f + shift) * 127.5f);
+	}
+	else
+	{
+		m_objCurrentRow = nullptr;
+	}
+}
+
+void TVScreenAnalog::setDataColor(int intCol, int objColor)
+{
+	if ((intCol < m_cols - 2) &&
+		(intCol >= -2) &&
+		(m_objCurrentRow != nullptr))
+	{
+		m_objCurrentRow[intCol + 2] = objColor;
+	}
+}
+
+void TVScreenAnalog::paintGL()
+{
+	if (!m_objMutex.tryLock(2))
+		return;
+
+	m_isDataChanged = false;
+
+	if (m_image->width() != m_cols || m_image->height() != m_rows)
+		initializeTextures();
+
+	float imageWidth = m_image->width();
+	float imageHeight = m_image->height();
+	float texelWidth = 1.0f / imageWidth;
+	float texelHeight = 1.0f / imageHeight;
+
+	m_shader->bind();
+	m_shader->setUniformValue(m_objTextureLoc1, 0);
+	m_shader->setUniformValue(m_objTextureLoc2, 1);
+	m_shader->setUniformValue(m_objImageWidthLoc, imageWidth);
+	m_shader->setUniformValue(m_objImageHeightLoc, imageHeight);
+	m_shader->setUniformValue(m_objTexelWidthLoc, texelWidth);
+	m_shader->setUniformValue(m_objTexelHeightLoc, texelHeight);
+
+	glActiveTexture(GL_TEXTURE0);
+	m_imageTexture->bind();
+	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
+		m_image->width(), m_image->height(), GL_RGBA, GL_UNSIGNED_BYTE, m_image->constScanLine(0));
+
+	glActiveTexture(GL_TEXTURE1);
+	m_lineShiftsTexture->bind();
+	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
+		1, m_image->height(), GL_RGBA, GL_UNSIGNED_BYTE, m_lineShifts->constScanLine(0));
+
+	float rectHalfWidth = 1.0f + 4 * texelWidth;
+	GLfloat vertices[] =
+	{
+		-rectHalfWidth, -1.0f,
+		-rectHalfWidth,  1.0f,
+		 rectHalfWidth,  1.0f,
+		 rectHalfWidth, -1.0f
+	};
+
+	static const GLfloat arrTextureCoords[] =
+	{
+		0.0f, 1.0f,
+		0.0f, 0.0f,
+		1.0f, 0.0f,
+		1.0f, 1.0f
+	};
+
+	glVertexAttribPointer(m_vertexAttribIndex, 2, GL_FLOAT, GL_FALSE, 0, vertices);
+	glEnableVertexAttribArray(m_vertexAttribIndex);
+	glVertexAttribPointer(m_texCoordAttribIndex, 2, GL_FLOAT, GL_FALSE, 0, arrTextureCoords);
+	glEnableVertexAttribArray(m_texCoordAttribIndex);
+	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+	glDisableVertexAttribArray(m_vertexAttribIndex);
+	glDisableVertexAttribArray(m_texCoordAttribIndex);
+
+	m_shader->release();
+
+	m_objMutex.unlock();
+}


### PR DESCRIPTION
Here is my vision of how analog TV samples should be converted to digital pixels.

These commits introduce new class: `TVScreenAnalog`.
Which is capable of shifting each individual line with subsample precision.
With it comes `TVScreenAnalogData`, which contains image and line shifts data.
Since new screen now allows independent shifts, HSync algorithm is reworked.

New TV screen uses shaders to accomplish its tasks.
Because of this, it should be tested on various hardware.
As GPU drivers can contain bugs and execute shaders command wrong.

With separate test program > 1000 FPS was obtained with this shader.
Main time consumer in render function is texture copy command.
So shader is not needed to be optimized further right now.

CPU consumption should stay approximately at the same level.
Or may be even lower, because of possibility of data access inlining.

This code is not too much tested yet.
So it may be ready to merge as is or not.