### PR TITLE
Save and restore main window position and size

### DIFF
--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -271,8 +271,8 @@ MainWindow::MainWindow(qtwebapp::LoggerWithFile *logger, const MainParser& parse
 
     // Restore window size and position
     QSettings s;
-    restoreGeometry(s.value("mainWindowGeometry").toByteArray());
-    restoreState(s.value("mainWindowState").toByteArray());
+    restoreGeometry(qUncompress(QByteArray::fromBase64(s.value("mainWindowGeometry").toByteArray())));
+    restoreState(qUncompress(QByteArray::fromBase64(s.value("mainWindowState").toByteArray())));
 
     qDebug() << "MainWindow::MainWindow: end";
 }
@@ -856,9 +856,10 @@ void MainWindow::closeEvent(QCloseEvent *closeEvent)
     qDebug("MainWindow::closeEvent");
 
     // Save window size and position
+    // Need to use base64, as it seems binary values aren't saved on Linux
     QSettings s;
-    s.setValue("mainWindowGeometry", saveGeometry());
-    s.setValue("mainWindowState", saveState());
+    s.setValue("mainWindowGeometry", qCompress(saveGeometry()).toBase64());
+    s.setValue("mainWindowState", qCompress(saveState()).toBase64());
 
     savePresetSettings(m_mainCore->m_settings.getWorkingPreset(), 0);
     saveFeatureSetPresetSettings(m_mainCore->m_settings.getWorkingFeatureSetPreset(), 0);

--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -856,7 +856,6 @@ void MainWindow::closeEvent(QCloseEvent *closeEvent)
     qDebug("MainWindow::closeEvent");
 
     // Save window size and position
-    // Need to use base64, as it seems binary values aren't saved on Linux
     QSettings s;
     s.setValue("mainWindowGeometry", qCompress(saveGeometry()).toBase64());
     s.setValue("mainWindowState", qCompress(saveState()).toBase64());

--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -269,6 +269,11 @@ MainWindow::MainWindow(qtwebapp::LoggerWithFile *logger, const MainParser& parse
 
     delete splash;
 
+    // Restore window size and position
+    QSettings s;
+    restoreGeometry(s.value("mainWindowGeometry").toByteArray());
+    restoreState(s.value("mainWindowState").toByteArray());
+
     qDebug() << "MainWindow::MainWindow: end";
 }
 
@@ -849,6 +854,11 @@ void MainWindow::createStatusBar()
 void MainWindow::closeEvent(QCloseEvent *closeEvent)
 {
     qDebug("MainWindow::closeEvent");
+
+    // Save window size and position
+    QSettings s;
+    s.setValue("mainWindowGeometry", saveGeometry());
+    s.setValue("mainWindowState", saveState());
 
     savePresetSettings(m_mainCore->m_settings.getWorkingPreset(), 0);
     saveFeatureSetPresetSettings(m_mainCore->m_settings.getWorkingFeatureSetPreset(), 0);


### PR DESCRIPTION
This patch saves and restores the main window position and size between invocations of SDRangel. Fixes #89
