### PR TITLE
Remove SDRGUI_API to allow linking on Windows

### DIFF
--- a/sdrsrv/feature/featureset.h
+++ b/sdrsrv/feature/featureset.h
@@ -28,7 +28,7 @@ class Feature;
 class FeatureSetPreset;
 class WebAPIAdapterInterface;
 
-class SDRGUI_API FeatureSet
+class FeatureSet
 {
 public:
     FeatureSet(int tabIndex);

--- a/sdrsrv/feature/featureset.h
+++ b/sdrsrv/feature/featureset.h
@@ -21,8 +21,6 @@
 #include <QString>
 #include <QList>
 
-#include "export.h"
-
 class PluginAPI;
 class Feature;
 class FeatureSetPreset;


### PR DESCRIPTION
The current head fails to link on Windows for me, with:

webapiadaptersrv.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) public: int __cdecl FeatureSet:
:getNumberOfFeatures(void)const " (__imp_?getNumberOfFeatures@FeatureSet@@QEBAHXZ) 

Removing SDRGUI_API from the class declaration fixes it.

(I'm not sure why your automated Windows build doesn't have the same problem too?)
