### PR TITLE
ADS-B improvements

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.cpp
@@ -20,9 +20,10 @@
 
 #include "adsbdemoddisplaydialog.h"
 
-ADSBDemodDisplayDialog::ADSBDemodDisplayDialog
-(int removeTimeout, float airportRange, ADSBDemodSettings::AirportType airportMinimumSize,
-                                                bool displayHeliports, bool siUnits, QString fontName, int fontSize, bool displayDemodStats, QWidget* parent) :
+ADSBDemodDisplayDialog::ADSBDemodDisplayDialog(
+        int removeTimeout, float airportRange, ADSBDemodSettings::AirportType airportMinimumSize,
+        bool displayHeliports, bool siUnits, QString fontName, int fontSize, bool displayDemodStats,
+        bool autoResizeTableColumns, QWidget* parent) :
     QDialog(parent),
     ui(new Ui::ADSBDemodDisplayDialog),
     m_fontName(fontName),
@@ -35,6 +36,7 @@ ADSBDemodDisplayDialog::ADSBDemodDisplayDialog
     ui->heliports->setChecked(displayHeliports);
     ui->units->setCurrentIndex((int)siUnits);
     ui->displayStats->setChecked(displayDemodStats);
+    ui->autoResizeTableColumns->setChecked(autoResizeTableColumns);
 }
 
 ADSBDemodDisplayDialog::~ADSBDemodDisplayDialog()
@@ -50,6 +52,7 @@ void ADSBDemodDisplayDialog::accept()
     m_displayHeliports = ui->heliports->isChecked();
     m_siUnits = ui->units->currentIndex() == 0 ? false : true;
     m_displayDemodStats = ui->displayStats->isChecked();
+    m_autoResizeTableColumns = ui->autoResizeTableColumns->isChecked();
     QDialog::accept();
 }
 

--- a/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.h
+++ b/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.h
@@ -26,8 +26,8 @@ class ADSBDemodDisplayDialog : public QDialog {
 
 public:
     explicit ADSBDemodDisplayDialog(int removeTimeout, float airportRange, ADSBDemodSettings::AirportType airportMinimumSize, 
-                                        bool displayHeliports, bool siUnits, QString fontName, int fontSize, bool displayDemodStats
-, QWidget* parent = 0);
+                                        bool displayHeliports, bool siUnits, QString fontName, int fontSize, bool displayDemodStats,
+                                        bool autoResizeTableColumns, QWidget* parent = 0);
     ~ADSBDemodDisplayDialog();
 
     int m_removeTimeout;
@@ -38,6 +38,7 @@ public:
     QString m_fontName;
     int m_fontSize;
     bool m_displayDemodStats;
+    bool m_autoResizeTableColumns;
     
 private slots:
     void accept();

--- a/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.ui
+++ b/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.ui
@@ -89,14 +89,14 @@
       <item row="3" column="0">
        <widget class="QLabel" name="airportRangeLabel">
         <property name="text">
-         <string>Airport display range (nm)</string>
+         <string>Airport display distance (km)</string>
         </property>
        </widget>
       </item>
       <item row="3" column="1">
        <widget class="QSpinBox" name="airportRange">
         <property name="toolTip">
-         <string>Displays airports within the specified range in nautical miles from My Position</string>
+         <string>Displays airports within the specified distance in kilometres from My Position</string>
         </property>
         <property name="maximum">
          <number>20000</number>

--- a/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.ui
+++ b/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>351</width>
-    <height>275</height>
+    <height>289</height>
    </rect>
   </property>
   <property name="font">
@@ -22,35 +22,95 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="groupBox">
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="unitsLabel">
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="5" column="1">
+       <widget class="QPushButton" name="font">
+        <property name="toolTip">
+         <string>Select a font for the table</string>
+        </property>
         <property name="text">
-         <string>Units</string>
+         <string>Select...</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="units">
-        <property name="toolTip">
-         <string>The units to use for altitude, speed and climb rate</string>
+      <item row="4" column="0">
+       <widget class="QLabel" name="timeoutLabel">
+        <property name="text">
+         <string>Aircraft timeout (s)</string>
         </property>
-        <item>
-         <property name="text">
-          <string>ft, kn, ft/min</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>m, kph, m/s</string>
-         </property>
-        </item>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="airportRange">
+        <property name="toolTip">
+         <string>Displays airports within the specified distance in kilometres from My Position</string>
+        </property>
+        <property name="maximum">
+         <number>20000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="heliports">
+        <property name="toolTip">
+         <string>When checked, heliports are displayed on the map</string>
+        </property>
+        <property name="text">
+         <string>Display heliports</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSpinBox" name="timeout">
+        <property name="toolTip">
+         <string>How long in seconds after not receving any frames will an aircraft be removed from the table and map</string>
+        </property>
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="airportSizeLabel">
         <property name="text">
          <string>Display airports with size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="airportRangeLabel">
