### PR TITLE
Only write .sqriq header once when the first samples are written

### DIFF
--- a/sdrbase/dsp/filerecord.cpp
+++ b/sdrbase/dsp/filerecord.cpp
@@ -117,7 +117,6 @@ void FileRecord::startRecording()
         m_recordOn = true;
         m_recordStart = true;
         m_byteCount = 0;
-        writeHeader();
     }
 }
 


### PR DESCRIPTION
I noticed that .sdriq files contain two headers. One is written in FileRecord::startRecording() when the file is opened and the next one in FileRecord::feed when the first samples are written.

![image](https://user-images.githubusercontent.com/30509320/90982273-690b6200-e566-11ea-80d1-ad574109af07.png)


From the documentation of the plugin, I assume that there should be only one header.