### PR TITLE
FCDPro+ not visible

### DIFF
--- a/plugins/samplesource/fcdproplus/fcdproplusplugin.cpp
+++ b/plugins/samplesource/fcdproplus/fcdproplusplugin.cpp
@@ -71,7 +71,7 @@ void FCDProPlusPlugin::enumOriginDevices(QStringList& listedHwIds, OriginDevices
 
         originDevices.append(OriginDevice(
             displayableName,
-            fcd_traits<Pro>::hardwareID,
+            fcd_traits<ProPlus>::hardwareID,
             serialNumber,
             i,
             1, // nb Rx


### PR DESCRIPTION
Although the plugin is loaded and the device attached, fcdpro+ is not shown up in the list of available samplin devices.
This patch makes the fcdpro+ device visible.