+        <property name="text">
+         <string>Airport display distance (km)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="fontLabel">
+        <property name="text">
+         <string>Table font</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="displayStats">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Display demodulator statistics</string>
+        </property>
+        <property name="text">
+         <string>Display demodulator statistics</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="unitsLabel">
+        <property name="text">
+         <string>Units</string>
         </property>
        </widget>
       </item>
@@ -76,75 +136,31 @@
         </item>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="heliports">
+      <item row="7" column="0" colspan="2">
+       <widget class="QCheckBox" name="autoResizeTableColumns">
         <property name="toolTip">
-         <string>When checked, heliports are displayed on the map</string>
+         <string>Resize the columns in the table after an aircraft is added to it</string>
         </property>
         <property name="text">
-         <string>Display heliports</string>
+         <string>Resize columns after adding aircraft</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="airportRangeLabel">
-        <property name="text">
-         <string>Airport display distance (km)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QSpinBox" name="airportRange">
+      <item row="0" column="1">
+       <widget class="QComboBox" name="units">
         <property name="toolTip">
-         <string>Displays airports within the specified distance in kilometres from My Position</string>
+         <string>The units to use for altitude, speed and climb rate</string>
         </property>
-        <property name="maximum">
-         <number>20000</number>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="timeoutLabel">
-        <property name="text">
-         <string>Aircraft timeout (s)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QSpinBox" name="timeout">
-        <property name="toolTip">
-         <string>How long in seconds after not receving any frames will an aircraft be removed from the table and map</string>
-        </property>
-        <property name="maximum">
-         <number>1000000</number>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="fontLabel">
-        <property name="text">
-         <string>Table font</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QPushButton" name="font">
-        <property name="toolTip">
-         <string>Select a font for the table</string>
-        </property>
-        <property name="text">
-         <string>Select...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QCheckBox" name="displayStats">
-        <property name="toolTip">
-         <string>Display demodulator statistics</string>
-        </property>
-        <property name="text">
-         <string>Display demodulator statistics</string>
-        </property>
+        <item>
+         <property name="text">
+          <string>ft, kn, ft/min</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>m, kph, m/s</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>

--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -957,7 +957,7 @@ void ADSBDemodGUI::handleADSB(
                 }
                 else
                 {
-                    qDebug() << "ADSBDemodGUI::handleADSB: Invalid latitude " << latitude << " for " << Qt::hex << aircraft->m_icao
+                    qDebug() << "ADSBDemodGUI::handleADSB: Invalid latitude " << latitude << " for " << QString("%1").arg(aircraft->m_icao, 1, 16)
                         << " m_cprLat[0] " << aircraft->m_cprLat[0]
                         << " m_cprLat[1] " << aircraft->m_cprLat[1];
                     aircraft->m_cprValid[0] = false;

--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -703,6 +703,8 @@ void ADSBDemodGUI::handleADSB(
                 }
             }
         }
+        if (m_settings.m_autoResizeTableColumns)
+            ui->adsbData->resizeColumnsToContents();
         ui->adsbData->setSortingEnabled(true);
     }
     aircraft->m_time = dateTime;
