### PR TITLE
Replace qtDeviceName by alsaDeviceName in fcd* plugins

### DIFF
--- a/plugins/samplesource/fcdpro/fcdproinput.cpp
+++ b/plugins/samplesource/fcdpro/fcdproinput.cpp
@@ -85,14 +85,14 @@ bool FCDProInput::openDevice()
         return false;
     }
 
-    if (!openFCDAudio(fcd_traits<Pro>::qtDeviceName))
+    if (!openFCDAudio(fcd_traits<Pro>::alsaDeviceName))
     {
-        qCritical("FCDProInput::start: could not open FCD audio source");
+        qCritical("FCDProInput::start: could not open FCD audio source %s",fcd_traits<Pro>::alsaDeviceName);
         return false;
     }
     else
     {
-        qDebug("FCDProInput::start: FCD audio source opened");
+        qDebug("FCDProInput::start: FCD audio source opened %s",fcd_traits<Pro>::alsaDeviceName);
     }
 
     return true;

--- a/plugins/samplesource/fcdproplus/fcdproplusinput.cpp
+++ b/plugins/samplesource/fcdproplus/fcdproplusinput.cpp
@@ -81,18 +81,18 @@ bool FCDProPlusInput::openDevice()
 
     if (m_dev == 0)
     {
-        qCritical("FCDProPlusInput::start: could not open FCD");
+        qCritical("FCDProPlusInput::start: could not open FCDProPlus");
         return false;
     }
 
-	if (!openFCDAudio(fcd_traits<ProPlus>::qtDeviceName))
+	if (!openFCDAudio(fcd_traits<ProPlus>::alsaDeviceName))
 	{
-        qCritical("FCDProPlusInput::start: could not open FCD audio source");
+        qCritical("FCDProPlusInput::start: could not open FCDProPlus audio source, alsa: %s , qt: %s ", fcd_traits<ProPlus>::alsaDeviceName,fcd_traits<ProPlus>::qtDeviceName);
         return false;
 	}
     else
     {
-        qDebug("FCDProPlusInput::start: FCD audio source opened");
+        qDebug("FCDProPlusInput::start: FCDProPlus audio source opened, alsa: %s , qt: %s", fcd_traits<ProPlus>::alsaDeviceName,fcd_traits<ProPlus>::qtDeviceName);
     }
 
     return true;


### PR DESCRIPTION
sdrangel works fine with the fcdpro and fcdpro+ devices if pulseaudio is used. 
But on installations with pure alsa and without pulseaudio these devices are detected but cannot be opened.
The failure looks like:

FCDProPlusInput::openFCDAudio: device with name FUNcube_Dongle_V2.0 not found

Switching from qtDeviceName to alsaDeviceName in openDevice() solves this issue. After this change sdrangel works flawless in a pulseaudio and an alsa environment 