### PR TITLE
Pager: Add extra Hebrew characters. 

### DIFF
--- a/plugins/channelrx/demodpager/pagerdemodcharsetdialog.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodcharsetdialog.cpp
@@ -29,7 +29,7 @@ PagerDemodCharsetDialog::PagerDemodCharsetDialog(PagerDemodSettings *settings,
     if (settings->m_sevenbit.size() > 0) {
         ui->preset->setCurrentIndex(2); // User
     }
-    ui->readingOrder->setCurrentIndex(settings->m_rightToLeft ? 1 : 0);
+    ui->reverse->setChecked(settings->m_reverse);
     for (int i = 0; i < settings->m_sevenbit.size(); i++) {
         addRow(settings->m_sevenbit[i], settings->m_unicode[i]);
     }
@@ -52,7 +52,7 @@ void PagerDemodCharsetDialog::accept()
         m_settings->m_sevenbit.append(sevenbit);
         m_settings->m_unicode.append(unicode);
     }
-    m_settings->m_rightToLeft = ui->readingOrder->currentIndex() == 1;
+    m_settings->m_reverse = ui->reverse->isChecked();
     QDialog::accept();
 }
 
@@ -74,14 +74,15 @@ void PagerDemodCharsetDialog::on_remove_clicked()
 void PagerDemodCharsetDialog::on_preset_currentIndexChanged(int index)
 {
     ui->table->setRowCount(0);
-    ui->readingOrder->setCurrentIndex(0);
+    ui->reverse->setChecked(false);
     if (index == 1)
     {
         // Hebrew
-        for (int i = 0; i < 22; i++) {
+        for (int i = 0; i < 22+5; i++) {
             addRow(96 + i, 0x05D0 + i);
         }
-        ui->readingOrder->setCurrentIndex(1);
+        // Even though Hebrew is right-to-left, it seems characters are
+        // transmitted last first, so no need to check reverse
     }
 }
 

--- a/plugins/channelrx/demodpager/pagerdemodcharsetdialog.ui
+++ b/plugins/channelrx/demodpager/pagerdemodcharsetdialog.ui
@@ -65,33 +65,13 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="readingOrderLabel">
-       <property name="text">
-        <string>Reading Order</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="readingOrder">
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
+      <widget class="QCheckBox" name="reverse">
        <property name="toolTip">
-        <string>Specify the order in which characters should be displayed</string>
+        <string>Reverse the order of the characters received</string>
        </property>
-       <item>
-        <property name="text">
-         <string>Left-to-right</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Right-to-left</string>
-        </property>
-       </item>
+       <property name="text">
+        <string>Reverse order</string>
+       </property>
       </widget>
      </item>
     </layout>

--- a/plugins/channelrx/demodpager/pagerdemodsettings.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodsettings.cpp
@@ -52,7 +52,7 @@ void PagerDemodSettings::resetToDefaults()
     m_reverseAPIPort = 8888;
     m_reverseAPIDeviceIndex = 0;
     m_reverseAPIChannelIndex = 0;
-    m_rightToLeft = 0;
+    m_reverse = false;
 
     for (int i = 0; i < PAGERDEMOD_MESSAGE_COLUMNS; i++)
     {
@@ -88,7 +88,7 @@ QByteArray PagerDemodSettings::serialize() const
     s.writeU32(19, m_reverseAPIDeviceIndex);
     s.writeU32(20, m_reverseAPIChannelIndex);
     s.writeBlob(21, m_scopeGUI->serialize());
-    s.writeBool(22, m_rightToLeft);
+    s.writeBool(22, m_reverse);
     s.writeBlob(23, serializeIntList(m_sevenbit));
     s.writeBlob(24, serializeIntList(m_unicode));
 
@@ -160,7 +160,7 @@ bool PagerDemodSettings::deserialize(const QByteArray& data)
             d.readBlob(21, &bytetmp);
             m_scopeGUI->deserialize(bytetmp);
         }
-        d.readBool(22, &m_rightToLeft, false);
+        d.readBool(22, &m_reverse, false);
         d.readBlob(23, &blob);
         deserializeIntList(blob, m_sevenbit);
         d.readBlob(24, &blob);

--- a/plugins/channelrx/demodpager/pagerdemodsettings.h
+++ b/plugins/channelrx/demodpager/pagerdemodsettings.h
@@ -60,7 +60,7 @@ struct PagerDemodSettings
     uint16_t m_reverseAPIChannelIndex;
     Serializable *m_scopeGUI;
 
-    bool m_rightToLeft;                 //!< Whether characters are right to left or left to right
+    bool m_reverse;                 //!< Whether characters should be reversed, for right-to-left reading order
     QList<qint32> m_sevenbit;
     QList<qint32> m_unicode;
 

--- a/plugins/channelrx/demodpager/pagerdemodsink.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodsink.cpp
@@ -284,7 +284,7 @@ void PagerDemodSink::decodeBatch()
                         m_alphaMessage[i] = c;
                     }
                     // Reverse reading order, if required
-                    if (m_settings.m_rightToLeft) {
+                    if (m_settings.m_reverse) {
                         std::reverse(m_alphaMessage.begin(), m_alphaMessage.end());
                     }
                     // Send to channel and GUI


### PR DESCRIPTION
Use reverse option, instead of right-to-left, as Hebrew appears to be transmitted last first. 

As discussed in comments on PR #960 