### PR TITLE
Use shared_ptr to keep track of DeviceScan across multiple collections

### DIFF
--- a/devices/plutosdr/deviceplutosdrscan.cpp
+++ b/devices/plutosdr/deviceplutosdrscan.cpp
@@ -70,9 +70,9 @@ void DevicePlutoSDRScan::scan()
             // managed pointer, as to keep track of when it's safe to delete.
             std::shared_ptr<DeviceScan> dev_scan = std::make_shared<DeviceScan>(
                 DeviceScan({
-                    .m_name = std::string(description),
-                    .m_serial = std::string("TBD"),
-                    .m_uri = std::string(uri)
+                    std::string(description),
+                    std::string("TBD"),
+                    std::string(uri)
                 }));
             m_scans.push_back(dev_scan);
             m_urilMap[m_scans.back()->m_uri] = m_scans.back();

--- a/devices/plutosdr/deviceplutosdrscan.h
+++ b/devices/plutosdr/deviceplutosdrscan.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <memory>
 
 #include "plugin/plugininterface.h"
 #include "export.h"
@@ -46,9 +47,9 @@ public:
     void enumOriginDevices(const QString& hardwareId, PluginInterface::OriginDevices& originDevices);
 
 private:
-    std::vector<DeviceScan> m_scans;
-    std::map<std::string, DeviceScan*> m_serialMap;
-    std::map<std::string, DeviceScan*> m_urilMap;
+    std::vector<std::shared_ptr<DeviceScan>> m_scans;
+    std::map<std::string, std::shared_ptr<DeviceScan>> m_serialMap;
+    std::map<std::string, std::shared_ptr<DeviceScan>> m_urilMap;
 };
 
 


### PR DESCRIPTION
Fixes #681.

Relying on memory allocated by `std::vector` via direct pointers is dangerous, as vectors may move buffers during resize. This fix puts the `DeviceScan` allocation into a `str::shared_ptr`, which 1) allocates the memory on heap and 2) keeps track of the memory through reference counting. Thus it is safe to store the `shared_ptr` across different vectors/maps.