### PR TITLE
Add SatelliteTracker to webapirequestmapper to partially fix #948

### DIFF
--- a/plugins/feature/satellitetracker/readme.md
+++ b/plugins/feature/satellitetracker/readme.md
@@ -197,3 +197,13 @@ SatNogs satellite database https://db.satnogs.org/
 Satellite two-line elements (TLEs) are from Celestrak https://celestrak.com/
 
 Icons are by Freepik from Flaticon https://www.flaticon.com/
+
+<h2>API</h2>
+
+Full details of the API can be found in the Swagger documentation. Here is a quick example of how to set the satellites to track:
+
+    curl -X PATCH "http://127.0.0.1:8091/sdrangel/featureset/0/feature/0/settings" -d '{"featureType": "SatelliteTracker",  "SatelliteTrackerSettings": { "satellites": [ "NOAA 15", "NOAA 19" ] }}'
+
+And how to set the target:
+
+    curl -X PATCH "http://127.0.0.1:8091/sdrangel/featureset/0/feature/0/settings" -d '{"featureType": "SatelliteTracker",  "SatelliteTrackerSettings": { "target": "NOAA 15"  }}'

--- a/sdrbase/webapi/webapirequestmapper.cpp
+++ b/sdrbase/webapi/webapirequestmapper.cpp
@@ -4465,6 +4465,11 @@ bool WebAPIRequestMapper::getFeatureSettings(
             featureSettings->setPerTesterSettings(new SWGSDRangel::SWGPERTesterSettings());
             featureSettings->getPerTesterSettings()->fromJsonObject(settingsJsonObject);
         }
+        else if (featureSettingsKey == "SatelliteTrackerSettings")
+        {
+            featureSettings->setSatelliteTrackerSettings(new SWGSDRangel::SWGSatelliteTrackerSettings());
+            featureSettings->getSatelliteTrackerSettings()->fromJsonObject(settingsJsonObject);
+        }
         else if (featureSettingsKey == "SimplePTTSettings")
         {
             featureSettings->setSimplePttSettings(new SWGSDRangel::SWGSimplePTTSettings());
@@ -4723,6 +4728,7 @@ void WebAPIRequestMapper::resetFeatureSettings(SWGSDRangel::SWGFeatureSettings& 
     featureSettings.setGs232ControllerSettings(nullptr);
     featureSettings.setMapSettings(nullptr);
     featureSettings.setPerTesterSettings(nullptr);
+    featureSettings.setSatelliteTrackerSettings(nullptr);
     featureSettings.setSimplePttSettings(nullptr);
     featureSettings.setStarTrackerSettings(nullptr);
     featureSettings.setRigCtlServerSettings(nullptr);

--- a/sdrbase/webapi/webapiutils.cpp
+++ b/sdrbase/webapi/webapiutils.cpp
@@ -265,6 +265,7 @@ const QMap<QString, QString> WebAPIUtils::m_featureTypeToSettingsKey = {
     {"GS232Controller", "GS232ControllerSettings"},
     {"Map", "MapSettings"},
     {"PERTester", "PERTesterSettings"},
+    {"SatelliteTracker", "SatelliteTrackerSettings"},
     {"SimplePTT", "SimplePTTSettings"},
     {"StarTracker", "StarTrackerSettings"},
     {"RigCtlServer", "RigCtlServerSettings"}
@@ -282,6 +283,7 @@ const QMap<QString, QString> WebAPIUtils::m_featureURIToSettingsKey = {
     {"sdrangel.feature.gs232controller", "GS232ControllerSettings"},
     {"sdrangel.feature.map", "MapSettings"},
     {"sdrangel.feature.pertester", "PERTesterSettings"},
+    {"sdrangel.feature.satellitetracker", "SatelliteTrackerSettings"},
     {"sdrangel.feature.simpleptt", "SimplePTTSettings"},
     {"sdrangel.feature.startracker", "StarTrackerSettings"},
     {"sdrangel.feature.rigctlserver", "RigCtlServerSettings"}


### PR DESCRIPTION
Add SatelliteTracker to webapirequestmapper to partially fix #948

This allows basic settings to be set, i.e. target satellite, but it seems there's a null pointer exception when trying to set "satellites" which uses a string array.