### PR TITLE
Satellite Tracker: Fix for #893

### DIFF
--- a/plugins/feature/satellitetracker/satellitetracker.cpp
+++ b/plugins/feature/satellitetracker/satellitetracker.cpp
@@ -990,3 +990,19 @@ void SatelliteTracker::updateSatData()
     else
         qDebug() << "SatelliteTracker::updateSatData: update in progress";
 }
+
+// Redirect requests for current time via these methods, so it can be adjusted when testing
+
+QDateTime SatelliteTracker::currentDateTimeUtc()
+{
+    QDateTime now = QDateTime::currentDateTimeUtc();
+    //now = now.addSecs(26*60);
+    return now;
+}
+
+QDateTime SatelliteTracker::currentDateTime()
+{
+    QDateTime now = QDateTime::currentDateTime();
+    //now = now.addSecs(26*60);
+    return now;
+}

--- a/plugins/feature/satellitetracker/satellitetracker.h
+++ b/plugins/feature/satellitetracker/satellitetracker.h
@@ -153,6 +153,9 @@ public:
             const QStringList& featureSettingsKeys,
             SWGSDRangel::SWGFeatureSettings& response);
 
+    static QDateTime currentDateTimeUtc();
+    static QDateTime currentDateTime();
+
     static const char* const m_featureIdURI;
     static const char* const m_featureId;
 

--- a/plugins/feature/satellitetracker/satellitetrackergui.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackergui.cpp
@@ -263,7 +263,7 @@ SatelliteTrackerGUI::SatelliteTrackerGUI(PluginAPI* pluginAPI, FeatureUISet *fea
     ui->passChart->setChart(&m_emptyChart);
     ui->passChart->setRenderHint(QPainter::Antialiasing);
 
-    ui->dateTime->setDateTime(QDateTime::currentDateTime());
+    ui->dateTime->setDateTime(SatelliteTracker::currentDateTime());
 
     // Use My Position from preferences, if none set
     if ((m_settings.m_latitude == 0.0) && (m_settings.m_longitude == 0.0))
@@ -595,7 +595,7 @@ void SatelliteTrackerGUI::updateTimeToAOS()
         ui->aos->setText("Now");
     else if (m_nextTargetAOS.isValid())
     {
-        QDateTime currentTime = QDateTime::currentDateTime();
+        QDateTime currentTime = SatelliteTracker::currentDateTime();
         int secondsToAOS = m_nextTargetAOS.toSecsSinceEpoch() - currentTime.toSecsSinceEpoch();
         if (secondsToAOS > 0)
         {
@@ -824,7 +824,7 @@ void SatelliteTrackerGUI::plotPolarChart()
 
         QDateTime currentTime;
         if (m_settings.m_dateTime == "")
-            currentTime = QDateTime::currentDateTimeUtc();
+            currentTime = SatelliteTracker::currentDateTimeUtc();
         else if (m_settings.m_utc)
             currentTime = QDateTime::fromString(m_settings.m_dateTime, Qt::ISODateWithMs);
         else
@@ -854,7 +854,7 @@ void SatelliteTrackerGUI::plotPolarChart()
         // Possibly geostationary, just plot current position
         QDateTime currentTime;
         if (m_settings.m_dateTime == "")
-            currentTime = QDateTime::currentDateTimeUtc();
+            currentTime = SatelliteTracker::currentDateTimeUtc();
         else if (m_settings.m_utc)
             currentTime = QDateTime::fromString(m_settings.m_dateTime, Qt::ISODateWithMs);
         else

--- a/plugins/feature/satellitetracker/satellitetrackerworker.h
+++ b/plugins/feature/satellitetracker/satellitetrackerworker.h
@@ -48,11 +48,7 @@ public:
         m_satState.m_name = name;
     }
 
-    bool hasAOS()
-    {
-        QDateTime currentTime = QDateTime::currentDateTime();
-        return (m_aos <= currentTime) && (m_los > currentTime);
-    }
+    bool hasAOS();
 
 protected:
     QString m_name;             // Name of the satellite


### PR DESCRIPTION
Hopefully fix #893.

Ensure LOS is signalled even if new AOS is calculated 1second before LOS.
Redirect calls to get the time via a functions in SatelliteTracker, so it can easily be adjusted for testing.
Delete some obsolete code.