@@ -1604,7 +1606,7 @@ void ADSBDemodGUI::on_displaySettings_clicked(bool checked)
     ADSBDemodDisplayDialog dialog(m_settings.m_removeTimeout, m_settings.m_airportRange, m_settings.m_airportMinimumSize,
                                 m_settings.m_displayHeliports, m_settings.m_siUnits,
                                 m_settings.m_tableFontName, m_settings.m_tableFontSize,
-                                m_settings.m_displayDemodStats);
+                                m_settings.m_displayDemodStats, m_settings.m_autoResizeTableColumns);
     if (dialog.exec() == QDialog::Accepted)
     {
         bool unitsChanged = m_settings.m_siUnits != dialog.m_siUnits;
@@ -1617,6 +1619,7 @@ void ADSBDemodGUI::on_displaySettings_clicked(bool checked)
         m_settings.m_tableFontName = dialog.m_fontName;
         m_settings.m_tableFontSize = dialog.m_fontSize;
         m_settings.m_displayDemodStats = dialog.m_displayDemodStats;
+        m_settings.m_autoResizeTableColumns = dialog.m_autoResizeTableColumns;
 
         if (unitsChanged)
             m_aircraftModel.allAircraftUpdated();
@@ -1947,7 +1950,7 @@ void ADSBDemodGUI::resizeTable()
     ui->adsbData->setItem(row, ADSB_COL_RANGE, new QTableWidgetItem("D (km)"));
     ui->adsbData->setItem(row, ADSB_COL_AZEL, new QTableWidgetItem("Az/El (o)"));
     ui->adsbData->setItem(row, ADSB_COL_LATITUDE, new QTableWidgetItem("-90.00000"));
-    ui->adsbData->setItem(row, ADSB_COL_LONGITUDE, new QTableWidgetItem("-180.00000"));
+    ui->adsbData->setItem(row, ADSB_COL_LONGITUDE, new QTableWidgetItem("-180.000000"));
     ui->adsbData->setItem(row, ADSB_COL_CATEGORY, new QTableWidgetItem("Heavy"));
     ui->adsbData->setItem(row, ADSB_COL_STATUS, new QTableWidgetItem("No emergency"));
     ui->adsbData->setItem(row, ADSB_COL_SQUAWK, new QTableWidgetItem("Squawk"));

--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -957,7 +957,7 @@ void ADSBDemodGUI::handleADSB(
                 }
                 else
                 {
-                    qDebug() << "ADSBDemodGUI::handleADSB: Invalid latitude " << latitude << " for " << hex << aircraft->m_icao
+                    qDebug() << "ADSBDemodGUI::handleADSB: Invalid latitude " << latitude << " for " << Qt::hex << aircraft->m_icao
                         << " m_cprLat[0] " << aircraft->m_cprLat[0]
                         << " m_cprLat[1] " << aircraft->m_cprLat[1];
                     aircraft->m_cprValid[0] = false;

--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -1214,6 +1214,21 @@ void ADSBDemodGUI::on_threshold_valueChanged(int value)
     applySettings();
 }
 
+void ADSBDemodGUI::on_phaseSteps_valueChanged(int value)
+{
+    ui->phaseStepsText->setText(QString("%1").arg(value));
+    m_settings.m_interpolatorPhaseSteps = value;
+    applySettings();
+}
+
+void ADSBDemodGUI::on_tapsPerPhase_valueChanged(int value)
+{
+    Real tapsPerPhase = ((Real)value)/10.0f;
+    ui->tapsPerPhaseText->setText(QString("%1").arg(tapsPerPhase, 0, 'f', 1));
+    m_settings.m_interpolatorTapsPerPhase = tapsPerPhase;
+    applySettings();
+}
+
 void ADSBDemodGUI::on_feed_clicked(bool checked)
 {
     m_settings.m_feedEnabled = checked;
@@ -1927,6 +1942,18 @@ void ADSBDemodGUI::displaySettings()
     ui->thresholdText->setText(QString("%1").arg(m_settings.m_correlationThreshold, 0, 'f', 1));
     ui->threshold->setValue((int)(m_settings.m_correlationThreshold*10.0f));
 
+    ui->phaseStepsText->setText(QString("%1").arg(m_settings.m_interpolatorPhaseSteps));
+    ui->phaseSteps->setValue(m_settings.m_interpolatorPhaseSteps);
+    ui->tapsPerPhaseText->setText(QString("%1").arg(m_settings.m_interpolatorTapsPerPhase, 0, 'f', 1));
+    ui->tapsPerPhase->setValue((int)(m_settings.m_interpolatorTapsPerPhase*10.0f));
+    // Enable these controls only for developers
+    if (1)
+    {
+        ui->phaseStepsText->setVisible(false);
+        ui->phaseSteps->setVisible(false);
+        ui->tapsPerPhaseText->setVisible(false);
+        ui->tapsPerPhase->setVisible(false);
+    }
     ui->feed->setChecked(m_settings.m_feedEnabled);
 
     ui->flightPaths->setChecked(m_settings.m_flightPaths);

--- a/plugins/channelrx/demodadsb/adsbdemodgui.h
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.h
@@ -91,6 +91,7 @@ struct Aircraft {
     int m_verticalRate;         // Vertical climb rate in ft/min
     QString m_emitterCategory;  // Aircraft type
     QString m_status;           // Aircraft status
+    int m_squawk;               // Mode-A code
     Real m_range;               // Distance from station to aircraft
     Real m_azimuth;             // Azimuth from station to aircraft
     Real m_elevation;           // Elevation from station to aicraft;
@@ -138,6 +139,7 @@ struct Aircraft {
     QTableWidgetItem *m_azElItem;
     QTableWidgetItem *m_emitterCategoryItem;
     QTableWidgetItem *m_statusItem;
+    QTableWidgetItem *m_squawkItem;
     QTableWidgetItem *m_registrationItem;
     QTableWidgetItem *m_countryItem;
     QTableWidgetItem *m_registeredItem;
@@ -193,6 +195,7 @@ struct Aircraft {
         m_longitudeItem = new QTableWidgetItem();
         m_emitterCategoryItem = new QTableWidgetItem();
         m_statusItem = new QTableWidgetItem();
+        m_squawkItem = new QTableWidgetItem();
         m_registrationItem = new QTableWidgetItem();
         m_countryItem = new QTableWidgetItem();
         m_registeredItem = new QTableWidgetItem();

--- a/plugins/channelrx/demodadsb/adsbdemodgui.h
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.h
@@ -324,16 +324,18 @@ public:
     {
     }
 
-    Q_INVOKABLE void addAirport(AirportInformation *airport) {
+    Q_INVOKABLE void addAirport(AirportInformation *airport, float az, float el, float distance) {
         QString text;
         int rows;
 
         beginInsertRows(QModelIndex(), rowCount(), rowCount());
         m_airports.append(airport);
-        airportFreq(airport, text, rows);
+        airportFreq(airport, az, el, distance, text, rows);
         m_airportDataFreq.append(text);
         m_airportDataFreqRows.append(rows);
         m_showFreq.append(false);
+        m_azimuth.append(az);
+        m_elevation.append(el);
         endInsertRows();
     }
 
@@ -346,6 +348,8 @@ public:
             m_airportDataFreq.removeAt(row);
             m_airportDataFreqRows.removeAt(row);
             m_showFreq.removeAt(row);
+            m_azimuth.removeAt(row);
+            m_elevation.removeAt(row);
             endRemoveRows();
         }
     }
@@ -356,6 +360,8 @@ public:
         m_airportDataFreq.clear();
         m_airportDataFreqRows.clear();
         m_showFreq.clear();
+        m_azimuth.clear();
+        m_elevation.clear();
         endRemoveRows();
     }
 
@@ -372,7 +378,7 @@ public:
         return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable;
     }
 
-    void airportFreq(AirportInformation *airport, QString& text, int& rows) {
+    void airportFreq(AirportInformation *airport, float az, float el, float distance, QString& text, int& rows) {
         // Create the text to go in the bubble next to the airport
         // Display name and frequencies
         QStringList list;
@@ -385,6 +391,9 @@ public:
             list.append(QString("%1: %2 MHz").arg(frequencyInfo->m_type).arg(frequencyInfo->m_frequency));
             rows++;
         }
+        list.append(QString("Az/El: %1/%2").arg((int)std::round(az)).arg((int)std::round(el)));
+        list.append(QString("Distance: %1 km").arg(distance/1000.0f, 0, 'f', 1));
+        rows += 2;
         text = list.join("\n");
     }
 
@@ -415,6 +424,8 @@ private:
     QList<QString> m_airportDataFreq;
     QList<int> m_airportDataFreqRows;
     QList<bool> m_showFreq;
+    QList<float> m_azimuth;
+    QList<float> m_elevation;
 };
 
 class ADSBDemodGUI : public ChannelGUI {
@@ -430,6 +441,7 @@ public:
     virtual MessageQueue *getInputMessageQueue() { return &m_inputMessageQueue; }
     void highlightAircraft(Aircraft *aircraft);
     void targetAircraft(Aircraft *aircraft);
+    void target(float az, float el);
     bool setFrequency(float frequency);
     bool useSIUints() { return m_settings.m_siUnits; }
 

--- a/plugins/channelrx/demodadsb/adsbdemodgui.h
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.h
@@ -508,6 +508,8 @@ private:
     QString getAirportFrequenciesDBFilename();
     QString getOSNDBFilename();
     QString getFastDBFilename();
+    qint64 ADSBDemodGUI::fileAgeInDays(QString filename);
+    bool ADSBDemodGUI::confirmDownload(QString filename);
     void readAirportDB(const QString& filename);
     void readAirportFrequenciesDB(const QString& filename);
     bool readOSNDB(const QString& filename);

--- a/plugins/channelrx/demodadsb/adsbdemodgui.h
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.h
@@ -528,6 +528,8 @@ private slots:
     void on_deltaFrequency_changed(qint64 value);
     void on_rfBW_valueChanged(int value);
     void on_threshold_valueChanged(int value);
+    void on_phaseSteps_valueChanged(int value);
+    void on_tapsPerPhase_valueChanged(int value);
     void on_adsbData_cellClicked(int row, int column);
     void on_adsbData_cellDoubleClicked(int row, int column);
     void adsbData_sectionMoved(int logicalIndex, int oldVisualIndex, int newVisualIndex);

--- a/plugins/channelrx/demodadsb/adsbdemodgui.h
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.h
@@ -497,6 +497,7 @@ private:
     void displayStreamIndex();
     bool handleMessage(const Message& message);
     void updatePosition(Aircraft *aircraft);
+    bool updateLocalPosition(Aircraft *aircraft, double latitude, double longitude, bool surfacePosition);
     void handleADSB(
         const QByteArray data,
         const QDateTime dateTime,

--- a/plugins/channelrx/demodadsb/adsbdemodgui.h
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.h
@@ -509,8 +509,8 @@ private:
     QString getAirportFrequenciesDBFilename();
     QString getOSNDBFilename();
     QString getFastDBFilename();
-    qint64 ADSBDemodGUI::fileAgeInDays(QString filename);
-    bool ADSBDemodGUI::confirmDownload(QString filename);
+    qint64 fileAgeInDays(QString filename);
+    bool confirmDownload(QString filename);
     void readAirportDB(const QString& filename);
     void readAirportFrequenciesDB(const QString& filename);
     bool readOSNDB(const QString& filename);

--- a/plugins/channelrx/demodadsb/adsbdemodgui.ui
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.ui
@@ -695,6 +695,14 @@
       </column>
       <column>
        <property name="text">
+        <string>Squawk</string>
+       </property>
+       <property name="toolTip">
+        <string>Mode-A transponder code</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
         <string>Reg</string>
        </property>
        <property name="toolTip">
@@ -845,6 +853,11 @@
    <header location="global">QtQuickWidgets/QQuickWidget</header>
   </customwidget>
   <customwidget>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
+  </customwidget>
+  <customwidget>
    <class>RollupWidget</class>
    <extends>QWidget</extends>
    <header>gui/rollupwidget.h</header>
@@ -861,11 +874,6 @@
    <extends>QWidget</extends>
    <header>gui/valuedialz.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ButtonSwitch</class>
-   <extends>QToolButton</extends>
-   <header>gui/buttonswitch.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/plugins/channelrx/demodadsb/adsbdemodgui.ui
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>384</width>
+    <width>435</width>
     <height>1046</height>
    </rect>
   </property>
@@ -36,7 +36,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>381</width>
+     <width>431</width>
      <height>141</height>
     </rect>
    </property>
@@ -168,6 +168,13 @@
     <item>
      <layout class="QHBoxLayout" name="levelMeterLayout">
       <item>
+       <widget class="Line" name="line_5">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="channelPowerMeterUnits">
         <property name="text">
          <string>dB</string>
@@ -204,9 +211,16 @@
     <item>
      <layout class="QHBoxLayout" name="rfBWLayout">
       <item>
+       <widget class="Line" name="line_4">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="rfBWLabel">
         <property name="text">
-         <string>RFBW</string>
+         <string>BW</string>
         </property>
        </widget>
       </item>
@@ -259,6 +273,85 @@
        <widget class="Line" name="line_2">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDial" name="phaseSteps">
+        <property name="maximumSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Interpolator phase steps</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>16</number>
+        </property>
+        <property name="pageStep">
+         <number>1</number>
+        </property>
+        <property name="value">
+         <number>16</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="phaseStepsText">
+        <property name="minimumSize">
+         <size>
+          <width>16</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>12</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDial" name="tapsPerPhase">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Interpolator taps per phase</string>
+        </property>
+        <property name="minimum">
+         <number>10</number>
+        </property>
+        <property name="maximum">
+         <number>60</number>
+        </property>
+        <property name="pageStep">
+         <number>1</number>
+        </property>
+        <property name="value">
+         <number>45</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="tapsPerPhaseText">
+        <property name="minimumSize">
+         <size>
+          <width>16</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>4.5</string>
         </property>
        </widget>
       </item>
@@ -547,7 +640,7 @@
     <rect>
      <x>0</x>
      <y>140</y>
-     <width>381</width>
+     <width>431</width>
      <height>291</height>
     </rect>
    </property>
@@ -787,7 +880,7 @@
     <rect>
      <x>10</x>
      <y>450</y>
-     <width>361</width>
+     <width>421</width>
      <height>581</height>
     </rect>
    </property>
@@ -879,8 +972,21 @@
  <tabstops>
   <tabstop>deltaFrequency</tabstop>
   <tabstop>rfBW</tabstop>
+  <tabstop>phaseSteps</tabstop>
+  <tabstop>tapsPerPhase</tabstop>
   <tabstop>spb</tabstop>
+  <tabstop>demodModeS</tabstop>
+  <tabstop>correlateFullPreamble</tabstop>
   <tabstop>threshold</tabstop>
+  <tabstop>getOSNDB</tabstop>
+  <tabstop>getAirportDB</tabstop>
+  <tabstop>displaySettings</tabstop>
+  <tabstop>flightPaths</tabstop>
+  <tabstop>feed</tabstop>
+  <tabstop>devicesRefresh</tabstop>
+  <tabstop>device</tabstop>
+  <tabstop>adsbData</tabstop>
+  <tabstop>map</tabstop>
  </tabstops>
  <resources>
   <include location="../../../sdrgui/resources/res.qrc"/>

--- a/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
@@ -61,6 +61,8 @@ void ADSBDemodSettings::resetToDefaults()
     m_demodModeS = false;
     m_deviceIndex = -1;
     m_autoResizeTableColumns = false;
+    m_interpolatorPhaseSteps = 4;      // Higher than these two values will struggle to run in real-time
+    m_interpolatorTapsPerPhase = 3.5f; // without gaining much improvement in PER
     for (int i = 0; i < ADSBDEMOD_COLUMNS; i++)
     {
         m_columnIndexes[i] = i;
@@ -105,6 +107,8 @@ QByteArray ADSBDemodSettings::serialize() const
     s.writeBool(28, m_correlateFullPreamble);
     s.writeBool(29, m_demodModeS);
     s.writeBool(30, m_autoResizeTableColumns);
+    s.writeS32(31, m_interpolatorPhaseSteps);
+    s.writeFloat(32, m_interpolatorTapsPerPhase);
 
     for (int i = 0; i < ADSBDEMOD_COLUMNS; i++)
         s.writeS32(100 + i, m_columnIndexes[i]);
@@ -182,6 +186,8 @@ bool ADSBDemodSettings::deserialize(const QByteArray& data)
         d.readBool(28, &m_correlateFullPreamble, true);
         d.readBool(29, &m_demodModeS, false);
         d.readBool(30, &m_autoResizeTableColumns, false);
+        d.readS32(31, &m_interpolatorPhaseSteps, 4);
+        d.readFloat(32, &m_interpolatorTapsPerPhase, 3.5f);
 
         for (int i = 0; i < ADSBDEMOD_COLUMNS; i++)
             d.readS32(100 + i, &m_columnIndexes[i], i);

--- a/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
@@ -60,6 +60,7 @@ void ADSBDemodSettings::resetToDefaults()
     m_correlateFullPreamble = true;
     m_demodModeS = false;
     m_deviceIndex = -1;
+    m_autoResizeTableColumns = false;
     for (int i = 0; i < ADSBDEMOD_COLUMNS; i++)
     {
         m_columnIndexes[i] = i;
@@ -103,6 +104,7 @@ QByteArray ADSBDemodSettings::serialize() const
     s.writeBool(27, m_displayDemodStats);
     s.writeBool(28, m_correlateFullPreamble);
     s.writeBool(29, m_demodModeS);
+    s.writeBool(30, m_autoResizeTableColumns);
 
     for (int i = 0; i < ADSBDEMOD_COLUMNS; i++)
         s.writeS32(100 + i, m_columnIndexes[i]);
@@ -179,6 +181,7 @@ bool ADSBDemodSettings::deserialize(const QByteArray& data)
         d.readBool(27, &m_displayDemodStats, false);
         d.readBool(28, &m_correlateFullPreamble, true);
         d.readBool(29, &m_demodModeS, false);
+        d.readBool(30, &m_autoResizeTableColumns, false);
 
         for (int i = 0; i < ADSBDEMOD_COLUMNS; i++)
             d.readS32(100 + i, &m_columnIndexes[i], i);

--- a/plugins/channelrx/demodadsb/adsbdemodsettings.h
+++ b/plugins/channelrx/demodadsb/adsbdemodsettings.h
@@ -57,7 +57,7 @@ struct ADSBDemodSettings
 
     Serializable *m_channelMarker;
 
-    float m_airportRange;               //!< How far away should we display airports (nm)
+    float m_airportRange;               //!< How far away should we display airports (km)
     enum AirportType {
         Small,
         Medium,

--- a/plugins/channelrx/demodadsb/adsbdemodsettings.h
+++ b/plugins/channelrx/demodadsb/adsbdemodsettings.h
@@ -74,6 +74,8 @@ struct ADSBDemodSettings
     bool m_demodModeS;                  //!< Demodulate all Mode-S frames, not just ADS-B
     int m_deviceIndex;                  //!< Device to set to ATC frequencies
     bool m_autoResizeTableColumns;
+    int m_interpolatorPhaseSteps;
+    float m_interpolatorTapsPerPhase;
 
     ADSBDemodSettings();
     void resetToDefaults();

--- a/plugins/channelrx/demodadsb/adsbdemodsettings.h
+++ b/plugins/channelrx/demodadsb/adsbdemodsettings.h
@@ -73,6 +73,7 @@ struct ADSBDemodSettings
     bool m_correlateFullPreamble;
     bool m_demodModeS;                  //!< Demodulate all Mode-S frames, not just ADS-B
     int m_deviceIndex;                  //!< Device to set to ATC frequencies
+    bool m_autoResizeTableColumns;
 
     ADSBDemodSettings();
     void resetToDefaults();

--- a/plugins/channelrx/demodadsb/map/map.qml
+++ b/plugins/channelrx/demodadsb/map/map.qml
@@ -161,11 +161,17 @@ Item {
                                     var freqIdx = Math.floor((mouse.y-5)/((height-10)/airportDataRows))
                                     if (freqIdx == 0) {
                                         showFreq = false
-                                    } else {
-                                        selectedFreq = freqIdx - 1
                                     }
                                 } else {
-                                    showFreq = true
+                                   showFreq = true
+                                }
+                            }
+                            onDoubleClicked: (mouse) => {
+                                if (showFreq) {
+                                    var freqIdx = Math.floor((mouse.y-5)/((height-10)/airportDataRows))
+                                    if (freqIdx != 0) {
+                                        selectedFreq = freqIdx - 1
+                                    }
                                 }
                             }
                         }

--- a/plugins/channelrx/demodadsb/osndb.h
+++ b/plugins/channelrx/demodadsb/osndb.h
@@ -70,7 +70,6 @@ struct AircraftInformation {
         if ((file = fopen(utfFilename.constData(), "r")) != NULL)
         {
             char row[2048];
-            int idx;
 
             if (fgets(row, sizeof(row), file))
             {

--- a/plugins/channelrx/demodadsb/ourairportsdb.h
+++ b/plugins/channelrx/demodadsb/ourairportsdb.h
@@ -82,7 +82,6 @@ struct AirportInformation {
         if ((file = fopen(utfFilename.constData(), "r")) != NULL)
         {
             char row[2048];
-            int idx;
 
             if (fgets(row, sizeof(row), file))
             {

--- a/plugins/channelrx/demodadsb/readme.md
+++ b/plugins/channelrx/demodadsb/readme.md
@@ -64,6 +64,8 @@ Clicking the Display Settings button will open the Display Settings dialog, whic
 * The distance (in kilometres), from the location set under Preferences > My Position, at which airports will be displayed on the map.
 * The timeout, in seconds, after which an aircraft will be removed from the table and map, if an ADS-B frame has not been received from it.
 * The font used for the table.
+* Whether demodulator statistics are displayed (primarily an option for developers).
+* Whether the columns in the table are automatically resized after an aircraft is added to it. If unchecked, columns can be resized manually and should be saved with presets.
 
 <h3>12: Display Flight Paths</h3>
 

--- a/plugins/channelrx/demodadsb/readme.md
+++ b/plugins/channelrx/demodadsb/readme.md
@@ -61,7 +61,7 @@ Clicking the Display Settings button will open the Display Settings dialog, whic
 * The units for altitude, speed and vertical climb rate. These can be either ft (feet), kn (knots) and ft/min (feet per minute), or m (metres), kph (kilometers per hour) and m/s (metres per second).
 * The minimum size airport that will be displayed on the map: small, medium or large. Use small to display GA airfields, medium for regional airports and large for international airports.
 * Whether or not to display heliports.
-* The range (in nautical miles) from My Position at which airports will be displayed on the map.
+* The distance (in kilometres), from the location set under Preferences > My Position, at which airports will be displayed on the map.
 * The timeout, in seconds, after which an aircraft will be removed from the table and map, if an ADS-B frame has not been received from it.
 * The font used for the table.
 
@@ -99,18 +99,18 @@ The table displays the decoded ADS-B data for each aircraft along side data avai
 * Flight No. - Airline flight number or callsign. (ADS-B)
 * Aircraft - The aircraft model. (DB)
 * Airline - The logo of the operator of the aircraft (or owner if no operator known). (DB)
-* Altitude - Altitude in feet or metres. (ADS-B)
-* Speed - Speed (either ground speed, indicated airspeed, or true airspeed) in knots or kph. (ADS-B)
-* Heading - The direction the aircraft is heading, in degrees. (ADS-B)
-* VR - The vertical climb rate (or descent rate if negative) in feet/minute or m/s. (ADS-B)
-* Range - The range (distance) to the aircraft from the receiving antenna in kilometres. The location of the receiving antenna is set under the Preferences > My Position menu.
+* Altitude (Alt) - Altitude in feet or metres. (ADS-B)
+* Speed (Spd) - Speed (either ground speed, indicated airspeed, or true airspeed) in knots or kph. (ADS-B)
+* Heading (Hd) - The direction the aircraft is heading, in degrees. (ADS-B)
+* Vertical rate (VR) - The vertical climb rate (or descent rate if negative) in feet/minute or m/s. (ADS-B)
+* Distance (D) - The distance to the aircraft from the receiving antenna in kilometres. The location of the receiving antenna is set under the Preferences > My Position menu.
 * Az/El - The azimuth and elevation angles to the aircraft from the receiving antenna in degrees. These values can be sent to a rotator controller Feature plugin to track the aircraft.
-* Latitude - Vertical position coordinate, in decimal degrees. (ADS-B)
-* Longitude - Horizontal position coordinate, in decimal degrees. (ADS-B)
-* Category - The vehicle category, such as Light, Large, Heavy or Rotorcraft. (ADS-B)
+* Latitude (Lat) - Vertical position coordinate, in decimal degrees. (ADS-B)
+* Longitude (Lon) - Horizontal position coordinate, in decimal degrees. (ADS-B)
+* Category (Cat) - The vehicle category, such as Light, Large, Heavy or Rotorcraft. (ADS-B)
 * Status - The status of the flight, including if there is an emergency. (ADS-B)
 * Squawk - The squawk code (Mode-A transponder code). (ADS-B)
-* Registration - The registration number of the aircraft. (DB)
+* Registration (Reg) - The registration number of the aircraft. (DB)
 * Country - The flag of the country the aircraft is registered in. (DB)
 * Registered - The date when the aircraft was registered. (DB)
 * Manufacturer - The manufacturer of the aircraft. (DB)
@@ -122,14 +122,14 @@ The table displays the decoded ADS-B data for each aircraft along side data avai
 
 If an ADS-B frame has not been received from an aircraft for 60 seconds, the aircraft is removed from the table and map. This timeout can be adjusted in the Display Settings dialog.
 
-Single clicking in a cell will highlight the row and the corresponding aircraft information box on the map will be coloured orange, rather than blue.
-Right clicking on the header will open a menu allowing you to select which columns are visible.
-To reorder the columns, left click and drag left or right a column header.
-Left click on a header to sort the table by the data in that column.
-Double clicking in an ICAO ID cell will open a Web browser and search for the corresponding aircraft on https://www.planespotters.net/
-Double clicking in an Flight No cell will open a Web browser and search for the corresponding flight on https://www.flightradar24.com/
-Double clicking in an Az/El cell will set the aircraft as the active target. The azimuth and elevation to the aicraft will be sent to a rotator controller plugin. The aircraft information box will be coloured green, rather than blue, on the map.
-Double clicking on any other cell in the table will centre the map on the corresponding aircraft.
+* Single clicking in a cell will highlight the row and the corresponding aircraft information box on the map will be coloured orange, rather than blue.
+* Right clicking on the header will open a menu allowing you to select which columns are visible.
+* To reorder the columns, left click and drag left or right a column header.
+* Left click on a header to sort the table by the data in that column.
+* Double clicking in an ICAO ID cell will open a Web browser and search for the corresponding aircraft on https://www.planespotters.net/
+* Double clicking in an Flight No cell will open a Web browser and search for the corresponding flight on https://www.flightradar24.com/
+* Double clicking in an Az/El cell will set the aircraft as the active target. The azimuth and elevation to the aicraft will be sent to a rotator controller plugin. The aircraft information box will be coloured green, rather than blue, on the map.
+* Double clicking on any other cell in the table will centre the map on the corresponding aircraft.
 
 <h3>Map</h3>
 
@@ -141,10 +141,11 @@ The initial antenna location is placed according to My Position set under the Pr
 
 Aircraft are only placed upon the map when a position can be calculated, which can require several frames to be received.
 
-To pan around the map, click the left mouse button and drag. To zoom in or out, use the mouse scroll wheel.
-Left clicking on an aicraft will highlight the corresponding row in the table for the aircraft and the information box on the map will be coloured orange, rather than blue.
-Left clicking the information box next to an aircraft will reveal more information. If can be closed by clicking it again.
-Left clicking the information box next to an airport will reveal ATC frequencies for the airport (if the OurAirports database has been downloaded.). This information box can be closed by left clicking on the airport identifier. Left clicking on one of the listed frequencies, will set it as the centre frequency on the selected SDRangel device set.
+* To pan around the map, click the left mouse button and drag. To zoom in or out, use the mouse scroll wheel.
+* Left clicking on an aicraft will highlight the corresponding row in the table for the aircraft and the information box on the map will be coloured orange, rather than blue.
+* Double clicking on an aircraft will set it as the active target and the information box will be coloured green.
+* Left clicking the information box next to an aircraft will reveal more information. It can be closed by clicking it again.
+* Left clicking the information box next to an airport will reveal ATC frequencies for the airport (if the OurAirports database has been downloaded.). This information box can be closed by left clicking on the airport identifier. Double clicking on one of the listed frequencies, will set it as the centre frequency on the selected SDRangel device set (15). The Az/El row gives the azimuth and elevation of the airport from the location set under Preferences > My Position. Double clicking on this row will set the airport as the active target.
 
 <h3>Attribution</h3>
 

--- a/plugins/channelrx/demodadsb/readme.md
+++ b/plugins/channelrx/demodadsb/readme.md
@@ -109,6 +109,7 @@ The table displays the decoded ADS-B data for each aircraft along side data avai
 * Longitude - Horizontal position coordinate, in decimal degrees. (ADS-B)
 * Category - The vehicle category, such as Light, Large, Heavy or Rotorcraft. (ADS-B)
 * Status - The status of the flight, including if there is an emergency. (ADS-B)
+* Squawk - The squawk code (Mode-A transponder code). (ADS-B)
 * Registration - The registration number of the aircraft. (DB)
 * Country - The flag of the country the aircraft is registered in. (DB)
 * Registered - The date when the aircraft was registered. (DB)


### PR DESCRIPTION
Hi Edouard,

This PR incudes some changes based on your feedback of the previous release, and also some additional bug fixes and improvements:

Add decode of Mode-A transponder (Squawk) code
Add decoding of surface position messages (so you can see aircraft position at airports)
Add Az/El and distance to airport information box
Require double click to set ATC frequency.
Allow airport to be set as target, by double clicking Az/El in airport info box.
Confirm redownload of files if less than 100 days old.
Add option to automatically resize columns after an aircraft is added to the table.
Check latitude and local CPR decode is in valid range (to prevent aircraft from jumping around the map).
Reduce interpolator taps to enable it to run in real-time. Should significantly improve packet error rate for RTLSDR at 2.4MSa/s.
