### PR TITLE
hackrfinput - Change LO ppm to adjust the hardware clocks.

### DIFF
--- a/plugins/samplesource/hackrfinput/hackrfinput.h
+++ b/plugins/samplesource/hackrfinput/hackrfinput.h
@@ -159,7 +159,7 @@ private:
     bool openDevice();
     void closeDevice();
 	bool applySettings(const HackRFInputSettings& settings, bool force);
-	void setDeviceCenterFrequency(quint64 freq, qint32 LOppmTenths);
+	void setDeviceCenterFrequency(quint64 freq);
     void webapiReverseSendSettings(QList<QString>& deviceSettingsKeys, const HackRFInputSettings& settings, bool force);
     void webapiReverseSendStartStop(bool start);
 


### PR DESCRIPTION
LO ppm now adjusts the primary clock in the hackrf one instead of offsetting the freq in software. The offset adjusts all clocks except the CPU which currently uses it's own crystal.
There is room for improvement but I tried to keep it simple and keep the user interface the same for now.