### PR TITLE
Fix crash in pipe garbage collection

### DIFF
--- a/sdrbase/pipes/elementpipesgc.h
+++ b/sdrbase/pipes/elementpipesgc.h
@@ -121,7 +121,8 @@ public:
                     QList<Consumer*>& consumers = cIt.value();
 
                     for (int i = 0; i < consumers.size(); i++) {
-                        sendMessageToConsumer(m_elements->operator[](producerKey)[i], producerKey, consumers[i]);
+                        if (existsConsumer(consumers[i]))
+                            sendMessageToConsumer(m_elements->operator[](producerKey)[i], producerKey, consumers[i]);
                     }
                 }
             }

--- a/sdrbase/pipes/elementpipesregistrations.h
+++ b/sdrbase/pipes/elementpipesregistrations.h
@@ -59,7 +59,7 @@ public:
         }
         else
         {
-            typeId++;
+            typeId = m_typeCount++;
             m_typeIds.insert(type, typeId);
         }
 


### PR DESCRIPTION
Hi,

It seems the pipe garbage collection can crash after a feature has been removed. As a example (on Windows at least)

- Run SDRangel and create VOR SC channel demod and VOR localiser
- Run them for a bit
- Delete the demod 
- Delete the localiser

After a few seconds, SDRangel will crash. (I actually noticed the problem when trying to change the ADSBDemod and GS232 Controller to use the pipes).

A possible fix to elementpipesgc.h is to check that the consumer exists before sending the message.

While debugging, I also noticed a compiler warning of the use of an uninitialized variable in elementpipesregistrations.h - while the m_typeCount variable isn't being used. So the change there is just a guess at what you might have been trying to do, but I'm not certain, so you probably need to take a look at that.
