### PR TITLE
hackrfinput - Add auto bandpass filter selection

### DIFF
--- a/plugins/samplesource/hackrfinput/hackrfinput.cpp
+++ b/plugins/samplesource/hackrfinput/hackrfinput.cpp
@@ -375,6 +375,12 @@ bool HackRFInput::applySettings(const HackRFInputSettings& settings, bool force)
 	                qDebug("HackRFInput::applySettings: sample rate set to %llu S/s", settings.m_devSampleRate);
 	                m_hackRFThread->setSamplerate(settings.m_devSampleRate);
 			    }
+    			rc = (hackrf_error) hackrf_set_baseband_filter_bandwidth(m_dev, m_settings.m_bandwidth); // restore baseband bandwidth filter. libhackrf automatically sets baseband filter when sample rate is set.
+				if (rc != HACKRF_SUCCESS) {
+					qDebug("HackRFInput::applySettings: Restore baseband filter failed: %s", hackrf_error_name(rc));
+				} else {
+					qDebug() << "HackRFInput:applySettings: Baseband BW filter restored to " << m_settings.m_bandwidth << " Hz";
+				}
 			}
 		}
 	}

--- a/plugins/samplesource/hackrfinput/hackrfinputgui.h
+++ b/plugins/samplesource/hackrfinput/hackrfinputgui.h
@@ -88,6 +88,7 @@ private slots:
 	void on_LOppm_valueChanged(int value);
 	void on_dcOffset_toggled(bool checked);
 	void on_iqImbalance_toggled(bool checked);
+	void on_autoBBF_toggled(bool checked);
 	void on_biasT_stateChanged(int state);
 	void on_decim_currentIndexChanged(int index);
 	void on_fcPos_currentIndexChanged(int index);

--- a/plugins/samplesource/hackrfinput/hackrfinputgui.ui
+++ b/plugins/samplesource/hackrfinput/hackrfinputgui.ui
@@ -215,6 +215,13 @@
      <property name="bottomMargin">
       <number>2</number>
      </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="corrLabel">
+       <property name="text">
+        <string>Auto</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
       <widget class="ButtonSwitch" name="dcOffset">
        <property name="toolTip">
@@ -235,40 +242,17 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="corrLabel">
+     <item row="0" column="3">
+       <widget class="ButtonSwitch" name="autoBBF">
+       <property name="toolTip">
+        <string>Bandpass Filter auto select</string>
+       </property>
        <property name="text">
-        <string>Auto</string>
+        <string>BBF</string>
        </property>
       </widget>
      </item>
      <item row="0" column="4">
-      <widget class="QCheckBox" name="biasT">
-       <property name="toolTip">
-        <string>Activate antenna bias tee</string>
-       </property>
-       <property name="layoutDirection">
-        <enum>Qt::RightToLeft</enum>
-       </property>
-       <property name="text">
-        <string>Bias T</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="5">
-      <widget class="QCheckBox" name="lnaExt">
-       <property name="toolTip">
-        <string>Extra LNA +14dB</string>
-       </property>
-       <property name="layoutDirection">
-        <enum>Qt::RightToLeft</enum>
-       </property>
-       <property name="text">
-        <string>RF Amp</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -281,7 +265,33 @@
        </property>
       </spacer>
      </item>
+     <item row="0" column="5">
+      <widget class="QCheckBox" name="biasT">
+       <property name="toolTip">
+        <string>Activate antenna bias tee</string>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::RightToLeft</enum>
+       </property>
+       <property name="text">
+        <string>Bias T</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="6">
+      <widget class="QCheckBox" name="lnaExt">
+       <property name="toolTip">
+        <string>Extra LNA +14dB</string>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::RightToLeft</enum>
+       </property>
+       <property name="text">
+        <string>RF Amp</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="7">
       <widget class="TransverterButton" name="transverter">
        <property name="maximumSize">
         <size>

--- a/plugins/samplesource/hackrfinput/hackrfinputsettings.cpp
+++ b/plugins/samplesource/hackrfinput/hackrfinputsettings.cpp
@@ -39,6 +39,7 @@ void HackRFInputSettings::resetToDefaults()
 	m_vgaGain = 16;
 	m_dcBlock = false;
 	m_iqCorrection = false;
+	m_autoBBF = true;
 	m_devSampleRate = 2400000;
     m_transverterMode = false;
 	m_transverterDeltaFrequency = 0;
@@ -71,6 +72,7 @@ QByteArray HackRFInputSettings::serialize() const
     s.writeBool(18, m_transverterMode);
     s.writeS64(19, m_transverterDeltaFrequency);
     s.writeBool(20, m_iqOrder);
+    s.writeBool(21, m_autoBBF);
 
 	return s.final();
 }
@@ -117,6 +119,7 @@ bool HackRFInputSettings::deserialize(const QByteArray& data)
         d.readBool(18, &m_transverterMode, false);
         d.readS64(19, &m_transverterDeltaFrequency, 0);
         d.readBool(20, &m_iqOrder, true);
+        d.readBool(21, &m_autoBBF, true);
 
 		return true;
 	}

--- a/plugins/samplesource/hackrfinput/hackrfinputsettings.h
+++ b/plugins/samplesource/hackrfinput/hackrfinputsettings.h
@@ -40,6 +40,7 @@ struct HackRFInputSettings {
 	bool m_lnaExt;
 	bool m_dcBlock;
 	bool m_iqCorrection;
+	bool m_autoBBF;
     bool   m_transverterMode;
 	qint64 m_transverterDeltaFrequency;
     bool m_iqOrder;

--- a/plugins/samplesource/hackrfinput/readme.md
+++ b/plugins/samplesource/hackrfinput/readme.md
@@ -44,6 +44,7 @@ These buttons control the local DSP auto correction options:
 
   - **DC**: auto remove DC component
   - **IQ**: auto make I/Q balance. The DC correction must be enabled for this to be effective.
+  - **BBF**: auto select bandpass filter setting. Compute best value depending on sample rate.
 
 <h3>4: Bias tee</h3>
 


### PR DESCRIPTION
libhackrf automatically sets bandpass filter every time the sample rate is set. This was causing a settings mismatch between gui and hardware. I made a change to force the current gui setting as hardware setting when sample rate is set.

It would probably be better if libhackrf would optionally apply auto setting and report bandwidth set. However, as far as I can tell it just forces it with no ability to report. It also seems like this change to SDRangel would get approved faster than a change to libhackrf.

I also implemented a button to enable auto bandpass filter selection. This matches the setting that libhackrf was applying.