### PR TITLE
sdriq sample rate can be zero

### DIFF
--- a/plugins/samplesource/fileinput/fileinput.cpp
+++ b/plugins/samplesource/fileinput/fileinput.cpp
@@ -110,14 +110,19 @@ void FileInput::openFileStream()
 		m_sampleSize = header.sampleSize;
 		QString crcHex = QString("%1").arg(header.crc32 , 0, 16);
 
-	    if (crcOK)
+	    if (crcOK && (m_sampleRate > 0) && (m_sampleSize > 0))
 	    {
 	        qDebug("FileInput::openFileStream: CRC32 OK for header: %s", qPrintable(crcHex));
 	        m_recordLengthMuSec = ((fileSize - sizeof(FileRecord::Header)) * 1000000UL) / ((m_sampleSize == 24 ? 8 : 4) * m_sampleRate);
 	    }
-	    else
+	    else if (!crcOK)
 	    {
 	        qCritical("FileInput::openFileStream: bad CRC32 for header: %s", qPrintable(crcHex));
+	        m_recordLengthMuSec = 0;
+	    }
+            else
+	    {
+	        qCritical("FileInput::openFileStream: invalid header");
 	        m_recordLengthMuSec = 0;
 	    }
 

--- a/sdrbase/dsp/filerecord.cpp
+++ b/sdrbase/dsp/filerecord.cpp
@@ -156,6 +156,7 @@ bool FileRecord::handleMessage(const Message& message)
 {
 	if (DSPSignalNotification::match(message))
 	{
+        QMutexLocker mutexLocker(&m_mutex);
 		DSPSignalNotification& notif = (DSPSignalNotification&) message;
 		quint32 sampleRate = notif.getSampleRate();
 		qint64 centerFrequency = notif.getCenterFrequency();


### PR DESCRIPTION
When opening a sdriq file created by the file sink, that had been started by the satellite tracker, SDRangel was crashing. The CRC was valid, but the samplerate in the file was 0.

The crash was due to a divide by 0 - and the first commit now checks for that.

I think the reason that the samplerate in the sdriq file was written as zero, is probably due to a race condition, whereby feed() is being called around the same time as handleMessage() which sets the sample rate.

To help, I've added a lock of the mutex in handleMessage and also add a 1 second delay after the preset is loaded before the file sinks start recording. I don't think that's perfect, but it's a bit better.
 
