### PR TITLE
Increase supported sample rate in fileoutput and testsink by 10x

### DIFF
--- a/plugins/samplesink/fileoutput/fileoutputgui.cpp
+++ b/plugins/samplesink/fileoutput/fileoutputgui.cpp
@@ -58,7 +58,7 @@ FileOutputGui::FileOutputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 	ui->centerFrequency->setValueRange(7, 0, pow(10,7));
 
     ui->sampleRate->setColorMapper(ColorMapper(ColorMapper::GrayGreenYellow));
-    ui->sampleRate->setValueRange(7, 32000U, 9000000U);
+    ui->sampleRate->setValueRange(8, 32000U, 90000000U);
 
 	ui->fileNameText->setText(m_fileName);
 

--- a/plugins/samplesink/testsink/testsinkgui.cpp
+++ b/plugins/samplesink/testsink/testsinkgui.cpp
@@ -55,7 +55,7 @@ TestSinkGui::TestSinkGui(DeviceUISet *deviceUISet, QWidget* parent) :
 	ui->centerFrequency->setValueRange(7, 0, pow(10,7));
 
     ui->sampleRate->setColorMapper(ColorMapper(ColorMapper::GrayGreenYellow));
-    ui->sampleRate->setValueRange(7, 32000U, 9000000U);
+    ui->sampleRate->setValueRange(8, 32000U, 90000000U);
 
     m_spectrumVis = m_sampleSink->getSpectrumVis();
     m_spectrumVis->setGLSpectrum(ui->glSpectrum);


### PR DESCRIPTION
This PR increases the supported sample rates in the file output and test sink plugins by 10x from 9MSa/s to 90MSa/s. This is needed because I'm testing a modulator plugin that requires a sample rate greater than 9MSa/s.