### PR TITLE
Delete ADSBDemod::m_worker after removing sink from DSP

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemod.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemod.cpp
@@ -83,11 +83,11 @@ ADSBDemod::~ADSBDemod()
     if (m_worker->isRunning()) {
         stop();
     }
-    delete m_worker;
     disconnect(m_networkManager, SIGNAL(finished(QNetworkReply*)), this, SLOT(networkManagerFinished(QNetworkReply*)));
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
     m_deviceAPI->removeChannelSink(this);
+    delete m_worker;
     delete m_basebandSink;
     delete m_thread;
 }


### PR DESCRIPTION
Fixes #915.

As described in the issue, during deconstruction of [`ADSBDemod`](https://github.com/f4exb/sdrangel/blob/3e9b4a4dee67dd37a9bcdd90c00c5141550c189d/plugins/channelrx/demodadsb/adsbdemod.cpp#L81) a segmentation fault might occur, if `DSPDeviceSourceEngine` calls [`sink->stop()`](https://github.com/f4exb/sdrangel/blob/3e9b4a4dee67dd37a9bcdd90c00c5141550c189d/sdrbase/dsp/dspdevicesourceengine.cpp#L596) _after_ `m_worker` was deleted.

This PR fixes the issue by deleting `m_worker` only after [`m_deviceAPI->removeChannelSink(this)`](https://github.com/f4exb/sdrangel/blob/3e9b4a4dee67dd37a9bcdd90c00c5141550c189d/plugins/channelrx/demodadsb/adsbdemod.cpp#L90) is called. This call would otherwise invoke `sink->stop()` with a broken `m_worker` somewhere down the line.