### PR TITLE
Higher resolution timestamp in sdriq format

### DIFF
--- a/plugins/samplesink/fileoutput/fileoutput.cpp
+++ b/plugins/samplesink/fileoutput/fileoutput.cpp
@@ -19,6 +19,7 @@
 #include <QDebug>
 #include <QNetworkReply>
 #include <QBuffer>
+#include <QDateTime>
 
 #include "SWGDeviceSettings.h"
 #include "SWGDeviceState.h"
@@ -74,8 +75,8 @@ void FileOutput::openFileStream()
 	int actualSampleRate = m_settings.m_sampleRate * (1<<m_settings.m_log2Interp);
     header.sampleRate = actualSampleRate;
     header.centerFrequency = m_settings.m_centerFrequency;
-    m_startingTimeStamp = time(0);
-    header.startTimeStamp = m_startingTimeStamp;
+    m_startingTimeStamp = QDateTime::currentMSecsSinceEpoch();
+    header.startTimeStamp = (quint64)m_startingTimeStamp;
     header.sampleSize = SDR_RX_SAMP_SZ;
 
     FileRecord::writeHeader(m_ofstream, header);

--- a/plugins/samplesink/fileoutput/fileoutput.h
+++ b/plugins/samplesink/fileoutput/fileoutput.h
@@ -233,7 +233,7 @@ private:
 	FileOutputWorker* m_fileOutputWorker;
     QThread m_fileOutputWorkerThread;
 	QString m_deviceDescription;
-	std::time_t m_startingTimeStamp;
+	qint64 m_startingTimeStamp;
 	const QTimer& m_masterTimer;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/samplesource/fileinput/fileinputgui.cpp
+++ b/plugins/samplesource/fileinput/fileinputgui.cpp
@@ -367,8 +367,8 @@ void FileInputGUI::updateWithStreamTime()
 	QString s_timems = t.toString("HH:mm:ss.zzz");
 	ui->relTimeText->setText(s_timems);
 
-    qint64 startingTimeStampMsec = m_startingTimeStamp * 1000LL;
-	QDateTime dt = QDateTime::fromMSecsSinceEpoch(startingTimeStampMsec);
+    qint64 startingTimeStampMsec = m_startingTimeStamp;
+    QDateTime dt = QDateTime::fromMSecsSinceEpoch(startingTimeStampMsec);
     dt = dt.addSecs(t_sec);
     dt = dt.addMSecs(t_msec);
 	QString s_date = dt.toString("yyyy-MM-dd HH:mm:ss.zzz");

--- a/rescuesdriq/readme.md
+++ b/rescuesdriq/readme.md
@@ -8,7 +8,7 @@ The header is composed as follows:
 
   - Sample rate in S/s (4 bytes, 32 bits)
   - Center frequency in Hz (8 bytes, 64 bits)
-  - Start time Unix timestamp epoch in seconds (8 bytes, 64 bits)
+  - Start time Unix timestamp epoch in milliseconds (8 bytes, 64 bits)
   - Sample size as 16 or 24 bits (4 bytes, 32 bits)
   - filler with all zeroes (4 bytes, 32 bits)
   - CRC32 (IEEE) of the 28 bytes above (4 bytes, 32 bits)

--- a/rescuesdriq/rescuesdriq.go
+++ b/rescuesdriq/rescuesdriq.go
@@ -71,7 +71,7 @@ func printHeader(header *HeaderStd) {
 	fmt.Println("Sample rate:", header.SampleRate)
 	fmt.Println("Frequency  :", header.CenterFrequency)
 	fmt.Println("Sample Size:", header.SampleSize)
-	tm := time.Unix(header.StartTimestamp, 0)
+	tm := time.Unix(header.StartTimestamp / 1000, header.StartTimestamp % 1000)
 	fmt.Println("Start      :", tm)
 	fmt.Println("CRC32      :", header.CRC32)
 	fmt.Println("CRC32 OK   :", GetCRC(header))
@@ -152,13 +152,13 @@ func main() {
 			if flagSeen["ts"] {
 				t, err := time.Parse(time.RFC3339, *timeStr)
 				if err == nil {
-					headerOrigin.StartTimestamp = t.Unix()
+					headerOrigin.StartTimestamp = t.UnixNano() / int64(time.Millisecond)
 				} else {
 					fmt.Println("Incorrect time specified. Defaulting to now")
-					headerOrigin.StartTimestamp = int64(time.Now().Unix())
+					headerOrigin.StartTimestamp = int64(time.Now().UnixNano() / int64(time.Millisecond))
 				}
 			} else if *timeNow {
-				headerOrigin.StartTimestamp = int64(time.Now().Unix())
+				headerOrigin.StartTimestamp = int64(time.Now().Unix() * 1000)
 			}
 
 			fmt.Println("\nHeader is now")

--- a/sdrbase/dsp/filerecord.cpp
+++ b/sdrbase/dsp/filerecord.cpp
@@ -183,8 +183,8 @@ void FileRecord::writeHeader()
     Header header;
     header.sampleRate = m_sampleRate;
     header.centerFrequency = m_centerFrequency;
-    std::time_t ts = time(0);
-    header.startTimeStamp = ts + (m_msShift / 1000);
+    qint64 ts = QDateTime::currentMSecsSinceEpoch();
+    header.startTimeStamp = (quint64)(ts + m_msShift);
     header.sampleSize = SDR_RX_SAMP_SZ;
     header.filler = 0;
 


### PR DESCRIPTION
As mentioned in #980 here's my take on increasing timestamp resolution in file-headers.

While going through the references I found some golang code for converting old sdriq files to the newer format. I tried changing that as well, but I'm not too familiar with go, so please someone vet my code.