### PR TITLE
File Input source filename settings

### DIFF
--- a/plugins/samplesource/fileinput/fileinput.h
+++ b/plugins/samplesource/fileinput/fileinput.h
@@ -336,7 +336,6 @@ public:
 	FileInputWorker* m_fileInputWorker;
 	QThread m_fileInputWorkerThread;
 	QString m_deviceDescription;
-	QString m_fileName;
 	int m_sampleRate;
 	quint32 m_sampleSize;
 	quint64 m_centerFrequency;

--- a/plugins/samplesource/fileinput/fileinputgui.cpp
+++ b/plugins/samplesource/fileinput/fileinputgui.cpp
@@ -46,7 +46,6 @@ FileInputGUI::FileInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 	m_doApplySettings(true),
 	m_sampleSource(0),
 	m_acquisition(false),
-	m_fileName("..."),
 	m_sampleRate(0),
 	m_centerFrequency(0),
 	m_recordLengthMuSec(0),
@@ -59,7 +58,6 @@ FileInputGUI::FileInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 	ui->setupUi(this);
 	ui->centerFrequency->setColorMapper(ColorMapper(ColorMapper::GrayGold));
 	ui->centerFrequency->setValueRange(7, 0, pow(10,7));
-	ui->fileNameText->setText(m_fileName);
 	ui->crcLabel->setStyleSheet("QLabel { background:rgb(79,79,79); }");
 
 	connect(&(m_deviceUISet->m_deviceAPI->getMasterTimer()), SIGNAL(timeout()), this, SLOT(tick()));
@@ -221,6 +219,12 @@ void FileInputGUI::displaySettings()
     blockApplySettings(true);
     ui->playLoop->setChecked(m_settings.m_loop);
     ui->acceleration->setCurrentIndex(FileInputSettings::getAccelerationIndex(m_settings.m_accelerationFactor));
+    if (!m_settings.m_fileName.isEmpty() && (m_settings.m_fileName != ui->fileNameText->text()))
+    {
+	ui->crcLabel->setStyleSheet("QLabel { background:rgb(79,79,79); }");
+	configureFileName();
+    }
+    ui->fileNameText->setText(m_settings.m_fileName);
     blockApplySettings(false);
 }
 
@@ -302,8 +306,8 @@ void FileInputGUI::on_showFileDialog_clicked(bool checked)
 
 	if (fileName != "")
 	{
-		m_fileName = fileName;
-		ui->fileNameText->setText(m_fileName);
+		m_settings.m_fileName = fileName;
+		ui->fileNameText->setText(m_settings.m_fileName);
 		ui->crcLabel->setStyleSheet("QLabel { background:rgb(79,79,79); }");
 		configureFileName();
 	}
@@ -321,8 +325,8 @@ void FileInputGUI::on_acceleration_currentIndexChanged(int index)
 
 void FileInputGUI::configureFileName()
 {
-	qDebug() << "FileInputGUI::configureFileName: " << m_fileName.toStdString().c_str();
-	FileInput::MsgConfigureFileSourceName* message = FileInput::MsgConfigureFileSourceName::create(m_fileName);
+	qDebug() << "FileInputGUI::configureFileName: " << m_settings.m_fileName.toStdString().c_str();
+	FileInput::MsgConfigureFileSourceName* message = FileInput::MsgConfigureFileSourceName::create(m_settings.m_fileName);
 	m_sampleSource->getInputMessageQueue()->push(message);
 }
 

--- a/plugins/samplesource/fileinput/fileinputgui.h
+++ b/plugins/samplesource/fileinput/fileinputgui.h
@@ -57,7 +57,6 @@ private:
 	std::vector<int> m_gains;
 	DeviceSampleSource* m_sampleSource;
     bool m_acquisition;
-    QString m_fileName;
 	int m_sampleRate;
 	quint32 m_sampleSize;
 	quint64 m_centerFrequency;

--- a/plugins/samplesource/fileinput/fileinputsettings.cpp
+++ b/plugins/samplesource/fileinput/fileinputsettings.cpp
@@ -15,6 +15,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.          //
 ///////////////////////////////////////////////////////////////////////////////////
 
+#include <QDebug>
 #include "util/simpleserializer.h"
 
 #include "fileinputsettings.h"
@@ -28,7 +29,7 @@ FileInputSettings::FileInputSettings()
 
 void FileInputSettings::resetToDefaults()
 {
-    m_fileName = "./test.sdriq";
+    m_fileName = "";
     m_accelerationFactor = 1;
     m_loop = true;
     m_useReverseAPI = false;
@@ -64,7 +65,7 @@ bool FileInputSettings::deserialize(const QByteArray& data)
     {
         uint32_t uintval;
 
-        d.readString(1, &m_fileName, "./test.sdriq");
+        d.readString(1, &m_fileName, "");
         d.readU32(2, &m_accelerationFactor, 1);
         d.readBool(3, &m_loop, true);
         d.readBool(4, &m_useReverseAPI, false);


### PR DESCRIPTION
This patch:

- Allows the filename for the file input source to be restored from settings
- Allows the filename to be set via the API

For testing, I quite often replay data from files, so saves a bit of time having the last file automatically opened. There was already an entry in the settings structure, but wasn't being used.