### PR TITLE
Star tracker separate resources

### DIFF
--- a/plugins/feature/startracker/CMakeLists.txt
+++ b/plugins/feature/startracker/CMakeLists.txt
@@ -29,6 +29,9 @@ if(NOT SERVER_MODE)
         startrackersettingsdialog.cpp
         startrackersettingsdialog.ui
         startracker.qrc
+        startracker150mhz.qrc
+        startracker408mhz.qrc
+        startracker1420mhz.qrc
     )
     set(startracker_HEADERS
         ${startracker_HEADERS}

--- a/plugins/feature/startracker/startracker.qrc
+++ b/plugins/feature/startracker/startracker.qrc
@@ -14,15 +14,5 @@
     <file>startracker/pulsar-32.png</file>
     <file>startracker/sun-40.png</file>
     <file>startracker/sun-button-24.png</file>
-    <file>startracker/150mhz_ra_dec.png</file>
-    <file>startracker/408mhz_ra_dec.png</file>
-    <file>startracker/1420mhz_ra_dec.png</file>
-    <file>startracker/150mhz_galactic.png</file>
-    <file>startracker/408mhz_galactic.png</file>
-    <file>startracker/1420mhz_galactic.png</file>
-    <file>startracker/150mhz_ra_dec.fits</file>
-    <file>startracker/408mhz_ra_dec.fits</file>
-    <file>startracker/1420mhz_ra_dec.fits</file>
-    <file>startracker/408mhz_ra_dec_spectral_index.fits</file>
   </qresource>
 </RCC>

--- a/plugins/feature/startracker/startracker1420mhz.qrc
+++ b/plugins/feature/startracker/startracker1420mhz.qrc
@@ -1,0 +1,7 @@
+<RCC>
+  <qresource prefix="/startracker/">
+    <file>startracker/1420mhz_ra_dec.png</file>
+    <file>startracker/1420mhz_galactic.png</file>
+    <file>startracker/1420mhz_ra_dec.fits</file>
+  </qresource>
+</RCC>

--- a/plugins/feature/startracker/startracker150mhz.qrc
+++ b/plugins/feature/startracker/startracker150mhz.qrc
@@ -1,0 +1,7 @@
+<RCC>
+  <qresource prefix="/startracker/">
+    <file>startracker/150mhz_ra_dec.png</file>
+    <file>startracker/150mhz_galactic.png</file>
+    <file>startracker/150mhz_ra_dec.fits</file>
+  </qresource>
+</RCC>

--- a/plugins/feature/startracker/startracker408mhz.qrc
+++ b/plugins/feature/startracker/startracker408mhz.qrc
@@ -1,0 +1,8 @@
+<RCC>
+  <qresource prefix="/startracker/">
+    <file>startracker/408mhz_ra_dec.png</file>
+    <file>startracker/408mhz_galactic.png</file>
+    <file>startracker/408mhz_ra_dec.fits</file>
+    <file>startracker/408mhz_ra_dec_spectral_index.fits</file>
+  </qresource>
+</RCC>

--- a/plugins/feature/startracker/startrackergui.cpp
+++ b/plugins/feature/startracker/startrackergui.cpp
@@ -1206,7 +1206,7 @@ void StarTrackerGUI::updateSolarFlux(bool all)
     {
         QDate today = QDateTime::currentDateTimeUtc().date();
         QString solarFluxFile = getSolarFluxFilename();
-        if (m_dlm.confirmDownload(solarFluxFile))
+        if (m_dlm.confirmDownload(solarFluxFile, nullptr, 1))
         {
             QString urlString = QString("http://www.sws.bom.gov.au/Category/World Data Centre/Data Display and Download/Solar Radio/station/learmonth/SRD/%1/L%2.SRD")
                                     .arg(today.year()).arg(today.toString("yyMMdd"));


### PR DESCRIPTION
As per the mailing list, Star Tracker was failing to compile on PI4. This appears to be due to gcc using an insane amount of memory when compiling the resource files. So I've split them in to several resource files. I don't have a PI to test, but uses ~75% less RAM on x64.
