### PR TITLE
DATV Mod: Add UDP buffer utilization in GUI on Windows

### DIFF
--- a/plugins/channeltx/moddatv/datvmod.cpp
+++ b/plugins/channeltx/moddatv/datvmod.cpp
@@ -52,6 +52,7 @@ MESSAGE_CLASS_DEFINITION(DATVMod::MsgConfigureTsFileName, Message)
 MESSAGE_CLASS_DEFINITION(DATVMod::MsgConfigureTsFileSourceSeek, Message)
 MESSAGE_CLASS_DEFINITION(DATVMod::MsgConfigureTsFileSourceStreamTiming, Message)
 MESSAGE_CLASS_DEFINITION(DATVMod::MsgGetUDPBitrate, Message)
+MESSAGE_CLASS_DEFINITION(DATVMod::MsgGetUDPBufferUtilization, Message)
 
 const char* const DATVMod::m_channelIdURI = "sdrangel.channeltx.moddatv";
 const char* const DATVMod::m_channelId = "DATVMod";
@@ -182,6 +183,12 @@ bool DATVMod::handleMessage(const Message& cmd)
     else if (MsgGetUDPBitrate::match(cmd))
     {
         m_basebandSource->getInputMessageQueue()->push(DATVMod::MsgGetUDPBitrate::create());
+
+        return true;
+    }
+    else if (MsgGetUDPBufferUtilization::match(cmd))
+    {
+        m_basebandSource->getInputMessageQueue()->push(DATVMod::MsgGetUDPBufferUtilization::create());
 
         return true;
     }

--- a/plugins/channeltx/moddatv/datvmod.h
+++ b/plugins/channeltx/moddatv/datvmod.h
@@ -181,6 +181,23 @@ public:
         { }
     };
 
+    class MsgGetUDPBufferUtilization : public Message {
+        MESSAGE_CLASS_DECLARATION
+
+    public:
+
+        static MsgGetUDPBufferUtilization* create()
+        {
+            return new MsgGetUDPBufferUtilization();
+        }
+
+    private:
+
+        MsgGetUDPBufferUtilization() :
+            Message()
+        { }
+    };
+
     //=================================================================
 
     DATVMod(DeviceAPI *deviceAPI);

--- a/plugins/channeltx/moddatv/datvmodbaseband.cpp
+++ b/plugins/channeltx/moddatv/datvmodbaseband.cpp
@@ -192,6 +192,11 @@ bool DATVModBaseband::handleMessage(const Message& cmd)
         m_source.reportUDPBitrate();
         return true;
     }
+    else if (DATVMod::MsgGetUDPBufferUtilization::match(cmd))
+    {
+        m_source.reportUDPBufferUtilization();
+        return true;
+    }
     else
     {
         return false;

--- a/plugins/channeltx/moddatv/datvmodgui.ui
+++ b/plugins/channeltx/moddatv/datvmodgui.ui
@@ -568,6 +568,23 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="Line" name="udpBufferUtilizationLine">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="udpBufferUtilization">
+        <property name="toolTip">
+         <string>Indicates how full the UDP receive buffer is. If this reaches 100%, packets will likely be dropped.</string>
+        </property>
+        <property name="text">
+         <string>0%</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </item>
     <item>

--- a/plugins/channeltx/moddatv/datvmodreport.cpp
+++ b/plugins/channeltx/moddatv/datvmodreport.cpp
@@ -22,6 +22,7 @@ MESSAGE_CLASS_DEFINITION(DATVModReport::MsgReportTsFileSourceStreamTiming, Messa
 MESSAGE_CLASS_DEFINITION(DATVModReport::MsgReportTsFileSourceStreamData, Message)
 MESSAGE_CLASS_DEFINITION(DATVModReport::MsgReportRates, Message)
 MESSAGE_CLASS_DEFINITION(DATVModReport::MsgReportUDPBitrate, Message)
+MESSAGE_CLASS_DEFINITION(DATVModReport::MsgReportUDPBufferUtilization, Message)
 
 DATVModReport::DATVModReport()
 { }

--- a/plugins/channeltx/moddatv/datvmodreport.h
+++ b/plugins/channeltx/moddatv/datvmodreport.h
@@ -125,6 +125,27 @@ public:
         { }
     };
 
+    class MsgReportUDPBufferUtilization : public Message
+    {
+        MESSAGE_CLASS_DECLARATION
+
+    public:
+        float getUtilization() const { return m_utilization; }
+
+        static MsgReportUDPBufferUtilization* create(int utilization)
+        {
+            return new MsgReportUDPBufferUtilization(utilization);
+        }
+
+    protected:
+        float m_utilization;
+
+        MsgReportUDPBufferUtilization(int utilization) :
+            Message(),
+            m_utilization(utilization)
+        { }
+    };
+
 public:
     DATVModReport();
     ~DATVModReport();

--- a/plugins/channeltx/moddatv/datvmodsettings.h
+++ b/plugins/channeltx/moddatv/datvmodsettings.h
@@ -108,6 +108,8 @@ struct DATVModSettings
     static DATVModulation mapModulation(const QString& string);
     static QString mapModulation(DATVModulation modulation);
 
+    static const int m_udpBufferSize = 5000000;
+
 };
 
 #endif /* PLUGINS_CHANNELTX_MODDATV_DATVMODSETTINGS_H_ */

--- a/plugins/channeltx/moddatv/datvmodsource.h
+++ b/plugins/channeltx/moddatv/datvmodsource.h
@@ -70,6 +70,7 @@ public:
     void seekTsFileStream(int seekPercentage);
     void reportTsFileSourceStreamTiming();
     void reportUDPBitrate();
+    void reportUDPBufferUtilization();
 
 private:
     uint8_t m_mpegTS[188];                                      //!< MPEG transport stream packet
@@ -99,6 +100,7 @@ private:
     uint8_t m_udpBuffer[188*10];
     int m_udpBufferIdx;                                         //!< TS frame index into buffer
     int m_udpBufferCount;                                       //!< Number of TS frames in buffer
+    int m_udpMaxBufferUtilization;
 
     int m_sampleRate;
     int m_channelSampleRate;
@@ -131,6 +133,7 @@ private:
     int getTSBitrate(const QString& filename);
     int getDVBSDataBitrate(const DATVModSettings& settings);
     void checkBitrates();
+    void updateUDPBufferUtilization();
 
     MessageQueue *getMessageQueueToGUI() { return m_messageQueueToGUI; }
 


### PR DESCRIPTION
Add a display of UDP receive buffer utilization to the DATV Modulator.

This only currently works on Windows, as the linux ioctl(s, SIOCINQ, &count); only seems to return size of first datagram, not all datagrams. So on Linux the GUI elements are currently hidden.

Should hopefully help with diagnosing issues such as #972 

Also increased buffer size to 5M