### PR TITLE
Use latest DAB lib API.

### DIFF
--- a/plugins/channelrx/demoddab/dabdemod.h
+++ b/plugins/channelrx/demoddab/dabdemod.h
@@ -254,20 +254,23 @@ public:
         MESSAGE_CLASS_DECLARATION
 
     public:
+        QByteArray getData() const { return m_data; }
         const QString getFilename() const { return m_filename; }
         int getContentSubType() const { return m_contentSubType; }
 
-        static MsgDABMOTData* create(const QString& filename, int contentSubType)
+        static MsgDABMOTData* create(QByteArray data, const QString& filename, int contentSubType)
         {
-            return new MsgDABMOTData(filename, contentSubType);
+            return new MsgDABMOTData(data, filename, contentSubType);
         }
 
     private:
+        QByteArray m_data;
         QString m_filename;
         int m_contentSubType;
 
-        MsgDABMOTData(const QString& filename, int contentSubType) :
+        MsgDABMOTData(QByteArray data, const QString& filename, int contentSubType) :
             Message(),
+            m_data(data),
             m_filename(filename),
             m_contentSubType(contentSubType)
         { }

--- a/plugins/channelrx/demoddab/dabdemodgui.cpp
+++ b/plugins/channelrx/demoddab/dabdemodgui.cpp
@@ -253,7 +253,6 @@ bool DABDemodGUI::handleMessage(const Message& message)
     else if (DABDemod::MsgDABSampleRate::match(message))
     {
         DABDemod::MsgDABSampleRate& report = (DABDemod::MsgDABSampleRate&) message;
-        qDebug() << "Ssample rate: " << report.getSampleRate();
         ui->sampleRate->setText(QString("%1k").arg(report.getSampleRate()/1000.0, 0, 'f', 0));
         return true;
     }
@@ -266,11 +265,16 @@ bool DABDemodGUI::handleMessage(const Message& message)
     else if (DABDemod::MsgDABMOTData::match(message))
     {
         DABDemod::MsgDABMOTData& report = (DABDemod::MsgDABMOTData&) message;
-        QPixmap pixmap(report.getFilename());
-        ui->motImage->resize(ui->motImage->width(), pixmap.height());
-        ui->motImage->setVisible(true);
-        ui->motImage->setPixmap(pixmap, pixmap.size());
-        arrangeRollups();
+        QString filename = report.getFilename();
+        if (filename.endsWith(".png") || filename.endsWith(".PNG") || filename.endsWith(".jpg") || filename.endsWith(".JPG"))
+        {
+            QPixmap pixmap;
+            pixmap.loadFromData(report.getData());
+            ui->motImage->resize(ui->motImage->width(), pixmap.height());
+            ui->motImage->setVisible(true);
+            ui->motImage->setPixmap(pixmap, pixmap.size());
+            arrangeRollups();
+        }
         return true;
     }
 

--- a/plugins/channelrx/demoddab/dabdemodsink.h
+++ b/plugins/channelrx/demoddab/dabdemodsink.h
@@ -89,7 +89,7 @@ public:
     void programQuality(int16_t frames, int16_t rs, int16_t aac);
     void fibQuality(int16_t percent);
     void data(const QString& data);
-    void motData(const QString& filename, int contentSubType);
+    void motData(const uint8_t *data, int len, const QString& filename, int contentSubType);
 
 private:
     struct MagSqLevelsStore
@@ -114,6 +114,8 @@ private:
     void *m_dab;
     DABDemodDevice m_device;
     audiodata m_ad;
+    packetdata m_pd;
+    API_struct m_api;
 
     NCO m_nco;
     Interpolator m_interpolator;


### PR DESCRIPTION
This no longer writes MOT files to disk. There was problem with this when the broadcast filename contained a sub-directory. 

Note, this requires latest version of DAB lib on: https://github.com/srcejon/dab-cmdline.git

This may fix the last issue reported on #853 (at least it does for the .sdriq file provided).
