### PR TITLE
Usrp improvements

### DIFF
--- a/devices/usrp/deviceusrp.cpp
+++ b/devices/usrp/deviceusrp.cpp
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <cmath>
 #include <regex>
+#include <thread>
 
 #include <uhd/types/device_addr.hpp>
 

--- a/devices/usrp/deviceusrp.cpp
+++ b/devices/usrp/deviceusrp.cpp
@@ -69,3 +69,31 @@ void DeviceUSRP::enumOriginDevices(const QString& hardwareId, PluginInterface::O
         qDebug() << "DeviceUSRP::enumOriginDevices: exception: " << e.what();
     }
 }
+
+void DeviceUSRP::waitForLock(uhd::usrp::multi_usrp::sptr usrp, const QString& clockSource, int channel)
+{
+    int tries;
+    const int maxTries = 100;
+
+    // Wait for Ref lock
+    std::vector<std::string> sensor_names;
+    sensor_names = usrp->get_tx_sensor_names(channel);
+    if (clockSource == "external")
+    {
+        if (std::find(sensor_names.begin(), sensor_names.end(), "ref_locked") != sensor_names.end())
+        {
+            for (tries = 0; !usrp->get_mboard_sensor("ref_locked", 0).to_bool() && (tries < maxTries); tries++)
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            if (tries == maxTries)
+                qCritical("USRPInput::acquireChannel: Failed to lock ref");
+        }
+    }
+    // Wait for LO lock
+    if (std::find(sensor_names.begin(), sensor_names.end(), "lo_locked") != sensor_names.end())
+    {
+        for (tries = 0; !usrp->get_tx_sensor("lo_locked", channel).to_bool() && (tries < maxTries); tries++)
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        if (tries == maxTries)
+            qCritical("USRPInput::acquireChannel: Failed to lock LO");
+    }
+}

