### PR TITLE
Fix missing cmath include

### DIFF
--- a/plugins/feature/rigctlserver/rigctlserverworker.cpp
+++ b/plugins/feature/rigctlserver/rigctlserverworker.cpp
@@ -22,6 +22,8 @@
 #include <QEventLoop>
 #include <QTimer>
 
+#include <cmath>
+
 #include "SWGDeviceState.h"
 #include "SWGSuccessResponse.h"
 #include "SWGErrorResponse.h"


### PR DESCRIPTION
This adds the `cmath` include to rigctlserverworker.cpp so the `std::abs()` on double overload is defined. Otherwise I get
```
plugins/feature/rigctlserver/rigctlserverworker.cpp:361:27: error: call to 'abs' is ambiguous
        bool outOfRange = std::abs(freq - targetFrequency) > m_settings.m_maxFrequencyOffset;
                          ^~~~~~~~
/usr/include/stdlib.h:132:6: note: candidate function
int      abs(int) ;
         ^
```