### PR TITLE
Fix libiio channel handling for IQ sampling with plutosdr

### DIFF
--- a/devices/plutosdr/deviceplutosdrbox.cpp
+++ b/devices/plutosdr/deviceplutosdrbox.cpp
@@ -41,6 +41,7 @@ DevicePlutoSDRBox::DevicePlutoSDRBox(const std::string& uri) :
         m_devRx(0),
         m_devTx(0),
         m_chnRx0(0),
+        m_chnRxQ(0),
         m_chnTx0i(0),
         m_chnTx0q(0),
         m_rxBuf(0),
@@ -254,12 +255,14 @@ bool DevicePlutoSDRBox::openRx()
 {
     if (!m_valid) { return false; }
 
-    if (!m_chnRx0) {
+    if (!m_chnRx0 || !m_chnRxQ) {
         m_chnRx0 = iio_device_find_channel(m_devRx, "voltage0", false);
+        m_chnRxQ = iio_device_find_channel(m_devRx, "voltage1", false);
     }
 
-    if (m_chnRx0) {
+    if (m_chnRx0 && m_chnRxQ) {
         iio_channel_enable(m_chnRx0);
+        iio_channel_enable(m_chnRxQ);
         const struct iio_data_format *df = iio_channel_get_data_format(m_chnRx0);
         qDebug("DevicePlutoSDRBox::openRx: length: %u bits: %u shift: %u signed: %s be: %s with_scale: %s scale: %lf repeat: %u",
                 df->length,

--- a/devices/plutosdr/deviceplutosdrbox.cpp
+++ b/devices/plutosdr/deviceplutosdrbox.cpp
@@ -40,8 +40,8 @@ DevicePlutoSDRBox::DevicePlutoSDRBox(const std::string& uri) :
         m_devPhy(0),
         m_devRx(0),
         m_devTx(0),
-        m_chnRx0(0),
-        m_chnRxQ(0),
+        m_chnRx0i(0),
+        m_chnRx0q(0),
         m_chnTx0i(0),
         m_chnTx0q(0),
         m_rxBuf(0),
@@ -255,16 +255,15 @@ bool DevicePlutoSDRBox::openRx()
 {
     if (!m_valid) { return false; }
 
-    if (!m_chnRx0 || !m_chnRxQ) {
-        m_chnRx0 = iio_device_find_channel(m_devRx, "voltage0", false);
-        m_chnRxQ = iio_device_find_channel(m_devRx, "voltage1", false);
+    if (!m_chnRx0i) {
+        m_chnRx0i = iio_device_find_channel(m_devRx, "voltage0", false);
     }
 
-    if (m_chnRx0 && m_chnRxQ) {
-        iio_channel_enable(m_chnRx0);
-        iio_channel_enable(m_chnRxQ);
-        const struct iio_data_format *df = iio_channel_get_data_format(m_chnRx0);
-        qDebug("DevicePlutoSDRBox::openRx: length: %u bits: %u shift: %u signed: %s be: %s with_scale: %s scale: %lf repeat: %u",
+    if (m_chnRx0i) {
+        iio_channel_enable(m_chnRx0i);
+        
+        const struct iio_data_format *df = iio_channel_get_data_format(m_chnRx0i);
+        qDebug("DevicePlutoSDRBox::openRx channel I: length: %u bits: %u shift: %u signed: %s be: %s with_scale: %s scale: %lf repeat: %u",
                 df->length,
                 df->bits,
                 df->shift,
@@ -273,8 +272,31 @@ bool DevicePlutoSDRBox::openRx()
                 df->with_scale? "true" : "false",
                 df->scale,
                 df->repeat);
-        return true;
     } else {
+        std::cerr << "DevicePlutoSDRBox::openRx: failed" << std::endl;
+        return false;
+    }
+
+    if (!m_chnRx0q) {
+        m_chnRx0q = iio_device_find_channel(m_devRx, "voltage1", false);
+    }
+
+    if (m_chnRx0q) {
+        iio_channel_enable(m_chnRx0q);
+
+        const struct iio_data_format* df = iio_channel_get_data_format(m_chnRx0q);
+        qDebug("DevicePlutoSDRBox::openRx channel Q: length: %u bits: %u shift: %u signed: %s be: %s with_scale: %s scale: %lf repeat: %u",
+            df->length,
+            df->bits,
+            df->shift,
+            df->is_signed ? "true" : "false",
+            df->is_be ? "true" : "false",
+            df->with_scale ? "true" : "false",
+            df->scale,
+            df->repeat);
+        return true;
+    }
+    else {
         std::cerr << "DevicePlutoSDRBox::openRx: failed" << std::endl;
         return false;
     }
@@ -330,7 +352,8 @@ bool DevicePlutoSDRBox::openTx()
 
 void DevicePlutoSDRBox::closeRx()
 {
-    if (m_chnRx0) { iio_channel_disable(m_chnRx0); }
+    if (m_chnRx0i) { iio_channel_disable(m_chnRx0i); }
+    if (m_chnRx0q) { iio_channel_disable(m_chnRx0q); }
 }
 
 void DevicePlutoSDRBox::closeTx()
@@ -434,7 +457,7 @@ char* DevicePlutoSDRBox::rxBufferEnd()
 char* DevicePlutoSDRBox::rxBufferFirst()
 {
     if (m_rxBuf) {
-        return (char *) iio_buffer_first(m_rxBuf, m_chnRx0);
+        return (char *) iio_buffer_first(m_rxBuf, m_chnRx0i);
     } else {
         return 0;
     }

--- a/devices/plutosdr/deviceplutosdrbox.h
+++ b/devices/plutosdr/deviceplutosdrbox.h
@@ -120,6 +120,7 @@ private:
     struct iio_device  *m_devRx;
     struct iio_device  *m_devTx;
     struct iio_channel *m_chnRx0;
+    struct iio_channel* m_chnRxQ;
     struct iio_channel *m_chnTx0i;
     struct iio_channel *m_chnTx0q;
     struct iio_buffer  *m_rxBuf;

--- a/devices/plutosdr/deviceplutosdrbox.h
+++ b/devices/plutosdr/deviceplutosdrbox.h
@@ -85,7 +85,7 @@ public:
     void deleteTxBuffer();
     ssize_t getRxSampleSize();
     ssize_t getTxSampleSize();
-    struct iio_channel *getRxChannel0() { return m_chnRx0; }
+    struct iio_channel *getRxChannel0() { return m_chnRx0i; }
     struct iio_channel *getTxChannel0I() { return m_chnTx0i; }
     struct iio_channel *getTxChannel0Q() { return m_chnTx0q; }
     ssize_t rxBufferRefill();
@@ -119,8 +119,8 @@ private:
     struct iio_device  *m_devPhy;
     struct iio_device  *m_devRx;
     struct iio_device  *m_devTx;
-    struct iio_channel *m_chnRx0;
-    struct iio_channel* m_chnRxQ;
+    struct iio_channel *m_chnRx0i;
+    struct iio_channel* m_chnRx0q;
     struct iio_channel *m_chnTx0i;
     struct iio_channel *m_chnTx0q;
     struct iio_buffer  *m_rxBuf;

--- a/plugins/samplesource/plutosdrinput/plutosdrinputthread.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinputthread.cpp
@@ -94,7 +94,7 @@ void PlutoSDRInputThread::run()
         // Refill RX buffer
         nbytes_rx = m_plutoBox->rxBufferRefill();
 
-        if (nbytes_rx != m_blockSizeSamples*2)
+        if (nbytes_rx != m_blockSizeSamples*4)
         {
             qWarning("PlutoSDRInputThread::run: error refilling buf (1) %d / %d",(int) nbytes_rx, (int)  m_blockSizeSamples*2);
             usleep(200000);
@@ -111,13 +111,14 @@ void PlutoSDRInputThread::run()
 
         for (p_dat = m_plutoBox->rxBufferFirst(); p_dat < p_end; p_dat += p_inc)
         {
-            m_buf[ihs] = *((int16_t *) p_dat);
+            m_buf[ihs++] = *((int16_t *) p_dat);
+            m_buf[ihs++] = *(((int16_t*)p_dat)+1);
 //            iio_channel_convert(m_plutoBox->getRxChannel0(), (void *) &m_bufConv[ihs], (const void *) &m_buf[ihs]);
-            ihs++;
+            //ihs++;
         }
 
         // Refill RX buffer again - we still need twice more samples to complete since they come as I followed by Q
-        nbytes_rx = m_plutoBox->rxBufferRefill();
+        /*nbytes_rx = m_plutoBox->rxBufferRefill();
 
         if (nbytes_rx != m_blockSizeSamples*2)
         {
@@ -139,7 +140,7 @@ void PlutoSDRInputThread::run()
 //            iio_channel_convert(m_plutoBox->getRxChannel0(), (void *) &m_bufConv[ihs], (const void *) &m_buf[ihs]);
             ihs++;
         }
-
+        */
         if (m_iqOrder) {
             convertIQ(m_buf, 2*m_blockSizeSamples); // size given in number of int16_t (I and Q interleaved)
         } else {

--- a/plugins/samplesource/plutosdrinput/plutosdrinputthread.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinputthread.cpp
@@ -80,7 +80,7 @@ void PlutoSDRInputThread::run()
     qDebug("PlutoSDRInputThread::run: rxBufferStep: %ld bytes", p_inc);
     qDebug("PlutoSDRInputThread::run: Rx sample size is %ld bytes", m_plutoBox->getRxSampleSize());
     qDebug("PlutoSDRInputThread::run: Tx sample size is %ld bytes", m_plutoBox->getTxSampleSize());
-    qDebug("PlutoSDRInputThread::run: nominal nbytes_rx is %d bytes with 2 refills", m_blockSizeSamples*2);
+    qDebug("PlutoSDRInputThread::run: nominal nbytes_rx is %d bytes with 1 refill", m_blockSizeSamples*4);
 
     m_running = true;
     m_startWaiter.wakeAll();
@@ -96,7 +96,7 @@ void PlutoSDRInputThread::run()
 
         if (nbytes_rx != m_blockSizeSamples*4)
         {
-            qWarning("PlutoSDRInputThread::run: error refilling buf (1) %d / %d",(int) nbytes_rx, (int)  m_blockSizeSamples*2);
+            qWarning("PlutoSDRInputThread::run: error refilling buf %d / %d",(int) nbytes_rx, (int)  m_blockSizeSamples*4);
             usleep(200000);
             continue;
         }
@@ -105,42 +105,17 @@ void PlutoSDRInputThread::run()
         p_end = m_plutoBox->rxBufferEnd();
         ihs = 0;
 
-        // p_inc is 2 on a char* buffer therefore each iteration processes only the I or Q sample
-        // I and Q samples are processed one after the other
+        // p_inc is 4 on a char* buffer therefore each iteration processes a single IQ sample,
+        // I and Q each being two bytes
         // conversion is not needed as samples are little endian
 
         for (p_dat = m_plutoBox->rxBufferFirst(); p_dat < p_end; p_dat += p_inc)
         {
             m_buf[ihs++] = *((int16_t *) p_dat);
-            m_buf[ihs++] = *(((int16_t*)p_dat)+1);
+            m_buf[ihs++] = *(((int16_t *) p_dat) + 1);
 //            iio_channel_convert(m_plutoBox->getRxChannel0(), (void *) &m_bufConv[ihs], (const void *) &m_buf[ihs]);
-            //ihs++;
         }
 
-        // Refill RX buffer again - we still need twice more samples to complete since they come as I followed by Q
-        /*nbytes_rx = m_plutoBox->rxBufferRefill();
-
-        if (nbytes_rx != m_blockSizeSamples*2)
-        {
-            qWarning("PlutoSDRInputThread::run: error refilling buf (2) %d / %d",(int) nbytes_rx, (int)  m_blockSizeSamples*2);
-            usleep(200000);
-            continue;
-        }
-
-        // READ: Get pointers to RX buf and read IQ from RX buf port 0
-        p_end = m_plutoBox->rxBufferEnd();
-
-        // p_inc is 2 on a char* buffer therefore each iteration processes only the I or Q sample
-        // I and Q samples are processed one after the other
-        // conversion is not needed as samples are little endian
-
-        for (p_dat = m_plutoBox->rxBufferFirst(); p_dat < p_end; p_dat += p_inc)
-        {
-            m_buf[ihs] = *((int16_t *) p_dat);
-//            iio_channel_convert(m_plutoBox->getRxChannel0(), (void *) &m_bufConv[ihs], (const void *) &m_buf[ihs]);
-            ihs++;
-        }
-        */
         if (m_iqOrder) {
             convertIQ(m_buf, 2*m_blockSizeSamples); // size given in number of int16_t (I and Q interleaved)
         } else {


### PR DESCRIPTION
Correctly open I and Q channels for RX sampling.

See: https://github.com/f4exb/sdrangel/issues/604