### PR TITLE
Stop UDP forwarded AIS packets containing null byte from being truncated

### DIFF
--- a/plugins/channelrx/demodais/aisdemod.cpp
+++ b/plugins/channelrx/demodais/aisdemod.cpp
@@ -171,7 +171,7 @@ bool AISDemod::handleMessage(const Message& cmd)
             }
             else
             {
-                QString nmea = AISMessage::toNMEA(report.getMessage().data());
+                QString nmea = AISMessage::toNMEA(report.getMessage());
                 QByteArray bytes = nmea.toLatin1();
                 m_udpSocket.writeDatagram(bytes.data(), bytes.size(),
                                           QHostAddress(m_settings.m_udpAddress), m_settings.m_udpPort);

--- a/sdrbase/util/ais.cpp
+++ b/sdrbase/util/ais.cpp
@@ -32,7 +32,7 @@ QString AISMessage::toHex()
 }
 
 // See: https://gpsd.gitlab.io/gpsd/AIVDM.html
-QString AISMessage::toNMEA(QByteArray bytes)
+QString AISMessage::toNMEA(const QByteArray bytes)
 {
     QStringList nmeaSentences;
 


### PR DESCRIPTION
As per #903