--- a/devices/usrp/deviceusrp.cpp
+++ b/devices/usrp/deviceusrp.cpp
@@ -52,7 +52,7 @@ void DeviceUSRP::enumOriginDevices(const QString& hardwareId, PluginInterface::O
             qDebug() << "DeviceUSRP::enumOriginDevices: found USRP device " << displayedName;
 
             DeviceUSRPParams usrpParams;
-            usrpParams.open(id.toStdString().c_str());
+            usrpParams.open(id.toStdString().c_str(), true);
             usrpParams.close();
 
             originDevices.append(PluginInterface::OriginDevice(

--- a/devices/usrp/deviceusrp.h
+++ b/devices/usrp/deviceusrp.h
@@ -33,8 +33,6 @@ public:
     /** Enumeration of USRP hardware devices */
     static void enumOriginDevices(const QString& hardwareId, PluginInterface::OriginDevices& originDevices);
 
-    /** Block size used for transferring IQ samples to and from the device. This perhaps needs tuning. */
-    static const unsigned int blockSize = (1<<15);
 };
 
 #endif /* DEVICES_USRP_DEVICEUSRP_H_ */

--- a/devices/usrp/deviceusrp.h
+++ b/devices/usrp/deviceusrp.h
@@ -33,6 +33,8 @@ public:
     /** Enumeration of USRP hardware devices */
     static void enumOriginDevices(const QString& hardwareId, PluginInterface::OriginDevices& originDevices);
 
+    /** Wait for ref clock and LO to lock */
+    static void waitForLock(uhd::usrp::multi_usrp::sptr usrp, const QString& clockSource, int channel);
 };
 
 #endif /* DEVICES_USRP_DEVICEUSRP_H_ */

--- a/devices/usrp/deviceusrpparam.cpp
+++ b/devices/usrp/deviceusrpparam.cpp
@@ -67,7 +67,7 @@ bool DeviceUSRPParams::open(const char *deviceStr, bool channelNumOnly)
             m_srRangeTx = uhd::meta_range_t(std::min(txLow.start(), txHigh.start()), std::max(txLow.stop(), txHigh.stop()));
 
             // Need to restore automatic clock rate
-            uhd::property_tree::sptr properties = m_dev->get_tree();
+            uhd::property_tree::sptr properties = m_dev->get_device()->get_tree();
             if (properties->exists("/mboards/0/auto_tick_rate"))
             {
                 properties->access<bool>("/mboards/0/auto_tick_rate").set(true);

--- a/devices/usrp/deviceusrpparam.cpp
+++ b/devices/usrp/deviceusrpparam.cpp
@@ -19,7 +19,7 @@
 #include <QDebug>
 #include "deviceusrpparam.h"
 
-bool DeviceUSRPParams::open(const char *deviceStr)
+bool DeviceUSRPParams::open(const char *deviceStr, bool channelNumOnly)
 {
     qDebug("DeviceUSRPParams::open: %s", (const char *) deviceStr);
 
@@ -32,37 +32,71 @@ bool DeviceUSRPParams::open(const char *deviceStr)
     m_nbRxChannels = m_dev->get_rx_num_channels();
     m_nbTxChannels = m_dev->get_tx_num_channels();
 
-    m_lpfRangeRx = m_dev->get_rx_bandwidth_range();
-    m_lpfRangeTx = m_dev->get_tx_bandwidth_range();
+    // Speed up program initialisation, by not getting all properties
+    // If we could find out number of channles without ::make ing the device
+    // that would be even better
+    if (!channelNumOnly)
+    {
+        m_lpfRangeRx = m_dev->get_rx_bandwidth_range();
+        m_lpfRangeTx = m_dev->get_tx_bandwidth_range();
 
-    m_loRangeRx = m_dev->get_fe_rx_freq_range();
-    m_loRangeTx = m_dev->get_fe_tx_freq_range();
+        m_loRangeRx = m_dev->get_fe_rx_freq_range();
+        m_loRangeTx = m_dev->get_fe_tx_freq_range();
 
-    m_srRangeRx = m_dev->get_rx_rates();
-    m_srRangeTx = m_dev->get_tx_rates();
+        // For some devices (B210), rx/tx_rates vary with master_clock_rate
+        // Note master_clock_rate is rate between FPGA and RFIC
+        // tx/rx_rate is rate between PC and FPGA
+        uhd::meta_range_t clockRange = m_dev->get_master_clock_rate_range();
+        if (clockRange.start() == clockRange.stop())
+        {
+            m_srRangeRx = m_dev->get_rx_rates();
+            m_srRangeTx = m_dev->get_tx_rates();
+        }
+        else
+        {
+            // Find max and min sample rate, for max and min master clock rates
+            m_dev->set_master_clock_rate(clockRange.start());
+            uhd::meta_range_t rxLow = m_dev->get_rx_rates();
+            uhd::meta_range_t txLow = m_dev->get_tx_rates();
 
-    m_gainRangeRx = m_dev->get_rx_gain_range();
-    m_gainRangeTx = m_dev->get_tx_gain_range();
+            m_dev->set_master_clock_rate(clockRange.stop());
+            uhd::meta_range_t rxHigh = m_dev->get_rx_rates();
+            uhd::meta_range_t txHigh = m_dev->get_tx_rates();
 
-    std::vector<std::string> txAntennas = m_dev->get_tx_antennas();
-    m_txAntennas.reserve(txAntennas.size());
-    for(size_t i = 0, l = txAntennas.size(); i < l; ++i)
-        m_txAntennas << QString::fromStdString(txAntennas[i]);
+            m_srRangeRx = uhd::meta_range_t(std::min(rxLow.start(), rxHigh.start()), std::max(rxLow.stop(), rxHigh.stop()));
+            m_srRangeTx = uhd::meta_range_t(std::min(txLow.start(), txHigh.start()), std::max(txLow.stop(), txHigh.stop()));
 
-    std::vector<std::string> rxAntennas = m_dev->get_rx_antennas();
-    m_rxAntennas.reserve(rxAntennas.size());
-    for(size_t i = 0, l = rxAntennas.size(); i < l; ++i)
-        m_rxAntennas << QString::fromStdString(rxAntennas[i]);
+            // Need to restore automatic clock rate
+            uhd::property_tree::sptr properties = m_dev->get_tree();
+            if (properties->exists("/mboards/0/auto_tick_rate"))
+            {
+                properties->access<bool>("/mboards/0/auto_tick_rate").set(true);
+            }
+        }
 
-    std::vector<std::string> rxGainNames = m_dev->get_rx_gain_names();
-    m_rxGainNames.reserve(rxGainNames.size());
-    for(size_t i = 0, l = rxGainNames.size(); i < l; ++i)
-        m_rxGainNames << QString::fromStdString(rxGainNames[i]);
+        m_gainRangeRx = m_dev->get_rx_gain_range();
+        m_gainRangeTx = m_dev->get_tx_gain_range();
 
-    std::vector<std::string> clockSources = m_dev->get_clock_sources(0);
-    m_clockSources.reserve(clockSources.size());
-    for(size_t i = 0, l = clockSources.size(); i < l; ++i)
-        m_clockSources << QString::fromStdString(clockSources[i]);
+        std::vector<std::string> txAntennas = m_dev->get_tx_antennas();
+        m_txAntennas.reserve(txAntennas.size());
+        for(size_t i = 0, l = txAntennas.size(); i < l; ++i)
+            m_txAntennas << QString::fromStdString(txAntennas[i]);
+
+        std::vector<std::string> rxAntennas = m_dev->get_rx_antennas();
+        m_rxAntennas.reserve(rxAntennas.size());
+        for(size_t i = 0, l = rxAntennas.size(); i < l; ++i)
+            m_rxAntennas << QString::fromStdString(rxAntennas[i]);
+
+        std::vector<std::string> rxGainNames = m_dev->get_rx_gain_names();
+        m_rxGainNames.reserve(rxGainNames.size());
+        for(size_t i = 0, l = rxGainNames.size(); i < l; ++i)
+            m_rxGainNames << QString::fromStdString(rxGainNames[i]);
+
+        std::vector<std::string> clockSources = m_dev->get_clock_sources(0);
+        m_clockSources.reserve(clockSources.size());
+        for(size_t i = 0, l = clockSources.size(); i < l; ++i)
+            m_clockSources << QString::fromStdString(clockSources[i]);
+    }
 
     return true;
 }

--- a/devices/usrp/deviceusrpparam.h
+++ b/devices/usrp/deviceusrpparam.h
@@ -47,11 +47,6 @@ struct DEVICES_API DeviceUSRPParams
     uhd::meta_range_t m_srRangeTx;              //!< Sample rate range
     uhd::gain_range_t m_gainRangeRx;            //!< Gain range for Rx
     uhd::gain_range_t m_gainRangeTx;            //!< Gain range for Tx
-    float        m_sampleRate;                  //!< Sample rate between host and device
-    int          m_log2OvSRRx;                  //!< log2 of Rx oversampling (0..5)
-    int          m_log2OvSRTx;                  //!< log2 of Tx oversampling (0..5)
-    float        m_rxFrequency;                 //!< Rx frequency
-    float        m_txFrequency;                 //!< Tx frequency
     QStringList  m_txAntennas;                  //!< List of Tx antenna names
     QStringList  m_rxAntennas;                  //!< List of Rx antenna names
     QStringList  m_rxGainNames;                 //!< List of Rx gain stages - Currently this seems limited to "PGA"
@@ -61,11 +56,6 @@ struct DEVICES_API DeviceUSRPParams
         m_dev(),
         m_nbRxChannels(0),
         m_nbTxChannels(0),
-        m_sampleRate(1e6),
-        m_log2OvSRRx(0),
-        m_log2OvSRTx(0),
-        m_rxFrequency(1e6),
-        m_txFrequency(1e6),
         m_lpfRangeRx(),
         m_lpfRangeTx(),
         m_loRangeRx(),
@@ -84,7 +74,7 @@ struct DEVICES_API DeviceUSRPParams
     /**
      * Opens and initialize the device and obtain information (# channels, ranges, ...)
      */
-    bool open(const char *deviceStr);
+    bool open(const char *deviceStr, bool channelNumOnly);
     void close();
     uhd::usrp::multi_usrp::sptr getDevice() { return m_dev; }
 

--- a/devices/usrp/deviceusrpshared.h
+++ b/devices/usrp/deviceusrpshared.h
@@ -37,18 +37,21 @@ public:
         int      getDevSampleRate() const { return m_devSampleRate; }
         uint64_t getCenterFrequency() const { return m_centerFrequency; }
         int      getLOOffset() const { return m_loOffset; }
+        int      getMasterClockRate() const { return m_masterClockRate; }
         bool getRxElseTx() const { return m_rxElseTx; }
 
         static MsgReportBuddyChange* create(
                 int devSampleRate,
                 uint64_t centerFrequency,
                 int loOffset,
+                int masterClockRate,
                 bool rxElseTx)
         {
             return new MsgReportBuddyChange(
                     devSampleRate,
                     centerFrequency,
                     loOffset,
+                    masterClockRate,
                     rxElseTx);
         }
 
@@ -56,17 +59,20 @@ public:
         int      m_devSampleRate;       //!< device/host sample rate
         uint64_t m_centerFrequency;     //!< Center frequency
         int      m_loOffset;            //!< LO offset
+        int      m_masterClockRate;     //!< FPGA/RFIC sample rate
         bool     m_rxElseTx;            //!< tells which side initiated the message
 
         MsgReportBuddyChange(
                 int devSampleRate,
                 uint64_t centerFrequency,
                 int loOffset,
+                int masterClockRate,
                 bool rxElseTx) :
             Message(),
             m_devSampleRate(devSampleRate),
             m_centerFrequency(centerFrequency),
             m_loOffset(loOffset),
+            m_masterClockRate(masterClockRate),
             m_rxElseTx(rxElseTx)
         { }
     };

--- a/devices/usrp/deviceusrpshared.h
+++ b/devices/usrp/deviceusrpshared.h
@@ -36,31 +36,37 @@ public:
     public:
         int      getDevSampleRate() const { return m_devSampleRate; }
         uint64_t getCenterFrequency() const { return m_centerFrequency; }
+        int      getLOOffset() const { return m_loOffset; }
         bool getRxElseTx() const { return m_rxElseTx; }
 
         static MsgReportBuddyChange* create(
                 int devSampleRate,
                 uint64_t centerFrequency,
+                int loOffset,
                 bool rxElseTx)
         {
             return new MsgReportBuddyChange(
                     devSampleRate,
                     centerFrequency,
+                    loOffset,
                     rxElseTx);
         }
 
     private:
         int      m_devSampleRate;       //!< device/host sample rate
         uint64_t m_centerFrequency;     //!< Center frequency
+        int      m_loOffset;            //!< LO offset
         bool     m_rxElseTx;            //!< tells which side initiated the message
 
         MsgReportBuddyChange(
                 int devSampleRate,
                 uint64_t centerFrequency,
+                int loOffset,
                 bool rxElseTx) :
             Message(),
             m_devSampleRate(devSampleRate),
             m_centerFrequency(centerFrequency),
+            m_loOffset(loOffset),
             m_rxElseTx(rxElseTx)
         { }
     };

