### PR TITLE
Avoid divide by 0 if symbol rate is 0.

### DIFF
--- a/plugins/channeltx/moddatv/datvmodgui.ui
+++ b/plugins/channeltx/moddatv/datvmodgui.ui
@@ -272,6 +272,9 @@
         <property name="toolTip">
          <string>Symbol rate</string>
         </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
         <property name="maximum">
          <number>10000000</number>
         </property>


### PR DESCRIPTION
Fix for #849.