--- a/plugins/samplesink/usrpoutput/readme.md
+++ b/plugins/samplesink/usrpoutput/readme.md
@@ -105,6 +105,10 @@ Use this slider to adjust the global gain of the Tx chain. The allowable values 
 
 This is the Tx hardware filter bandwidth in kHz in the AD936x device for the given channel. Use the wheels to adjust the value. Pressing shift simultaneously moves digit by 5 and pressing control moves it by 2.
 
+<h3>Tx LO offset</h3>
+
+This adjusts the Tx local oscillator (LO) frequency from the centre frequency by the given amount in kHz, and the NCOs are used to digitally shift the signal to the set centre frequency. This can be used to push the Tx LO leakage (which for the AD396x is -50dBc) out of band. The shift should be less than half of the sample rate.
+
 <h3>12: Stream status indicator</h3>
 
 This label turns green when data has been transmitted to the device.

--- a/plugins/samplesink/usrpoutput/usrpoutput.cpp
+++ b/plugins/samplesink/usrpoutput/usrpoutput.cpp
@@ -951,6 +951,9 @@ void USRPOutput::webapiUpdateDeviceSettings(
     if (deviceSettingsKeys.contains("devSampleRate")) {
         settings.m_devSampleRate = response.getUsrpOutputSettings()->getDevSampleRate();
     }
+    if (deviceSettingsKeys.contains("loOffset")) {
+        settings.m_loOffset = response.getUsrpOutputSettings()->getLoOffset();
+    }
     if (deviceSettingsKeys.contains("clockSource")) {
         settings.m_clockSource = *response.getUsrpOutputSettings()->getClockSource();
     }
@@ -998,6 +1001,7 @@ void USRPOutput::webapiFormatDeviceSettings(SWGSDRangel::SWGDeviceSettings& resp
     response.getUsrpOutputSettings()->setAntennaPath(new QString(settings.m_antennaPath));
     response.getUsrpOutputSettings()->setCenterFrequency(settings.m_centerFrequency);
     response.getUsrpOutputSettings()->setDevSampleRate(settings.m_devSampleRate);
+    response.getUsrpOutputSettings()->setLoOffset(settings.m_loOffset);
     response.getUsrpOutputSettings()->setClockSource(new QString(settings.m_clockSource));
     response.getUsrpOutputSettings()->setGain(settings.m_gain);
     response.getUsrpOutputSettings()->setLog2SoftInterp(settings.m_log2SoftInterp);
@@ -1082,6 +1086,9 @@ void USRPOutput::webapiReverseSendSettings(QList<QString>& deviceSettingsKeys, c
     }
     if (deviceSettingsKeys.contains("devSampleRate") || force) {
         swgUsrpOutputSettings->setDevSampleRate(settings.m_devSampleRate);
+    }
+    if (deviceSettingsKeys.contains("loOffset") || force) {
+        swgUsrpOutputSettings->setLoOffset(settings.m_loOffset);
     }
     if (deviceSettingsKeys.contains("clockSource") || force) {
         swgUsrpOutputSettings->setClockSource(new QString(settings.m_clockSource));

--- a/plugins/samplesink/usrpoutput/usrpoutput.h
+++ b/plugins/samplesink/usrpoutput/usrpoutput.h
@@ -238,7 +238,7 @@ private:
     void resumeRxBuddies();
     void suspendTxBuddies();
     void resumeTxBuddies();
-    bool applySettings(const USRPOutputSettings& settings, bool force = false);
+    bool applySettings(const USRPOutputSettings& settings, bool preGetStream, bool force = false);
     void webapiFormatDeviceReport(SWGSDRangel::SWGDeviceReport& response);
     void webapiReverseSendSettings(QList<QString>& deviceSettingsKeys, const USRPOutputSettings& settings, bool force);
     void webapiReverseSendStartStop(bool start);

--- a/plugins/samplesink/usrpoutput/usrpoutput.h
+++ b/plugins/samplesink/usrpoutput/usrpoutput.h
@@ -226,6 +226,7 @@ private:
     DeviceUSRPShared m_deviceShared;
     bool m_channelAcquired;
     uhd::tx_streamer::sptr m_streamId;
+    size_t m_bufSamples;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;
 

--- a/plugins/samplesink/usrpoutput/usrpoutputgui.cpp
+++ b/plugins/samplesink/usrpoutput/usrpoutputgui.cpp
@@ -180,9 +180,10 @@ bool USRPOutputGUI::handleMessage(const Message& message)
     else if (DeviceUSRPShared::MsgReportBuddyChange::match(message))
     {
         DeviceUSRPShared::MsgReportBuddyChange& report = (DeviceUSRPShared::MsgReportBuddyChange&) message;
-        m_settings.m_devSampleRate = report.getDevSampleRate();
+        m_settings.m_masterClockRate = report.getMasterClockRate();
 
         if (!report.getRxElseTx()) {
+            m_settings.m_devSampleRate   = report.getDevSampleRate();
             m_settings.m_centerFrequency = report.getCenterFrequency();
             m_settings.m_loOffset        = report.getLOOffset();
         }
@@ -291,11 +292,19 @@ void USRPOutputGUI::updateSampleRateAndFrequency()
 void USRPOutputGUI::updateSampleRate()
 {
     uint32_t sr = m_settings.m_devSampleRate;
+    int cr = m_settings.m_masterClockRate;
 
     if (sr < 100000000) {
         ui->sampleRateLabel->setText(tr("%1k").arg(QString::number(sr / 1000.0f, 'g', 5)));
     } else {
         ui->sampleRateLabel->setText(tr("%1M").arg(QString::number(sr / 1000000.0f, 'g', 5)));
+    }
+    if (cr < 0) {
+       ui->masterClockRateLabel->setText("-");
+    } else if (cr < 100000000) {
+        ui->masterClockRateLabel->setText(tr("%1k").arg(QString::number(cr / 1000.0f, 'g', 5)));
+    } else {
+        ui->masterClockRateLabel->setText(tr("%1M").arg(QString::number(cr / 1000000.0f, 'g', 5)));
     }
     // LO offset shouldn't be greater than half the sample rate
     ui->loOffset->setValueRange(false, 5, -(int32_t)sr/2/1000, (int32_t)sr/2/1000);

--- a/plugins/samplesink/usrpoutput/usrpoutputgui.cpp
+++ b/plugins/samplesink/usrpoutput/usrpoutputgui.cpp
@@ -57,6 +57,9 @@ USRPOutputGUI::USRPOutputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
     ui->sampleRate->setColorMapper(ColorMapper(ColorMapper::GrayGreenYellow));
     ui->sampleRate->setValueRange(8, (uint32_t) minF, (uint32_t) maxF);
 
+    ui->loOffset->setColorMapper(ColorMapper(ColorMapper::GrayYellow));
+    ui->loOffset->setValueRange(false, 5, (int32_t)-maxF/2/1000, (int32_t)maxF/2/1000); // LO offset shouldn't be greater than half the sample rate
+
     m_usrpOutput->getLPRange(minF, maxF);
     ui->lpf->setColorMapper(ColorMapper(ColorMapper::GrayYellow));
     ui->lpf->setValueRange(5, (minF/1000)+1, maxF/1000);
@@ -181,6 +184,7 @@ bool USRPOutputGUI::handleMessage(const Message& message)
 
         if (!report.getRxElseTx()) {
             m_settings.m_centerFrequency = report.getCenterFrequency();
+            m_settings.m_loOffset        = report.getLOOffset();
         }
 
         blockApplySettings(true);
@@ -293,6 +297,8 @@ void USRPOutputGUI::updateSampleRate()
     } else {
         ui->sampleRateLabel->setText(tr("%1M").arg(QString::number(sr / 1000000.0f, 'g', 5)));
     }
+    // LO offset shouldn't be greater than half the sample rate
+    ui->loOffset->setValueRange(false, 5, -(int32_t)sr/2/1000, (int32_t)sr/2/1000);
 }
 
 void USRPOutputGUI::displaySampleRate()
@@ -343,6 +349,7 @@ void USRPOutputGUI::displaySettings()
     updateSampleRate();
 
     ui->lpf->setValue(m_settings.m_lpfBW / 1000);
+    ui->loOffset->setValue(m_settings.m_loOffset / 1000);
 
     ui->gain->setValue(m_settings.m_gain);
     ui->gainText->setText(tr("%1dB").arg(m_settings.m_gain));
@@ -494,6 +501,12 @@ void USRPOutputGUI::on_swInterp_currentIndexChanged(int index)
 void USRPOutputGUI::on_lpf_changed(quint64 value)
 {
     m_settings.m_lpfBW = value * 1000;
+    sendSettings();
+}
+
+void USRPOutputGUI::on_loOffset_changed(qint64 value)
+{
+    m_settings.m_loOffset = value * 1000;
     sendSettings();
 }
 

--- a/plugins/samplesink/usrpoutput/usrpoutputgui.h
+++ b/plugins/samplesink/usrpoutput/usrpoutputgui.h
@@ -88,6 +88,7 @@ private slots:
     void on_sampleRate_changed(quint64 value);
     void on_swInterp_currentIndexChanged(int index);
     void on_lpf_changed(quint64 value);
+    void on_loOffset_changed(qint64 value);
     void on_gain_valueChanged(int value);
     void on_antenna_currentIndexChanged(int index);
     void on_clockSource_currentIndexChanged(int index);

--- a/plugins/samplesink/usrpoutput/usrpoutputgui.ui
+++ b/plugins/samplesink/usrpoutput/usrpoutputgui.ui
@@ -563,6 +563,55 @@
       </widget>
      </item>
      <item>
+      <widget class="Line" name="line_3">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="loOffsetLabel">
+       <property name="text">
+        <string>LO</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ValueDialZ" name="loOffset" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>32</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Liberation Mono</family>
+         <pointsize>12</pointsize>
+        </font>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="toolTip">
+        <string>LO frequency offset. This should not be greater than half the sample rate.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="loOffsetUnits">
+       <property name="text">
+        <string>kHz</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -682,6 +731,12 @@
    <class>ValueDial</class>
    <extends>QWidget</extends>
    <header>gui/valuedial.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ValueDialZ</class>
+   <extends>QWidget</extends>
+   <header>gui/valuedialz.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/plugins/samplesink/usrpoutput/usrpoutputgui.ui
+++ b/plugins/samplesink/usrpoutput/usrpoutputgui.ui
@@ -76,6 +76,16 @@
        <item>
         <layout class="QHBoxLayout" name="freqLeftBotLayout">
          <item>
+          <widget class="QLabel" name="masterClockRateLabel">
+           <property name="toolTip">
+            <string>Master clock rate (sample rate between FPGA and RFIC) (k or MS/s)</string>
+           </property>
+           <property name="text">
+            <string>00000k</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QLabel" name="sampleRateLabel">
            <property name="minimumSize">
             <size>

--- a/plugins/samplesink/usrpoutput/usrpoutputgui.ui
+++ b/plugins/samplesink/usrpoutput/usrpoutputgui.ui
@@ -230,7 +230,7 @@
       <widget class="QComboBox" name="antenna">
        <property name="minimumSize">
         <size>
-         <width>60</width>
+         <width>70</width>
          <height>0</height>
         </size>
        </property>

--- a/plugins/samplesink/usrpoutput/usrpoutputsettings.cpp
+++ b/plugins/samplesink/usrpoutput/usrpoutputsettings.cpp
@@ -27,6 +27,7 @@ USRPOutputSettings::USRPOutputSettings()
 
 void USRPOutputSettings::resetToDefaults()
 {
+    m_masterClockRate = -1; // Calculated by UHD
     m_centerFrequency = 435000*1000;
     m_devSampleRate = 3000000;
     m_loOffset = 0;

--- a/plugins/samplesink/usrpoutput/usrpoutputsettings.cpp
+++ b/plugins/samplesink/usrpoutput/usrpoutputsettings.cpp
@@ -29,8 +29,9 @@ void USRPOutputSettings::resetToDefaults()
 {
     m_centerFrequency = 435000*1000;
     m_devSampleRate = 3000000;
+    m_loOffset = 0;
     m_log2SoftInterp = 0;
-    m_lpfBW = 5.5e6f;
+    m_lpfBW = 10e6f;
     m_gain = 50;
     m_antennaPath = "TX/RX";
     m_clockSource = "internal";
@@ -58,6 +59,7 @@ QByteArray USRPOutputSettings::serialize() const
     s.writeString(10, m_reverseAPIAddress);
     s.writeU32(11, m_reverseAPIPort);
     s.writeU32(12, m_reverseAPIDeviceIndex);
+    s.writeS32(13, m_loOffset);
 
     return s.final();
 }
@@ -97,6 +99,7 @@ bool USRPOutputSettings::deserialize(const QByteArray& data)
 
         d.readU32(12, &uintval, 0);
         m_reverseAPIDeviceIndex = uintval > 99 ? 99 : uintval;
+        d.readS32(13, &m_loOffset, 0);
 
         return true;
     }

--- a/plugins/samplesink/usrpoutput/usrpoutputsettings.h
+++ b/plugins/samplesink/usrpoutput/usrpoutputsettings.h
@@ -33,6 +33,7 @@ struct USRPOutputSettings
     // global settings to be saved
     uint64_t m_centerFrequency;
     int      m_devSampleRate;
+    int      m_loOffset;
     // channel settings
     uint32_t m_log2SoftInterp;
     float    m_lpfBW;        //!< Analog lowpass filter bandwidth (Hz)

--- a/plugins/samplesink/usrpoutput/usrpoutputsettings.h
+++ b/plugins/samplesink/usrpoutput/usrpoutputsettings.h
@@ -30,6 +30,7 @@
  */
 struct USRPOutputSettings
 {
+    int      m_masterClockRate;
     // global settings to be saved
     uint64_t m_centerFrequency;
     int      m_devSampleRate;

--- a/plugins/samplesink/usrpoutput/usrpoutputthread.cpp
+++ b/plugins/samplesink/usrpoutput/usrpoutputthread.cpp
@@ -109,7 +109,7 @@ void USRPOutputThread::run()
             m_packets++;
             if (samples_sent != m_bufSamples)
             {
-                qDebug("USRPOutputThread::run written %ld/%d samples", samples_sent, m_bufSamples);
+                qDebug("USRPOutputThread::run written %ld/%ld samples", samples_sent, m_bufSamples);
             }
         }
         catch (std::exception& e)

--- a/plugins/samplesink/usrpoutput/usrpoutputthread.h
+++ b/plugins/samplesink/usrpoutput/usrpoutputthread.h
@@ -37,7 +37,7 @@ class USRPOutputThread : public QThread, public DeviceUSRPShared::ThreadInterfac
     Q_OBJECT
 
 public:
-    USRPOutputThread(uhd::tx_streamer::sptr stream, SampleSourceFifo* sampleFifo, QObject* parent = 0);
+    USRPOutputThread(uhd::tx_streamer::sptr stream, size_t bufSamples, SampleSourceFifo* sampleFifo, QObject* parent = 0);
     ~USRPOutputThread();
 
     virtual void startWork();
@@ -57,7 +57,8 @@ private:
     quint32 m_droppedPackets;
 
     uhd::tx_streamer::sptr m_stream;
-    qint16 m_buf[2*DeviceUSRP::blockSize]; //must hold I+Q values of each sample hence 2xcomplex size
+    qint16 *m_buf;
+    size_t m_bufSamples;
     SampleSourceFifo* m_sampleFifo;
 
     unsigned int m_log2Interp; // soft decimation

--- a/plugins/samplesource/usrpinput/readme.md
+++ b/plugins/samplesource/usrpinput/readme.md
@@ -132,3 +132,10 @@ This label turns green when data is being received from the device.
   - **T**: turns red if stream experiences timeouts
   
 The stream warning indicators are reset when the acqusition is started.
+
+<h2>Dependendices</h2>
+
+On Ubuntu 20, the libuhd-dev package should be installed. The FPGA images then need to be downloaded with:
+
+sudo /usr/lib/uhd/utils/uhd_images_downloader.py
+

--- a/plugins/samplesource/usrpinput/readme.md
+++ b/plugins/samplesource/usrpinput/readme.md
@@ -118,6 +118,10 @@ Check this button to enable IQ imbalance correction.
 
 This is the Rx hardware IF filter bandwidth in kHz for the given channel. Use the wheels to adjust the value. Pressing shift simultaneously moves digit by 5 and pressing control moves it by 2.
 
+<h3>Rx LO offset</h3>
+
+This adjusts the Rx local oscillator (LO) frequency from the centre frequency by the given amount in kHz, and the NCOs are used to digitally shift the signal to compensate. The shift should be less than half of the sample rate.
+
 <h3>15: Stream status indicator</h3>
 
 This label turns green when data is being received from the device.

--- a/plugins/samplesource/usrpinput/usrpinput.cpp
+++ b/plugins/samplesource/usrpinput/usrpinput.cpp
@@ -1025,6 +1025,9 @@ void USRPInput::webapiUpdateDeviceSettings(
     if (deviceSettingsKeys.contains("centerFrequency")) {
         settings.m_centerFrequency = response.getUsrpInputSettings()->getCenterFrequency();
     }
+    if (deviceSettingsKeys.contains("loOffset")) {
+        settings.m_loOffset = response.getUsrpInputSettings()->getLoOffset();
+    }
     if (deviceSettingsKeys.contains("dcBlock")) {
         settings.m_dcBlock = response.getUsrpInputSettings()->getDcBlock() != 0;
     }
@@ -1075,6 +1078,7 @@ void USRPInput::webapiFormatDeviceSettings(SWGSDRangel::SWGDeviceSettings& respo
     response.getUsrpInputSettings()->setCenterFrequency(settings.m_centerFrequency);
     response.getUsrpInputSettings()->setDcBlock(settings.m_dcBlock ? 1 : 0);
     response.getUsrpInputSettings()->setDevSampleRate(settings.m_devSampleRate);
+    response.getUsrpInputSettings()->setLoOffset(settings.m_loOffset);
     response.getUsrpInputSettings()->setClockSource(new QString(settings.m_clockSource));
     response.getUsrpInputSettings()->setGain(settings.m_gain);
     response.getUsrpInputSettings()->setGainMode((int) settings.m_gainMode);
@@ -1170,6 +1174,9 @@ void USRPInput::webapiReverseSendSettings(QList<QString>& deviceSettingsKeys, co
     }
     if (deviceSettingsKeys.contains("centerFrequency") || force) {
         swgUsrpInputSettings->setCenterFrequency(settings.m_centerFrequency);
+    }
+    if (deviceSettingsKeys.contains("loOffset") || force) {
+        swgUsrpInputSettings->setLoOffset(settings.m_loOffset);
     }
     if (deviceSettingsKeys.contains("dcBlock") || force) {
         swgUsrpInputSettings->setDcBlock(settings.m_dcBlock ? 1 : 0);

--- a/plugins/samplesource/usrpinput/usrpinput.h
+++ b/plugins/samplesource/usrpinput/usrpinput.h
@@ -227,6 +227,7 @@ private:
     DeviceUSRPShared m_deviceShared;
     bool m_channelAcquired;
     uhd::rx_streamer::sptr m_streamId;
+    size_t m_bufSamples;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;
 

--- a/plugins/samplesource/usrpinput/usrpinput.h
+++ b/plugins/samplesource/usrpinput/usrpinput.h
@@ -239,7 +239,7 @@ private:
     void resumeRxBuddies();
     void suspendTxBuddies();
     void resumeTxBuddies();
-    bool applySettings(const USRPInputSettings& settings, bool force = false);
+    bool applySettings(const USRPInputSettings& settings, bool preGetStream, bool force = false);
     void webapiFormatDeviceReport(SWGSDRangel::SWGDeviceReport& response);
     void webapiReverseSendSettings(QList<QString>& deviceSettingsKeys, const USRPInputSettings& settings, bool force);
     void webapiReverseSendStartStop(bool start);

--- a/plugins/samplesource/usrpinput/usrpinputgui.cpp
+++ b/plugins/samplesource/usrpinput/usrpinputgui.cpp
@@ -163,9 +163,10 @@ bool USRPInputGUI::handleMessage(const Message& message)
     else if (DeviceUSRPShared::MsgReportBuddyChange::match(message))
     {
         DeviceUSRPShared::MsgReportBuddyChange& report = (DeviceUSRPShared::MsgReportBuddyChange&) message;
-        m_settings.m_devSampleRate = report.getDevSampleRate();
+        m_settings.m_masterClockRate = report.getMasterClockRate();
 
         if (report.getRxElseTx()) {
+            m_settings.m_devSampleRate   = report.getDevSampleRate();
             m_settings.m_centerFrequency = report.getCenterFrequency();
             m_settings.m_loOffset        = report.getLOOffset();
         }
@@ -287,11 +288,19 @@ void USRPInputGUI::handleInputMessages()
 void USRPInputGUI::updateSampleRate()
 {
     uint32_t sr = m_settings.m_devSampleRate;
+    int cr = m_settings.m_masterClockRate;
 
     if (sr < 100000000) {
         ui->sampleRateLabel->setText(tr("%1k").arg(QString::number(sr / 1000.0f, 'g', 5)));
     } else {
         ui->sampleRateLabel->setText(tr("%1M").arg(QString::number(sr / 1000000.0f, 'g', 5)));
+    }
+    if (cr < 0) {
+       ui->masterClockRateLabel->setText("-");
+    } else if (cr < 100000000) {
+        ui->masterClockRateLabel->setText(tr("%1k").arg(QString::number(cr / 1000.0f, 'g', 5)));
+    } else {
+        ui->masterClockRateLabel->setText(tr("%1M").arg(QString::number(cr / 1000000.0f, 'g', 5)));
     }
     // LO offset shouldn't be greater than half the sample rate
     ui->loOffset->setValueRange(false, 5, -(int32_t)sr/2/1000, (int32_t)sr/2/1000);

--- a/plugins/samplesource/usrpinput/usrpinputgui.cpp
+++ b/plugins/samplesource/usrpinput/usrpinputgui.cpp
@@ -61,6 +61,9 @@ USRPInputGUI::USRPInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
     ui->sampleRate->setColorMapper(ColorMapper(ColorMapper::GrayGreenYellow));
     ui->sampleRate->setValueRange(8, (uint32_t) minF, (uint32_t) maxF);
 
+    ui->loOffset->setColorMapper(ColorMapper(ColorMapper::GrayYellow));
+    ui->loOffset->setValueRange(false, 5, (int32_t)-maxF/2/1000, (int32_t)maxF/2/1000); // LO offset shouldn't be greater than half the sample rate
+
     m_usrpInput->getLPRange(minF, maxF);
     ui->lpf->setColorMapper(ColorMapper(ColorMapper::GrayYellow));
     ui->lpf->setValueRange(5, (minF/1000)+1, maxF/1000);
@@ -164,6 +167,7 @@ bool USRPInputGUI::handleMessage(const Message& message)
 
         if (report.getRxElseTx()) {
             m_settings.m_centerFrequency = report.getCenterFrequency();
+            m_settings.m_loOffset        = report.getLOOffset();
         }
 
         blockApplySettings(true);
@@ -174,7 +178,7 @@ bool USRPInputGUI::handleMessage(const Message& message)
     }
     else if (DeviceUSRPShared::MsgReportClockSourceChange::match(message))
     {
-qDebug("USRPInputGUI::handleMessage MsgReportClockSourceChange");
+        qDebug("USRPInputGUI::handleMessage MsgReportClockSourceChange");
         DeviceUSRPShared::MsgReportClockSourceChange& report = (DeviceUSRPShared::MsgReportClockSourceChange&) message;
         m_settings.m_clockSource = report.getClockSource();
 
@@ -289,6 +293,8 @@ void USRPInputGUI::updateSampleRate()
     } else {
         ui->sampleRateLabel->setText(tr("%1M").arg(QString::number(sr / 1000000.0f, 'g', 5)));
     }
+    // LO offset shouldn't be greater than half the sample rate
+    ui->loOffset->setValueRange(false, 5, -(int32_t)sr/2/1000, (int32_t)sr/2/1000);
 }
 
 void USRPInputGUI::updateSampleRateAndFrequency()
@@ -350,6 +356,7 @@ void USRPInputGUI::displaySettings()
     updateSampleRate();
 
     ui->lpf->setValue(m_settings.m_lpfBW / 1000);
+    ui->loOffset->setValue(m_settings.m_loOffset / 1000);
 
     ui->gain->setValue(m_settings.m_gain);
     ui->gainText->setText(tr("%1").arg(m_settings.m_gain));
@@ -524,6 +531,12 @@ void USRPInputGUI::on_swDecim_currentIndexChanged(int index)
 void USRPInputGUI::on_lpf_changed(quint64 value)
 {
     m_settings.m_lpfBW = value * 1000;
+    sendSettings();
+}
+
+void USRPInputGUI::on_loOffset_changed(qint64 value)
+{
+    m_settings.m_loOffset = value * 1000;
     sendSettings();
 }
 

--- a/plugins/samplesource/usrpinput/usrpinputgui.h
+++ b/plugins/samplesource/usrpinput/usrpinputgui.h
@@ -89,6 +89,7 @@ private slots:
     void on_sampleRate_changed(quint64 value);
     void on_swDecim_currentIndexChanged(int index);
     void on_lpf_changed(quint64 value);
+    void on_loOffset_changed(qint64 value);
     void on_gainMode_currentIndexChanged(int index);
     void on_gain_valueChanged(int value);
     void on_antenna_currentIndexChanged(int index);

--- a/plugins/samplesource/usrpinput/usrpinputgui.ui
+++ b/plugins/samplesource/usrpinput/usrpinputgui.ui
@@ -627,6 +627,57 @@
       </widget>
      </item>
      <item>
+      <widget class="Line" name="line_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="loOffsetLabel">
+       <property name="text">
+        <string>LO</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ValueDialZ" name="loOffset" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>32</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Liberation Mono</family>
+         <pointsize>12</pointsize>
+         <weight>50</weight>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="toolTip">
+        <string>LO offset (kHz)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="loOffsetUnits">
+       <property name="text">
+        <string>kHz</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -752,6 +803,12 @@
    <class>TransverterButton</class>
    <extends>QPushButton</extends>
    <header>gui/transverterbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ValueDialZ</class>
+   <extends>QWidget</extends>
+   <header>gui/valuedialz.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/plugins/samplesource/usrpinput/usrpinputgui.ui
+++ b/plugins/samplesource/usrpinput/usrpinputgui.ui
@@ -76,6 +76,16 @@
        <item>
         <layout class="QHBoxLayout" name="freqLeftBotLayout">
          <item>
+          <widget class="QLabel" name="masterClockRateLabel">
+           <property name="toolTip">
+            <string>Master clock rate (sample rate between FPGA and RFIC) (k or MS/s)</string>
+           </property>
+           <property name="text">
+            <string>00000k</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QLabel" name="sampleRateLabel">
            <property name="minimumSize">
             <size>
@@ -800,15 +810,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>TransverterButton</class>
-   <extends>QPushButton</extends>
-   <header>gui/transverterbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>ValueDialZ</class>
    <extends>QWidget</extends>
    <header>gui/valuedialz.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>TransverterButton</class>
+   <extends>QPushButton</extends>
+   <header>gui/transverterbutton.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/plugins/samplesource/usrpinput/usrpinputsettings.cpp
+++ b/plugins/samplesource/usrpinput/usrpinputsettings.cpp
@@ -26,6 +26,7 @@ USRPInputSettings::USRPInputSettings()
 
 void USRPInputSettings::resetToDefaults()
 {
+    m_masterClockRate = -1; // Calculated by UHD
     m_centerFrequency = 435000*1000;
     m_devSampleRate = 3000000;
     m_loOffset = 0;

--- a/plugins/samplesource/usrpinput/usrpinputsettings.cpp
+++ b/plugins/samplesource/usrpinput/usrpinputsettings.cpp
@@ -28,10 +28,11 @@ void USRPInputSettings::resetToDefaults()
 {
     m_centerFrequency = 435000*1000;
     m_devSampleRate = 3000000;
+    m_loOffset = 0;
     m_dcBlock = false;
     m_iqCorrection = false;
     m_log2SoftDecim = 0;
-    m_lpfBW = 5.5e6f;
+    m_lpfBW = 10e6f;
     m_gain = 50;
     m_antennaPath = "TX/RX";
     m_gainMode = GAIN_AUTO;
@@ -63,6 +64,7 @@ QByteArray USRPInputSettings::serialize() const
     s.writeString(13, m_reverseAPIAddress);
     s.writeU32(14, m_reverseAPIPort);
     s.writeU32(15, m_reverseAPIDeviceIndex);
+    s.writeS32(16, m_loOffset);
     return s.final();
 }
 
@@ -105,6 +107,7 @@ bool USRPInputSettings::deserialize(const QByteArray& data)
 
         d.readU32(15, &uintval, 0);
         m_reverseAPIDeviceIndex = uintval > 99 ? 99 : uintval;
+        d.readS32(16, &m_loOffset, 0);
 
         return true;
     }

--- a/plugins/samplesource/usrpinput/usrpinputsettings.h
+++ b/plugins/samplesource/usrpinput/usrpinputsettings.h
@@ -34,6 +34,7 @@ struct USRPInputSettings
         GAIN_MANUAL
     } GainMode;
 
+    int      m_masterClockRate;
     // global settings to be saved
     uint64_t m_centerFrequency;
     int      m_devSampleRate;

--- a/plugins/samplesource/usrpinput/usrpinputsettings.h
+++ b/plugins/samplesource/usrpinput/usrpinputsettings.h
@@ -37,6 +37,7 @@ struct USRPInputSettings
     // global settings to be saved
     uint64_t m_centerFrequency;
     int      m_devSampleRate;
+    int      m_loOffset;
     // channel settings
     bool     m_dcBlock;
     bool     m_iqCorrection;

--- a/plugins/samplesource/usrpinput/usrpinputthread.cpp
+++ b/plugins/samplesource/usrpinput/usrpinputthread.cpp
@@ -146,7 +146,7 @@ void USRPInputThread::run()
             m_packets++;
             if (samples_received != m_bufSamples)
             {
-                qDebug("USRPInputThread::run - received %ld/%d samples", samples_received, m_bufSamples);
+                qDebug("USRPInputThread::run - received %ld/%ld samples", samples_received, m_bufSamples);
             }
             if (md.error_code ==  uhd::rx_metadata_t::ERROR_CODE_TIMEOUT)
             {

--- a/plugins/samplesource/usrpinput/usrpinputthread.h
+++ b/plugins/samplesource/usrpinput/usrpinputthread.h
@@ -36,7 +36,7 @@ class USRPInputThread : public QThread, public DeviceUSRPShared::ThreadInterface
     Q_OBJECT
 
 public:
-    USRPInputThread(uhd::rx_streamer::sptr stream, SampleSinkFifo* sampleFifo, QObject* parent = 0);
+    USRPInputThread(uhd::rx_streamer::sptr stream, size_t bufSamples, SampleSinkFifo* sampleFifo, QObject* parent = 0);
     ~USRPInputThread();
 
     virtual void startWork();
@@ -45,6 +45,7 @@ public:
     virtual bool isRunning() { return m_running; }
     void setLog2Decimation(unsigned int log2_decim);
     void getStreamStatus(bool& active, quint32& overflows, quint32& m_timeouts);
+    void issueStreamCmd(bool start);
 
 private:
     QMutex m_startWaitMutex;
@@ -56,13 +57,14 @@ private:
     quint32 m_timeouts;
 
     uhd::rx_streamer::sptr m_stream;
-    qint16 m_buf[2*DeviceUSRP::blockSize]; //must hold I+Q values of each sample hence 2xcomplex size
+    qint16 *m_buf;
+    size_t m_bufSamples;
     SampleVector m_convertBuffer;
     SampleSinkFifo* m_sampleFifo;
 
     unsigned int m_log2Decim; // soft decimation
 
-    Decimators<qint32, qint16, SDR_RX_SAMP_SZ, 12, true> m_decimatorsIQ;
+    Decimators<qint32, qint16, SDR_RX_SAMP_SZ, 16, true> m_decimatorsIQ;
 
     void run();
     void callbackIQ(const qint16* buf, qint32 len);

--- a/sdrbase/resources/webapi/doc/html2/index.html
+++ b/sdrbase/resources/webapi/doc/html2/index.html
@@ -7583,6 +7583,9 @@ margin-bottom: 20px;
     "devSampleRate" : {
       "type" : "integer"
     },
+    "loOffset" : {
+      "type" : "integer"
+    },
     "dcBlock" : {
       "type" : "integer"
     },
@@ -7657,6 +7660,9 @@ margin-bottom: 20px;
       "format" : "int64"
     },
     "devSampleRate" : {
+      "type" : "integer"
+    },
+    "loOffset" : {
       "type" : "integer"
     },
     "log2SoftInterp" : {
@@ -39969,7 +39975,7 @@ except ApiException as e:
           </div>
           <div id="generator">
             <div class="content">
-              Generated 2020-10-11T08:49:12.690+02:00
+              Generated 2020-10-25T21:28:04.207+01:00
             </div>
           </div>
       </div>

--- a/swagger/sdrangel/api/swagger/include/USRP.yaml
+++ b/swagger/sdrangel/api/swagger/include/USRP.yaml
@@ -6,6 +6,8 @@ USRPInputSettings:
       format: int64
     devSampleRate:
       type: integer
+    loOffset:
+      type: integer
     dcBlock:
       type: integer
     iqCorrection:
@@ -45,6 +47,8 @@ USRPOutputSettings:
       type: integer
       format: int64
     devSampleRate:
+      type: integer
+    loOffset:
       type: integer
     log2SoftInterp:
       type: integer

--- a/swagger/sdrangel/code/html2/index.html
+++ b/swagger/sdrangel/code/html2/index.html
@@ -7583,6 +7583,9 @@ margin-bottom: 20px;
     "devSampleRate" : {
       "type" : "integer"
     },
+    "loOffset" : {
+      "type" : "integer"
+    },
     "dcBlock" : {
       "type" : "integer"
     },
@@ -7657,6 +7660,9 @@ margin-bottom: 20px;
       "format" : "int64"
     },
     "devSampleRate" : {
+      "type" : "integer"
+    },
+    "loOffset" : {
       "type" : "integer"
     },
     "log2SoftInterp" : {
@@ -39969,7 +39975,7 @@ except ApiException as e:
           </div>
           <div id="generator">
             <div class="content">
-              Generated 2020-10-11T08:49:12.690+02:00
+              Generated 2020-10-25T21:28:04.207+01:00
             </div>
           </div>
       </div>

--- a/swagger/sdrangel/code/qt5/client/SWGUSRPInputSettings.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGUSRPInputSettings.cpp
@@ -32,6 +32,8 @@ SWGUSRPInputSettings::SWGUSRPInputSettings() {
     m_center_frequency_isSet = false;
     dev_sample_rate = 0;
     m_dev_sample_rate_isSet = false;
+    lo_offset = 0;
+    m_lo_offset_isSet = false;
     dc_block = 0;
     m_dc_block_isSet = false;
     iq_correction = 0;
@@ -72,6 +74,8 @@ SWGUSRPInputSettings::init() {
     m_center_frequency_isSet = false;
     dev_sample_rate = 0;
     m_dev_sample_rate_isSet = false;
+    lo_offset = 0;
+    m_lo_offset_isSet = false;
     dc_block = 0;
     m_dc_block_isSet = false;
     iq_correction = 0;
@@ -110,6 +114,7 @@ SWGUSRPInputSettings::cleanup() {
 
 
 
+
     if(antenna_path != nullptr) { 
         delete antenna_path;
     }
@@ -142,6 +147,8 @@ SWGUSRPInputSettings::fromJsonObject(QJsonObject &pJson) {
     ::SWGSDRangel::setValue(&center_frequency, pJson["centerFrequency"], "qint64", "");
     
     ::SWGSDRangel::setValue(&dev_sample_rate, pJson["devSampleRate"], "qint32", "");
+    
+    ::SWGSDRangel::setValue(&lo_offset, pJson["loOffset"], "qint32", "");
     
     ::SWGSDRangel::setValue(&dc_block, pJson["dcBlock"], "qint32", "");
     
@@ -192,6 +199,9 @@ SWGUSRPInputSettings::asJsonObject() {
     }
     if(m_dev_sample_rate_isSet){
         obj->insert("devSampleRate", QJsonValue(dev_sample_rate));
+    }
+    if(m_lo_offset_isSet){
+        obj->insert("loOffset", QJsonValue(lo_offset));
     }
     if(m_dc_block_isSet){
         obj->insert("dcBlock", QJsonValue(dc_block));
@@ -257,6 +267,16 @@ void
 SWGUSRPInputSettings::setDevSampleRate(qint32 dev_sample_rate) {
     this->dev_sample_rate = dev_sample_rate;
     this->m_dev_sample_rate_isSet = true;
+}
+
+qint32
+SWGUSRPInputSettings::getLoOffset() {
+    return lo_offset;
+}
+void
+SWGUSRPInputSettings::setLoOffset(qint32 lo_offset) {
+    this->lo_offset = lo_offset;
+    this->m_lo_offset_isSet = true;
 }
 
 qint32
@@ -408,6 +428,9 @@ SWGUSRPInputSettings::isSet(){
             isObjectUpdated = true; break;
         }
         if(m_dev_sample_rate_isSet){
+            isObjectUpdated = true; break;
+        }
+        if(m_lo_offset_isSet){
             isObjectUpdated = true; break;
         }
         if(m_dc_block_isSet){

--- a/swagger/sdrangel/code/qt5/client/SWGUSRPInputSettings.h
+++ b/swagger/sdrangel/code/qt5/client/SWGUSRPInputSettings.h
@@ -48,6 +48,9 @@ public:
     qint32 getDevSampleRate();
     void setDevSampleRate(qint32 dev_sample_rate);
 
+    qint32 getLoOffset();
+    void setLoOffset(qint32 lo_offset);
+
     qint32 getDcBlock();
     void setDcBlock(qint32 dc_block);
 
@@ -99,6 +102,9 @@ private:
 
     qint32 dev_sample_rate;
     bool m_dev_sample_rate_isSet;
+
+    qint32 lo_offset;
+    bool m_lo_offset_isSet;
 
     qint32 dc_block;
     bool m_dc_block_isSet;

--- a/swagger/sdrangel/code/qt5/client/SWGUSRPOutputSettings.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGUSRPOutputSettings.cpp
@@ -32,6 +32,8 @@ SWGUSRPOutputSettings::SWGUSRPOutputSettings() {
     m_center_frequency_isSet = false;
     dev_sample_rate = 0;
     m_dev_sample_rate_isSet = false;
+    lo_offset = 0;
+    m_lo_offset_isSet = false;
     log2_soft_interp = 0;
     m_log2_soft_interp_isSet = false;
     lpf_bw = 0;
@@ -66,6 +68,8 @@ SWGUSRPOutputSettings::init() {
     m_center_frequency_isSet = false;
     dev_sample_rate = 0;
     m_dev_sample_rate_isSet = false;
+    lo_offset = 0;
+    m_lo_offset_isSet = false;
     log2_soft_interp = 0;
     m_log2_soft_interp_isSet = false;
     lpf_bw = 0;
@@ -92,6 +96,7 @@ SWGUSRPOutputSettings::init() {
 
 void
 SWGUSRPOutputSettings::cleanup() {
+
 
 
 
@@ -127,6 +132,8 @@ SWGUSRPOutputSettings::fromJsonObject(QJsonObject &pJson) {
     ::SWGSDRangel::setValue(&center_frequency, pJson["centerFrequency"], "qint64", "");
     
     ::SWGSDRangel::setValue(&dev_sample_rate, pJson["devSampleRate"], "qint32", "");
+    
+    ::SWGSDRangel::setValue(&lo_offset, pJson["loOffset"], "qint32", "");
     
     ::SWGSDRangel::setValue(&log2_soft_interp, pJson["log2SoftInterp"], "qint32", "");
     
@@ -171,6 +178,9 @@ SWGUSRPOutputSettings::asJsonObject() {
     }
     if(m_dev_sample_rate_isSet){
         obj->insert("devSampleRate", QJsonValue(dev_sample_rate));
+    }
+    if(m_lo_offset_isSet){
+        obj->insert("loOffset", QJsonValue(lo_offset));
     }
     if(m_log2_soft_interp_isSet){
         obj->insert("log2SoftInterp", QJsonValue(log2_soft_interp));
@@ -227,6 +237,16 @@ void
 SWGUSRPOutputSettings::setDevSampleRate(qint32 dev_sample_rate) {
     this->dev_sample_rate = dev_sample_rate;
     this->m_dev_sample_rate_isSet = true;
+}
+
+qint32
+SWGUSRPOutputSettings::getLoOffset() {
+    return lo_offset;
+}
+void
+SWGUSRPOutputSettings::setLoOffset(qint32 lo_offset) {
+    this->lo_offset = lo_offset;
+    this->m_lo_offset_isSet = true;
 }
 
 qint32
@@ -348,6 +368,9 @@ SWGUSRPOutputSettings::isSet(){
             isObjectUpdated = true; break;
         }
         if(m_dev_sample_rate_isSet){
+            isObjectUpdated = true; break;
+        }
+        if(m_lo_offset_isSet){
             isObjectUpdated = true; break;
         }
         if(m_log2_soft_interp_isSet){

--- a/swagger/sdrangel/code/qt5/client/SWGUSRPOutputSettings.h
+++ b/swagger/sdrangel/code/qt5/client/SWGUSRPOutputSettings.h
@@ -48,6 +48,9 @@ public:
     qint32 getDevSampleRate();
     void setDevSampleRate(qint32 dev_sample_rate);
 
+    qint32 getLoOffset();
+    void setLoOffset(qint32 lo_offset);
+
     qint32 getLog2SoftInterp();
     void setLog2SoftInterp(qint32 log2_soft_interp);
 
@@ -90,6 +93,9 @@ private:
 
     qint32 dev_sample_rate;
     bool m_dev_sample_rate_isSet;
+
+    qint32 lo_offset;
+    bool m_lo_offset_isSet;
 
     qint32 log2_soft_interp;
     bool m_log2_soft_interp_isSet;


### PR DESCRIPTION
This PR includes a variety of improvements for the USRP plugins. Mainly:

Add LO offset option.
Work around bug in UHD library resulting in large TX LO leakage for low LPF bandwidths.
Check for reference and LO lock before streaming.
Set bit size to be 16 for interpolators and decimators.
Increase RX FIFO size, to reduce overflows at high sample rates.
Allow RX to continue streaming after receiving timeout.
Display master clock rate in GUI.


