### PR TITLE
Fix wrong start-datetime display in GUI for old file records

### DIFF
--- a/plugins/channeltx/filesource/filesource.cpp
+++ b/plugins/channeltx/filesource/filesource.cpp
@@ -471,7 +471,7 @@ void FileSource::webapiFormatChannelReport(SWGSDRangel::SWGChannelReport& respon
     qint64 t_msec = 0;
     quint64 samplesCount = m_basebandSource->getSamplesCount();
     uint32_t fileSampleRate = m_basebandSource->getFileSampleRate();
-    quint64 startingTimeStamp = m_basebandSource->getStartingTimeStamp();
+    QDateTime startingDateTime = m_basebandSource->getStartingDateTime();
     quint64 fileRecordLength = m_basebandSource->getRecordLengthMuSec() / 1000000UL;
     quint32 fileSampleSize = m_basebandSource->getFileSampleSize();
 
@@ -486,8 +486,7 @@ void FileSource::webapiFormatChannelReport(SWGSDRangel::SWGChannelReport& respon
     t = t.addMSecs(t_msec);
     response.getFileSourceReport()->setElapsedTime(new QString(t.toString("HH:mm:ss.zzz")));
 
-    qint64 startingTimeStampMsec = startingTimeStamp * 1000LL;
-    QDateTime dt = QDateTime::fromMSecsSinceEpoch(startingTimeStampMsec);
+    QDateTime dt = QDateTime(startingDateTime);
     dt = dt.addSecs(t_sec);
     dt = dt.addMSecs(t_msec);
     response.getFileSourceReport()->setAbsoluteTime(new QString(dt.toString("yyyy-MM-dd HH:mm:ss.zzz")));

--- a/plugins/channeltx/filesource/filesourcebaseband.h
+++ b/plugins/channeltx/filesource/filesourcebaseband.h
@@ -20,6 +20,7 @@
 
 #include <QObject>
 #include <QMutex>
+#include <QDateTime>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -127,7 +128,7 @@ public:
     quint64 getSamplesCount() const;
 
     uint32_t getFileSampleRate() const { return m_source.getFileSampleRate(); }
-    quint64 getStartingTimeStamp() const { return m_source.getStartingTimeStamp(); }
+    QDateTime getStartingDateTime() const { return m_source.getStartingDateTime(); }
     quint64 getRecordLengthMuSec() const { return m_source.getRecordLengthMuSec(); }
     quint32 getFileSampleSize() const { return m_source.getFileSampleSize(); }
 

--- a/plugins/channeltx/filesource/filesourcegui.cpp
+++ b/plugins/channeltx/filesource/filesourcegui.cpp
@@ -96,11 +96,11 @@ bool FileSourceGUI::handleMessage(const Message& message)
 	{
 		m_fileSampleRate = ((FileSourceReport::MsgReportFileSourceStreamData&)message).getSampleRate();
 		m_fileSampleSize = ((FileSourceReport::MsgReportFileSourceStreamData&)message).getSampleSize();
-		m_startingTimeStamp = ((FileSourceReport::MsgReportFileSourceStreamData&)message).getStartingTimeStamp();
-		m_recordLengthMuSec = ((FileSourceReport::MsgReportFileSourceStreamData&)message).getRecordLengthMuSec();
-		updateWithStreamData();
-		return true;
-	}
+        m_startingDateTime = ((FileSourceReport::MsgReportFileSourceStreamData &)message).getStartingDateTime();
+        m_recordLengthMuSec = ((FileSourceReport::MsgReportFileSourceStreamData &)message).getRecordLengthMuSec();
+        updateWithStreamData();
+        return true;
+    }
 	else if (FileSourceReport::MsgReportFileSourceStreamTiming::match(message))
 	{
 		m_samplesCount = ((FileSourceReport::MsgReportFileSourceStreamTiming&)message).getSamplesCount();
@@ -159,22 +159,21 @@ bool FileSourceGUI::handleMessage(const Message& message)
     }
 }
 
-FileSourceGUI::FileSourceGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSampleSource *channelTx, QWidget* parent) :
-        ChannelGUI(parent),
-        ui(new Ui::FileSourceGUI),
-        m_pluginAPI(pluginAPI),
-        m_deviceUISet(deviceUISet),
-        m_sampleRate(0),
-        m_shiftFrequencyFactor(0.0),
-        m_fileSampleRate(0),
-        m_fileSampleSize(0),
-        m_recordLengthMuSec(0),
-        m_startingTimeStamp(0),
-        m_samplesCount(0),
-        m_acquisition(false),
-        m_enableNavTime(false),
-        m_doApplySettings(true),
-        m_tickCount(0)
+FileSourceGUI::FileSourceGUI(PluginAPI *pluginAPI, DeviceUISet *deviceUISet, BasebandSampleSource *channelTx, QWidget *parent) : ChannelGUI(parent),
+                                                                                                                                 ui(new Ui::FileSourceGUI),
+                                                                                                                                 m_pluginAPI(pluginAPI),
+                                                                                                                                 m_deviceUISet(deviceUISet),
+                                                                                                                                 m_sampleRate(0),
+                                                                                                                                 m_shiftFrequencyFactor(0.0),
+                                                                                                                                 m_fileSampleRate(0),
+                                                                                                                                 m_fileSampleSize(0),
+                                                                                                                                 m_recordLengthMuSec(0),
+                                                                                                                                 m_startingDateTime(QDateTime::currentDateTime()),
+                                                                                                                                 m_samplesCount(0),
+                                                                                                                                 m_acquisition(false),
+                                                                                                                                 m_enableNavTime(false),
+                                                                                                                                 m_doApplySettings(true),
+                                                                                                                                 m_tickCount(0)
 {
     (void) channelTx;
 
@@ -274,8 +273,7 @@ void FileSourceGUI::updateWithStreamTime()
 	QString s_timems = t.toString("HH:mm:ss.zzz");
 	ui->relTimeText->setText(s_timems);
 
-    qint64 startingTimeStampMsec = m_startingTimeStamp * 1000LL;
-	QDateTime dt = QDateTime::fromMSecsSinceEpoch(startingTimeStampMsec);
+    QDateTime dt = QDateTime(m_startingDateTime);
     dt = dt.addSecs(t_sec);
     dt = dt.addMSecs(t_msec);
 	QString s_date = dt.toString("yyyy-MM-dd HH:mm:ss.zzz");

--- a/plugins/channeltx/filesource/filesourcegui.h
+++ b/plugins/channeltx/filesource/filesourcegui.h
@@ -18,6 +18,8 @@
 #ifndef PLUGINS_CHANNELTX_FILESOURCE_FILESOURCEGUI_H_
 #define PLUGINS_CHANNELTX_FILESOURCE_FILESOURCEGUI_H_
 
+#include <QDateTime>
+
 #include "dsp/channelmarker.h"
 #include "channel/channelgui.h"
 #include "util/messagequeue.h"
@@ -59,7 +61,7 @@ private:
     int m_fileSampleRate;
     quint32 m_fileSampleSize;
     quint64 m_recordLengthMuSec;
-    quint64 m_startingTimeStamp;
+    QDateTime m_startingDateTime;
     quint64 m_samplesCount;
     bool m_acquisition;
   	bool m_enableNavTime;

--- a/plugins/channeltx/filesource/filesourcereport.h
+++ b/plugins/channeltx/filesource/filesourcereport.h
@@ -19,6 +19,8 @@
 #define PLUGINS_CHANNELTX_FILESOURCE_FILESOURCEREPORT_H_
 
 #include <QObject>
+#include <QDateTime>
+
 #include "util/message.h"
 
 class FileSourceReport : public QObject
@@ -51,43 +53,44 @@ public:
 		int getSampleRate() const { return m_sampleRate; }
 		quint32 getSampleSize() const { return m_sampleSize; }
 		quint64 getCenterFrequency() const { return m_centerFrequency; }
-        quint64 getStartingTimeStamp() const { return m_startingTimeStamp; }
+        QDateTime getStartingDateTime() const { return m_startingDateTime; }
         quint64 getRecordLengthMuSec() const { return m_recordLengthMuSec; }
 
-		static MsgReportFileSourceStreamData* create(int sampleRate,
-		        quint32 sampleSize,
-				quint64 centerFrequency,
-                quint64 startingTimeStamp,
-                quint64 recordLengthMuSec)
-		{
-			return new MsgReportFileSourceStreamData(sampleRate, sampleSize, centerFrequency, startingTimeStamp, recordLengthMuSec);
-		}
+        static MsgReportFileSourceStreamData *create(int sampleRate,
+                                                     quint32 sampleSize,
+                                                     quint64 centerFrequency,
+                                                     QDateTime startingDateTime,
+                                                     quint64 recordLengthMuSec)
+        {
+            return new MsgReportFileSourceStreamData(sampleRate, sampleSize, centerFrequency, startingDateTime, recordLengthMuSec);
+        }
 
-	protected:
-		int m_sampleRate;
-		quint32 m_sampleSize;
-		quint64 m_centerFrequency;
-        quint64 m_startingTimeStamp;
+    protected:
+        int m_sampleRate;
+        quint32 m_sampleSize;
+        quint64 m_centerFrequency;
+        QDateTime m_startingDateTime;
         quint64 m_recordLengthMuSec;
 
-		MsgReportFileSourceStreamData(int sampleRate,
-		        quint32 sampleSize,
-				quint64 centerFrequency,
-                quint64 startingTimeStamp,
-                quint64 recordLengthMuSec) :
-			Message(),
-			m_sampleRate(sampleRate),
-			m_sampleSize(sampleSize),
-			m_centerFrequency(centerFrequency),
-			m_startingTimeStamp(startingTimeStamp),
-			m_recordLengthMuSec(recordLengthMuSec)
-		{ }
-	};
+        MsgReportFileSourceStreamData(int sampleRate,
+                                      quint32 sampleSize,
+                                      quint64 centerFrequency,
+                                      QDateTime startingDateTime,
+                                      quint64 recordLengthMuSec) : Message(),
+                                                                   m_sampleRate(sampleRate),
+                                                                   m_sampleSize(sampleSize),
+                                                                   m_centerFrequency(centerFrequency),
+                                                                   m_startingDateTime(startingDateTime),
+                                                                   m_recordLengthMuSec(recordLengthMuSec)
+        {
+        }
+    };
 
-	class MsgReportFileSourceStreamTiming : public Message {
-		MESSAGE_CLASS_DECLARATION
+    class MsgReportFileSourceStreamTiming : public Message
+    {
+        MESSAGE_CLASS_DECLARATION
 
-	public:
+    public:
         quint64 getSamplesCount() const { return m_samplesCount; }
 
         static MsgReportFileSourceStreamTiming* create(quint64 samplesCount)
@@ -102,7 +105,7 @@ public:
 			Message(),
 			m_samplesCount(samplesCount)
 		{ }
-	};
+    };
 
     class MsgPlayPause : public Message {
         MESSAGE_CLASS_DECLARATION

--- a/plugins/channeltx/filesource/filesourcesource.h
+++ b/plugins/channeltx/filesource/filesourcesource.h
@@ -26,6 +26,7 @@
 #include <QString>
 #include <QByteArray>
 #include <QTimer>
+#include <QDateTime>
 
 #include "dsp/channelsamplesource.h"
 #include "util/movingaverage.h"
@@ -77,7 +78,7 @@ public:
     void setRunning(bool running) { m_running = running; }
 
     uint32_t getFileSampleRate() const { return m_fileSampleRate; }
-    quint64 getStartingTimeStamp() const { return m_startingTimeStamp; }
+    QDateTime getStartingDateTime() const { return m_startingDateTime; }
     quint64 getRecordLengthMuSec() const { return m_recordLengthMuSec; }
     quint32 getFileSampleSize() const { return m_sampleSize; }
 
@@ -106,8 +107,8 @@ private:
     uint32_t m_sampleRate;
     uint32_t m_deviceSampleRate;
     quint64 m_recordLengthMuSec; //!< record length in microseconds computed from file size
-    quint64 m_startingTimeStamp;
-	QTimer m_masterTimer;
+    QDateTime m_startingDateTime;
+    QTimer m_masterTimer;
     bool m_running;
 
     double m_linearGain;

--- a/plugins/samplesink/fileoutput/fileoutput.cpp
+++ b/plugins/samplesink/fileoutput/fileoutput.cpp
@@ -42,13 +42,12 @@ MESSAGE_CLASS_DEFINITION(FileOutput::MsgConfigureFileOutputStreamTiming, Message
 MESSAGE_CLASS_DEFINITION(FileOutput::MsgReportFileOutputGeneration, Message)
 MESSAGE_CLASS_DEFINITION(FileOutput::MsgReportFileOutputStreamTiming, Message)
 
-FileOutput::FileOutput(DeviceAPI *deviceAPI) :
-    m_deviceAPI(deviceAPI),
-	m_settings(),
-	m_fileOutputWorker(nullptr),
-	m_deviceDescription("FileOutput"),
-	m_startingTimeStamp(0),
-	m_masterTimer(deviceAPI->getMasterTimer())
+FileOutput::FileOutput(DeviceAPI *deviceAPI) : m_deviceAPI(deviceAPI),
+                                               m_settings(),
+                                               m_fileOutputWorker(nullptr),
+                                               m_deviceDescription("FileOutput"),
+                                               m_startingDateTime(QDateTime::currentDateTime()),
+                                               m_masterTimer(deviceAPI->getMasterTimer())
 {
     m_deviceAPI->setNbSinkStreams(1);
 }
@@ -75,8 +74,7 @@ void FileOutput::openFileStream()
 	int actualSampleRate = m_settings.m_sampleRate * (1<<m_settings.m_log2Interp);
     header.sampleRate = actualSampleRate;
     header.centerFrequency = m_settings.m_centerFrequency;
-    m_startingTimeStamp = QDateTime::currentMSecsSinceEpoch();
-    header.startTimeStamp = (quint64)m_startingTimeStamp;
+    header.startTimeStamp = m_startingDateTime.toMSecsSinceEpoch();
     header.sampleSize = SDR_RX_SAMP_SZ;
 
     FileRecord::writeHeader(m_ofstream, header);
@@ -209,9 +207,9 @@ void FileOutput::setCenterFrequency(qint64 centerFrequency)
     }
 }
 
-std::time_t FileOutput::getStartingTimeStamp() const
+QDateTime FileOutput::getStartingDateTime() const
 {
-	return m_startingTimeStamp;
+    return m_startingDateTime;
 }
 
 bool FileOutput::handleMessage(const Message& message)

--- a/plugins/samplesink/fileoutput/fileoutput.h
+++ b/plugins/samplesink/fileoutput/fileoutput.h
@@ -22,6 +22,7 @@
 #include <QTimer>
 #include <QThread>
 #include <QNetworkRequest>
+#include <QDateTime>
 
 #include <ctime>
 #include <iostream>
@@ -193,9 +194,9 @@ public:
     virtual void setSampleRate(int sampleRate) { (void) sampleRate; }
 	virtual quint64 getCenterFrequency() const;
     virtual void setCenterFrequency(qint64 centerFrequency);
-	std::time_t getStartingTimeStamp() const;
+    QDateTime getStartingDateTime() const;
 
-	virtual bool handleMessage(const Message& message);
+    virtual bool handleMessage(const Message& message);
 
 	virtual int webapiSettingsGet(
 	            SWGSDRangel::SWGDeviceSettings& response,
@@ -233,8 +234,8 @@ private:
 	FileOutputWorker* m_fileOutputWorker;
     QThread m_fileOutputWorkerThread;
 	QString m_deviceDescription;
-	qint64 m_startingTimeStamp;
-	const QTimer& m_masterTimer;
+    QDateTime m_startingDateTime;
+    const QTimer& m_masterTimer;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;
 

--- a/plugins/samplesink/fileoutput/fileoutputgui.cpp
+++ b/plugins/samplesink/fileoutput/fileoutputgui.cpp
@@ -36,20 +36,19 @@
 #include "device/deviceuiset.h"
 #include "fileoutputgui.h"
 
-FileOutputGui::FileOutputGui(DeviceUISet *deviceUISet, QWidget* parent) :
-	DeviceGUI(parent),
-	ui(new Ui::FileOutputGui),
-	m_deviceUISet(deviceUISet),
-	m_doApplySettings(true),
-	m_forceSettings(true),
-	m_settings(),
-    m_deviceSampleSink(0),
-    m_sampleRate(0),
-    m_generation(false),
-	m_startingTimeStamp(0),
-	m_samplesCount(0),
-	m_tickCount(0),
-	m_lastEngineState(DeviceAPI::StNotStarted)
+FileOutputGui::FileOutputGui(DeviceUISet *deviceUISet, QWidget *parent) : DeviceGUI(parent),
+                                                                          ui(new Ui::FileOutputGui),
+                                                                          m_deviceUISet(deviceUISet),
+                                                                          m_doApplySettings(true),
+                                                                          m_forceSettings(true),
+                                                                          m_settings(),
+                                                                          m_deviceSampleSink(0),
+                                                                          m_sampleRate(0),
+                                                                          m_generation(false),
+                                                                          m_startingDateTime(QDateTime::currentDateTime()),
+                                                                          m_samplesCount(0),
+                                                                          m_tickCount(0),
+                                                                          m_lastEngineState(DeviceAPI::StNotStarted)
 {
 	ui->setupUi(this);
 

--- a/plugins/samplesink/fileoutput/fileoutputgui.h
+++ b/plugins/samplesink/fileoutput/fileoutputgui.h
@@ -21,6 +21,7 @@
 #include <device/devicegui.h>
 #include <QTimer>
 #include <QWidget>
+#include <QDateTime>
 
 #include "util/messagequeue.h"
 
@@ -61,7 +62,7 @@ private:
     int m_sampleRate;
     quint64 m_deviceCenterFrequency; //!< Center frequency in device
     bool m_generation;
-	std::time_t m_startingTimeStamp;
+	QDateTime m_startingDateTime;
 	int m_samplesCount;
 	std::size_t m_tickCount;
 	int m_lastEngineState;

--- a/plugins/samplesink/localoutput/localoutput.h
+++ b/plugins/samplesink/localoutput/localoutput.h
@@ -119,9 +119,9 @@ public:
     virtual void setSampleRate(int sampleRate);
 	virtual quint64 getCenterFrequency() const;
     virtual void setCenterFrequency(qint64 centerFrequency);
-	std::time_t getStartingTimeStamp() const;
+    QDateTime getStartingDateTime() const;
 
-	virtual bool handleMessage(const Message& message);
+    virtual bool handleMessage(const Message &message);
 
     virtual int webapiSettingsGet(
                 SWGSDRangel::SWGDeviceSettings& response,

--- a/plugins/samplesink/remoteoutput/remoteoutput.cpp
+++ b/plugins/samplesink/remoteoutput/remoteoutput.cpp
@@ -44,24 +44,23 @@ MESSAGE_CLASS_DEFINITION(RemoteOutput::MsgConfigureRemoteOutputChunkCorrection, 
 
 const uint32_t RemoteOutput::NbSamplesForRateCorrection = 5000000;
 
-RemoteOutput::RemoteOutput(DeviceAPI *deviceAPI) :
-    m_deviceAPI(deviceAPI),
-	m_settings(),
-	m_centerFrequency(0),
-    m_remoteOutputWorker(nullptr),
-	m_deviceDescription("RemoteOutput"),
-    m_startingTimeStamp(0),
-	m_masterTimer(deviceAPI->getMasterTimer()),
-	m_tickCount(0),
-    m_tickMultiplier(20),
-	m_lastRemoteSampleCount(0),
-	m_lastSampleCount(0),
-	m_lastRemoteTimestampRateCorrection(0),
-	m_lastTimestampRateCorrection(0),
-	m_lastQueueLength(-2),
-	m_nbRemoteSamplesSinceRateCorrection(0),
-	m_nbSamplesSinceRateCorrection(0),
-	m_chunkSizeCorrection(0)
+RemoteOutput::RemoteOutput(DeviceAPI *deviceAPI) : m_deviceAPI(deviceAPI),
+                                                   m_settings(),
+                                                   m_centerFrequency(0),
+                                                   m_remoteOutputWorker(nullptr),
+                                                   m_deviceDescription("RemoteOutput"),
+                                                   m_startingDateTime(QDateTime::currentDateTime()),
+                                                   m_masterTimer(deviceAPI->getMasterTimer()),
+                                                   m_tickCount(0),
+                                                   m_tickMultiplier(20),
+                                                   m_lastRemoteSampleCount(0),
+                                                   m_lastSampleCount(0),
+                                                   m_lastRemoteTimestampRateCorrection(0),
+                                                   m_lastTimestampRateCorrection(0),
+                                                   m_lastQueueLength(-2),
+                                                   m_nbRemoteSamplesSinceRateCorrection(0),
+                                                   m_nbSamplesSinceRateCorrection(0),
+                                                   m_chunkSizeCorrection(0)
 {
     m_deviceAPI->setNbSinkStreams(1);
     m_networkManager = new QNetworkAccessManager();
@@ -182,9 +181,9 @@ quint64 RemoteOutput::getCenterFrequency() const
 	return m_centerFrequency;
 }
 
-std::time_t RemoteOutput::getStartingTimeStamp() const
+QDateTime RemoteOutput::getStartingDateTime() const
 {
-	return m_startingTimeStamp;
+    return m_startingDateTime;
 }
 
 bool RemoteOutput::handleMessage(const Message& message)

--- a/plugins/samplesink/remoteoutput/remoteoutput.h
+++ b/plugins/samplesink/remoteoutput/remoteoutput.h
@@ -27,6 +27,7 @@
 #include <QTimer>
 #include <QNetworkRequest>
 #include <QThread>
+#include <QDateTime>
 
 #include "dsp/devicesamplesink.h"
 
@@ -140,9 +141,9 @@ public:
     virtual void setSampleRate(int sampleRate) { (void) sampleRate; }
 	virtual quint64 getCenterFrequency() const;
     virtual void setCenterFrequency(qint64 centerFrequency) { (void) centerFrequency; }
-	std::time_t getStartingTimeStamp() const;
+    QDateTime getStartingDateTime() const;
 
-	virtual bool handleMessage(const Message& message);
+    virtual bool handleMessage(const Message &message);
 
     virtual int webapiSettingsGet(
                 SWGSDRangel::SWGDeviceSettings& response,
@@ -184,9 +185,9 @@ private:
 	RemoteOutputWorker* m_remoteOutputWorker;
     QThread m_remoteOutputWorkerThread;
 	QString m_deviceDescription;
-	std::time_t m_startingTimeStamp;
-	const QTimer& m_masterTimer;
-	uint32_t m_tickCount;
+    QDateTime m_startingDateTime;
+    const QTimer &m_masterTimer;
+    uint32_t m_tickCount;
     uint32_t m_tickMultiplier;
 
     QNetworkAccessManager *m_networkManager;

--- a/plugins/samplesource/fileinput/fileinput.cpp
+++ b/plugins/samplesource/fileinput/fileinput.cpp
@@ -355,7 +355,7 @@ void FileInput::setCenterFrequency(qint64 centerFrequency)
     }
 }
 
-QDateTime FileInput::getStartingTimeStamp() const
+QDateTime FileInput::getStartingDateTime() const
 {
     return m_startingDateTime;
 }

--- a/plugins/samplesource/fileinput/fileinput.h
+++ b/plugins/samplesource/fileinput/fileinput.h
@@ -28,6 +28,7 @@
 #include <QThread>
 #include <QMutex>
 #include <QNetworkRequest>
+#include <QDateTime>
 
 #include "dsp/devicesamplesource.h"
 #include "fileinputsettings.h"
@@ -205,37 +206,37 @@ public:
 		int getSampleRate() const { return m_sampleRate; }
 		quint32 getSampleSize() const { return m_sampleSize; }
 		quint64 getCenterFrequency() const { return m_centerFrequency; }
-        quint64 getStartingTimeStamp() const { return m_startingTimeStamp; }
-        quint64 getRecordLengthMuSec() const { return m_recordLengthMuSec; }
+		QDateTime getStartingDateTime() const { return m_startingDateTime; }
+		quint64 getRecordLengthMuSec() const { return m_recordLengthMuSec; }
 
-		static MsgReportFileInputStreamData* create(int sampleRate,
-		        quint32 sampleSize,
-				quint64 centerFrequency,
-                quint64 startingTimeStamp,
-                quint64 recordLength)
+		static MsgReportFileInputStreamData *create(int sampleRate,
+													quint32 sampleSize,
+													quint64 centerFrequency,
+													QDateTime startingDateTime,
+													quint64 recordLength)
 		{
-			return new MsgReportFileInputStreamData(sampleRate, sampleSize, centerFrequency, startingTimeStamp, recordLength);
+			return new MsgReportFileInputStreamData(sampleRate, sampleSize, centerFrequency, startingDateTime, recordLength);
 		}
 
 	protected:
 		int m_sampleRate;
 		quint32 m_sampleSize;
 		quint64 m_centerFrequency;
-        quint64 m_startingTimeStamp;
-        quint64 m_recordLengthMuSec;
+		QDateTime m_startingDateTime;
+		quint64 m_recordLengthMuSec;
 
 		MsgReportFileInputStreamData(int sampleRate,
-		        quint32 sampleSize,
-				quint64 centerFrequency,
-                quint64 startingTimeStamp,
-                quint64 recordLengthMuSec) :
-			Message(),
-			m_sampleRate(sampleRate),
-			m_sampleSize(sampleSize),
-			m_centerFrequency(centerFrequency),
-			m_startingTimeStamp(startingTimeStamp),
-			m_recordLengthMuSec(recordLengthMuSec)
-		{ }
+									 quint32 sampleSize,
+									 quint64 centerFrequency,
+									 QDateTime startingDateTime,
+									 quint64 recordLengthMuSec) : Message(),
+																  m_sampleRate(sampleRate),
+																  m_sampleSize(sampleSize),
+																  m_centerFrequency(centerFrequency),
+																  m_startingDateTime(startingDateTime),
+																  m_recordLengthMuSec(recordLengthMuSec)
+		{
+		}
 	};
 
 	class MsgReportFileInputStreamTiming : public Message {
@@ -294,19 +295,19 @@ public:
     virtual void setSampleRate(int sampleRate) { (void) sampleRate; }
 	virtual quint64 getCenterFrequency() const;
     virtual void setCenterFrequency(qint64 centerFrequency);
-    quint64 getStartingTimeStamp() const;
+	QDateTime getStartingTimeStamp() const;
 
 	virtual int webapiSettingsGet(
-	            SWGSDRangel::SWGDeviceSettings& response,
-	            QString& errorMessage);
+		SWGSDRangel::SWGDeviceSettings &response,
+		QString &errorMessage);
 
 	virtual int webapiSettingsPutPatch(
-                bool force,
-                const QStringList& deviceSettingsKeys,
-                SWGSDRangel::SWGDeviceSettings& response, // query + response
-                QString& errorMessage);
+		bool force,
+		const QStringList &deviceSettingsKeys,
+		SWGSDRangel::SWGDeviceSettings &response, // query + response
+		QString &errorMessage);
 
-    virtual int webapiRunGet(
+	virtual int webapiRunGet(
             SWGSDRangel::SWGDeviceState& response,
             QString& errorMessage);
 
@@ -340,9 +341,9 @@ public:
 	quint32 m_sampleSize;
 	quint64 m_centerFrequency;
     quint64 m_recordLengthMuSec; //!< record length in microseconds computed from file size
-    quint64 m_startingTimeStamp;
+	QDateTime m_startingDateTime;
 	QTimer m_masterTimer;
-    QNetworkAccessManager *m_networkManager;
+	QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;
 
 	void startWorker();

--- a/plugins/samplesource/fileinput/fileinput.h
+++ b/plugins/samplesource/fileinput/fileinput.h
@@ -295,7 +295,7 @@ public:
     virtual void setSampleRate(int sampleRate) { (void) sampleRate; }
 	virtual quint64 getCenterFrequency() const;
     virtual void setCenterFrequency(qint64 centerFrequency);
-	QDateTime getStartingTimeStamp() const;
+	QDateTime getStartingDateTime() const;
 
 	virtual int webapiSettingsGet(
 		SWGSDRangel::SWGDeviceSettings &response,

--- a/plugins/samplesource/fileinput/fileinputgui.cpp
+++ b/plugins/samplesource/fileinput/fileinputgui.cpp
@@ -38,22 +38,21 @@
 #include "device/deviceapi.h"
 #include "device/deviceuiset.h"
 
-FileInputGUI::FileInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
-	DeviceGUI(parent),
-	ui(new Ui::FileInputGUI),
-	m_deviceUISet(deviceUISet),
-	m_settings(),
-	m_doApplySettings(true),
-	m_sampleSource(0),
-	m_acquisition(false),
-	m_sampleRate(0),
-	m_centerFrequency(0),
-	m_recordLengthMuSec(0),
-	m_startingTimeStamp(0),
-	m_samplesCount(0),
-	m_tickCount(0),
-	m_enableNavTime(false),
-	m_lastEngineState(DeviceAPI::StNotStarted)
+FileInputGUI::FileInputGUI(DeviceUISet *deviceUISet, QWidget *parent) : DeviceGUI(parent),
+																		ui(new Ui::FileInputGUI),
+																		m_deviceUISet(deviceUISet),
+																		m_settings(),
+																		m_doApplySettings(true),
+																		m_sampleSource(0),
+																		m_acquisition(false),
+																		m_sampleRate(0),
+																		m_centerFrequency(0),
+																		m_recordLengthMuSec(0),
+																		m_startingDateTime(QDateTime::currentDateTime()),
+																		m_samplesCount(0),
+																		m_tickCount(0),
+																		m_enableNavTime(false),
+																		m_lastEngineState(DeviceAPI::StNotStarted)
 {
 	ui->setupUi(this);
 	ui->centerFrequency->setColorMapper(ColorMapper(ColorMapper::GrayGold));
@@ -159,7 +158,7 @@ bool FileInputGUI::handleMessage(const Message& message)
 		m_sampleRate = ((FileInput::MsgReportFileInputStreamData&)message).getSampleRate();
 		m_sampleSize = ((FileInput::MsgReportFileInputStreamData&)message).getSampleSize();
 		m_centerFrequency = ((FileInput::MsgReportFileInputStreamData&)message).getCenterFrequency();
-		m_startingTimeStamp = ((FileInput::MsgReportFileInputStreamData&)message).getStartingTimeStamp();
+		m_startingDateTime = ((FileInput::MsgReportFileInputStreamData &)message).getStartingDateTime();
 		m_recordLengthMuSec = ((FileInput::MsgReportFileInputStreamData&)message).getRecordLengthMuSec();
 		updateWithStreamData();
 		return true;
@@ -367,10 +366,9 @@ void FileInputGUI::updateWithStreamTime()
 	QString s_timems = t.toString("HH:mm:ss.zzz");
 	ui->relTimeText->setText(s_timems);
 
-    qint64 startingTimeStampMsec = m_startingTimeStamp;
-    QDateTime dt = QDateTime::fromMSecsSinceEpoch(startingTimeStampMsec);
-    dt = dt.addSecs(t_sec);
-    dt = dt.addMSecs(t_msec);
+	QDateTime dt = QDateTime(m_startingDateTime);
+	dt = dt.addSecs(t_sec);
+	dt = dt.addMSecs(t_msec);
 	QString s_date = dt.toString("yyyy-MM-dd HH:mm:ss.zzz");
 	ui->absTimeText->setText(s_date);
 

--- a/plugins/samplesource/fileinput/fileinputgui.h
+++ b/plugins/samplesource/fileinput/fileinputgui.h
@@ -21,6 +21,7 @@
 #include <device/devicegui.h>
 #include <QTimer>
 #include <QWidget>
+#include <QDateTime>
 
 #include "util/messagequeue.h"
 
@@ -61,8 +62,8 @@ private:
 	quint32 m_sampleSize;
 	quint64 m_centerFrequency;
     quint64 m_recordLengthMuSec;
-    quint64 m_startingTimeStamp;
-    quint64 m_samplesCount;
+	QDateTime m_startingDateTime;
+	quint64 m_samplesCount;
 	std::size_t m_tickCount;
 	bool m_enableNavTime;
     int m_deviceSampleRate;

--- a/plugins/samplesource/localinput/localinputgui.cpp
+++ b/plugins/samplesource/localinput/localinputgui.cpp
@@ -43,45 +43,43 @@
 #include "device/deviceuiset.h"
 #include "localinputgui.h"
 
-
-LocalInputGui::LocalInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
-	DeviceGUI(parent),
-	ui(new Ui::LocalInputGui),
-	m_deviceUISet(deviceUISet),
-	m_settings(),
-	m_sampleSource(0),
-	m_acquisition(false),
-	m_streamSampleRate(0),
-	m_streamCenterFrequency(0),
-	m_lastEngineState(DeviceAPI::StNotStarted),
-	m_framesDecodingStatus(0),
-	m_bufferLengthInSecs(0.0),
-    m_bufferGauge(-50),
-	m_nbOriginalBlocks(128),
-    m_nbFECBlocks(0),
-    m_sampleBits(16), // assume 16 bits to start with
-    m_sampleBytes(2),
-    m_samplesCount(0),
-    m_tickCount(0),
-    m_addressEdited(false),
-    m_dataPortEdited(false),
-	m_countUnrecoverable(0),
-	m_countRecovered(0),
-    m_doApplySettings(true),
-    m_forceSettings(true),
-    m_txDelay(0.0)
+LocalInputGui::LocalInputGui(DeviceUISet *deviceUISet, QWidget *parent) : DeviceGUI(parent),
+                                                                          ui(new Ui::LocalInputGui),
+                                                                          m_deviceUISet(deviceUISet),
+                                                                          m_settings(),
+                                                                          m_sampleSource(0),
+                                                                          m_acquisition(false),
+                                                                          m_streamSampleRate(0),
+                                                                          m_streamCenterFrequency(0),
+                                                                          m_lastEngineState(DeviceAPI::StNotStarted),
+                                                                          m_startingDateTime(QDateTime::currentDateTime()),
+                                                                          m_framesDecodingStatus(0),
+                                                                          m_bufferLengthInSecs(0.0),
+                                                                          m_bufferGauge(-50),
+                                                                          m_nbOriginalBlocks(128),
+                                                                          m_nbFECBlocks(0),
+                                                                          m_sampleBits(16), // assume 16 bits to start with
+                                                                          m_sampleBytes(2),
+                                                                          m_samplesCount(0),
+                                                                          m_tickCount(0),
+                                                                          m_addressEdited(false),
+                                                                          m_dataPortEdited(false),
+                                                                          m_countUnrecoverable(0),
+                                                                          m_countRecovered(0),
+                                                                          m_doApplySettings(true),
+                                                                          m_forceSettings(true),
+                                                                          m_txDelay(0.0)
 {
     m_paletteGreenText.setColor(QPalette::WindowText, Qt::green);
     m_paletteWhiteText.setColor(QPalette::WindowText, Qt::white);
 
-	m_startingTimeStampms = 0;
-	ui->setupUi(this);
+    ui->setupUi(this);
 
-	ui->centerFrequency->setColorMapper(ColorMapper(ColorMapper::GrayGold));
-	ui->centerFrequency->setValueRange(7, 0, 9999999U);
+    ui->centerFrequency->setColorMapper(ColorMapper(ColorMapper::GrayGold));
+    ui->centerFrequency->setValueRange(7, 0, 9999999U);
 
-	ui->centerFrequencyHz->setColorMapper(ColorMapper(ColorMapper::GrayGold));
-	ui->centerFrequencyHz->setValueRange(3, 0, 999U);
+    ui->centerFrequencyHz->setColorMapper(ColorMapper(ColorMapper::GrayGold));
+    ui->centerFrequencyHz->setValueRange(3, 0, 999U);
 
     CRightClickEnabler *startStopRightClickEnabler = new CRightClickEnabler(ui->startStop);
     connect(startStopRightClickEnabler, SIGNAL(rightClick(const QPoint &)), this, SLOT(openDeviceSettingsDialog(const QPoint &)));

--- a/plugins/samplesource/localinput/localinputgui.h
+++ b/plugins/samplesource/localinput/localinputgui.h
@@ -21,6 +21,7 @@
 #include <QTimer>
 #include <QWidget>
 #include <QNetworkRequest>
+#include <QDateTime>
 
 #include "device/devicegui.h"
 #include "util/messagequeue.h"
@@ -65,9 +66,9 @@ private:
 
     //	int m_sampleRate;
     //	quint64 m_centerFrequency;
-	uint64_t m_startingTimeStampms;
-	int m_framesDecodingStatus;
-	bool m_allBlocksReceived;
+    QDateTime m_startingDateTime;
+    int m_framesDecodingStatus;
+    bool m_allBlocksReceived;
 	float m_bufferLengthInSecs;
     int32_t m_bufferGauge;
     int m_minNbBlocks;

--- a/plugins/samplesource/remoteinput/remoteinput.cpp
+++ b/plugins/samplesource/remoteinput/remoteinput.cpp
@@ -42,14 +42,13 @@ MESSAGE_CLASS_DEFINITION(RemoteInput::MsgReportRemoteInputStreamData, Message)
 MESSAGE_CLASS_DEFINITION(RemoteInput::MsgReportRemoteInputStreamTiming, Message)
 MESSAGE_CLASS_DEFINITION(RemoteInput::MsgStartStop, Message)
 
-RemoteInput::RemoteInput(DeviceAPI *deviceAPI) :
-    m_deviceAPI(deviceAPI),
-    m_sampleRate(48000),
-    m_mutex(QMutex::Recursive),
-    m_settings(),
-	m_remoteInputUDPHandler(nullptr),
-	m_deviceDescription(),
-	m_startingTimeStamp(0)
+RemoteInput::RemoteInput(DeviceAPI *deviceAPI) : m_deviceAPI(deviceAPI),
+                                                 m_sampleRate(48000),
+                                                 m_mutex(QMutex::Recursive),
+                                                 m_settings(),
+                                                 m_remoteInputUDPHandler(nullptr),
+                                                 m_deviceDescription(),
+                                                 m_startingDateTime(QDateTime::currentDateTime())
 {
 	m_sampleFifo.setSize(m_sampleRate * 8);
 	m_remoteInputUDPHandler = new RemoteInputUDPHandler(&m_sampleFifo, m_deviceAPI);
@@ -144,9 +143,9 @@ void RemoteInput::setCenterFrequency(qint64 centerFrequency)
     (void) centerFrequency;
 }
 
-std::time_t RemoteInput::getStartingTimeStamp() const
+QDateTime RemoteInput::getStartingDateTime() const
 {
-	return m_startingTimeStamp;
+    return m_startingDateTime;
 }
 
 bool RemoteInput::isStreaming() const
@@ -248,10 +247,10 @@ void RemoteInput::applySettings(const RemoteInputSettings& settings, bool force)
                 settings.m_iqCorrection ? "true" : "false");
     }
 
-    if ((m_settings.m_dataAddress != settings.m_dataAddress) || 
-        (m_settings.m_dataPort != settings.m_dataPort) || 
-        (m_settings.m_multicastAddress != settings.m_multicastAddress) || 
-        (m_settings.m_multicastJoin != settings.m_multicastJoin) || force) 
+    if ((m_settings.m_dataAddress != settings.m_dataAddress) ||
+        (m_settings.m_dataPort != settings.m_dataPort) ||
+        (m_settings.m_multicastAddress != settings.m_multicastAddress) ||
+        (m_settings.m_multicastJoin != settings.m_multicastJoin) || force)
     {
         m_remoteInputUDPHandler->configureUDPLink(settings.m_dataAddress, settings.m_dataPort, settings.m_multicastAddress, settings.m_multicastJoin);
         m_remoteInputUDPHandler->getRemoteAddress(remoteAddress);

--- a/plugins/samplesource/remoteinput/remoteinput.h
+++ b/plugins/samplesource/remoteinput/remoteinput.h
@@ -26,6 +26,7 @@
 #include <QByteArray>
 #include <QTimer>
 #include <QNetworkRequest>
+#include <QDateTime>
 
 #include "dsp/devicesamplesource.h"
 
@@ -265,10 +266,10 @@ public:
     virtual void setSampleRate(int sampleRate) { (void) sampleRate; }
 	virtual quint64 getCenterFrequency() const;
     virtual void setCenterFrequency(qint64 centerFrequency);
-	std::time_t getStartingTimeStamp() const;
-	bool isStreaming() const;
+    QDateTime getStartingDateTime() const;
+    bool isStreaming() const;
 
-	virtual bool handleMessage(const Message& message);
+    virtual bool handleMessage(const Message &message);
 
     virtual int webapiSettingsGet(
                 SWGSDRangel::SWGDeviceSettings& response,
@@ -310,7 +311,7 @@ private:
 	RemoteInputUDPHandler* m_remoteInputUDPHandler;
     QString m_remoteAddress;
 	QString m_deviceDescription;
-	std::time_t m_startingTimeStamp;
+    QDateTime m_startingDateTime;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;
 

--- a/plugins/samplesource/remoteinput/remoteinputgui.h
+++ b/plugins/samplesource/remoteinput/remoteinputgui.h
@@ -22,6 +22,7 @@
 #include <QElapsedTimer>
 #include <QWidget>
 #include <QNetworkRequest>
+#include <QDateTime>
 
 #include "device/devicegui.h"
 #include "util/messagequeue.h"
@@ -66,7 +67,7 @@ private:
 
     //	int m_sampleRate;
     //	quint64 m_centerFrequency;
-	uint64_t m_startingTimeStampms;
+	QDateTime m_startingDateTime;
 	int m_framesDecodingStatus;
 	bool m_allBlocksReceived;
 	float m_bufferLengthInSecs;

--- a/plugins/samplesource/sigmffileinput/sigmffileinput.cpp
+++ b/plugins/samplesource/sigmffileinput/sigmffileinput.cpp
@@ -60,22 +60,21 @@ MESSAGE_CLASS_DEFINITION(SigMFFileInput::MsgReportFileInputStreamTiming, Message
 MESSAGE_CLASS_DEFINITION(SigMFFileInput::MsgReportCRC, Message)
 MESSAGE_CLASS_DEFINITION(SigMFFileInput::MsgReportTotalSamplesCheck, Message)
 
-SigMFFileInput::SigMFFileInput(DeviceAPI *deviceAPI) :
-    m_deviceAPI(deviceAPI),
-	m_settings(),
-    m_trackMode(false),
-    m_currentTrackIndex(0),
-    m_recordOpen(false),
-    m_crcAvailable(false),
-    m_crcOK(false),
-    m_recordLengthOK(false),
-	m_fileInputWorker(nullptr),
-	m_deviceDescription(),
-	m_sampleRate(48000),
-	m_sampleBytes(1),
-	m_centerFrequency(0),
-	m_recordLength(0),
-    m_startingTimeStamp(0)
+SigMFFileInput::SigMFFileInput(DeviceAPI *deviceAPI) : m_deviceAPI(deviceAPI),
+                                                       m_settings(),
+                                                       m_trackMode(false),
+                                                       m_currentTrackIndex(0),
+                                                       m_recordOpen(false),
+                                                       m_crcAvailable(false),
+                                                       m_crcOK(false),
+                                                       m_recordLengthOK(false),
+                                                       m_fileInputWorker(nullptr),
+                                                       m_deviceDescription(),
+                                                       m_sampleRate(48000),
+                                                       m_sampleBytes(1),
+                                                       m_centerFrequency(0),
+                                                       m_recordLength(0),
+                                                       m_startingDateTime(QDateTime::currentDateTime())
 {
     m_deviceAPI->setNbSourceStreams(1);
     qDebug("SigMFFileInput::SigMFFileInput: device source engine: %p", m_deviceAPI->getDeviceSourceEngine());
@@ -564,9 +563,9 @@ void SigMFFileInput::setCenterFrequency(qint64 centerFrequency)
     }
 }
 
-quint64 SigMFFileInput::getStartingTimeStamp() const
+QDateTime SigMFFileInput::getStartingDateTime() const
 {
-	return m_startingTimeStamp;
+    return m_startingDateTime;
 }
 
 bool SigMFFileInput::handleMessage(const Message& message)

--- a/plugins/samplesource/sigmffileinput/sigmffileinput.h
+++ b/plugins/samplesource/sigmffileinput/sigmffileinput.h
@@ -27,6 +27,7 @@
 #include <QTimer>
 #include <QThread>
 #include <QNetworkRequest>
+#include <QDateTime>
 
 #include "dsp/sigmf_forward.h"
 
@@ -400,15 +401,15 @@ public:
     virtual void setSampleRate(int sampleRate) { (void) sampleRate; }
 	virtual quint64 getCenterFrequency() const;
     virtual void setCenterFrequency(qint64 centerFrequency);
-    quint64 getStartingTimeStamp() const;
+    QDateTime getStartingDateTime() const;
 
-	virtual bool handleMessage(const Message& message);
+    virtual bool handleMessage(const Message &message);
 
-	virtual int webapiSettingsGet(
-	            SWGSDRangel::SWGDeviceSettings& response,
-	            QString& errorMessage);
+    virtual int webapiSettingsGet(
+        SWGSDRangel::SWGDeviceSettings &response,
+        QString &errorMessage);
 
-	virtual int webapiSettingsPutPatch(
+    virtual int webapiSettingsPutPatch(
                 bool force,
                 const QStringList& deviceSettingsKeys,
                 SWGSDRangel::SWGDeviceSettings& response, // query + response
@@ -464,8 +465,8 @@ private:
 	unsigned int m_sampleBytes;
 	quint64 m_centerFrequency;
     quint64 m_recordLength; //!< record length in seconds computed from file size
-    quint64 m_startingTimeStamp;
-	QTimer m_masterTimer;
+    QDateTime m_startingDateTime;
+    QTimer m_masterTimer;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;
 

--- a/plugins/samplesource/sigmffileinput/sigmffileinputgui.cpp
+++ b/plugins/samplesource/sigmffileinput/sigmffileinputgui.cpp
@@ -40,26 +40,25 @@
 #include "recordinfodialog.h"
 #include "sigmffileinputgui.h"
 
-SigMFFileInputGUI::SigMFFileInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
-	DeviceGUI(parent),
-	ui(new Ui::SigMFFileInputGUI),
-	m_deviceUISet(deviceUISet),
-	m_settings(),
-    m_currentTrackIndex(0),
-	m_doApplySettings(true),
-	m_sampleSource(0),
-	m_startStop(false),
-    m_trackMode(false),
-	m_metaFileName("..."),
-	m_sampleRate(48000),
-	m_centerFrequency(0),
-	m_recordLength(0),
-	m_startingTimeStamp(0),
-	m_samplesCount(0),
-	m_tickCount(0),
-	m_enableTrackNavTime(false),
-	m_enableFullNavTime(false),
-	m_lastEngineState(DeviceAPI::StNotStarted)
+SigMFFileInputGUI::SigMFFileInputGUI(DeviceUISet *deviceUISet, QWidget *parent) : DeviceGUI(parent),
+                                                                                  ui(new Ui::SigMFFileInputGUI),
+                                                                                  m_deviceUISet(deviceUISet),
+                                                                                  m_settings(),
+                                                                                  m_currentTrackIndex(0),
+                                                                                  m_doApplySettings(true),
+                                                                                  m_sampleSource(0),
+                                                                                  m_startStop(false),
+                                                                                  m_trackMode(false),
+                                                                                  m_metaFileName("..."),
+                                                                                  m_sampleRate(48000),
+                                                                                  m_centerFrequency(0),
+                                                                                  m_recordLength(0),
+                                                                                  m_startingDateTime(QDateTime::currentDateTime()),
+                                                                                  m_samplesCount(0),
+                                                                                  m_tickCount(0),
+                                                                                  m_enableTrackNavTime(false),
+                                                                                  m_enableFullNavTime(false),
+                                                                                  m_lastEngineState(DeviceAPI::StNotStarted)
 {
 	ui->setupUi(this);
 
@@ -232,7 +231,7 @@ bool SigMFFileInputGUI::handleMessage(const Message& message)
         addCaptures(m_captures);
         m_centerFrequency = m_captures.size() > 0 ? m_captures.at(0).m_centerFrequency : 0;
         m_recordLength = m_captures.size() > 0 ? m_captures.at(0).m_length : m_metaInfo.m_totalSamples;
-        m_startingTimeStamp = m_captures.size() > 0 ? m_captures.at(0).m_tsms : 0;
+        m_startingDateTime = QDateTime::fromMSecsSinceEpoch(m_captures.size() > 0 ? m_captures.at(0).m_tsms : 0);
         m_sampleRate = m_metaInfo.m_coreSampleRate;
         m_sampleSize = m_metaInfo.m_dataType.m_sampleBits;
 
@@ -260,7 +259,7 @@ bool SigMFFileInputGUI::handleMessage(const Message& message)
         m_centerFrequency = m_captures.at(m_currentTrackIndex).m_centerFrequency;
         m_sampleRate = m_captures.at(m_currentTrackIndex).m_sampleRate;
         m_recordLength = m_captures.at(m_currentTrackIndex).m_length;
-        m_startingTimeStamp = m_captures.at(m_currentTrackIndex).m_tsms;
+        m_startingDateTime = QDateTime::fromMSecsSinceEpoch(m_captures.at(m_currentTrackIndex).m_tsms);
         m_samplesCount = m_captures.at(m_currentTrackIndex).m_sampleStart;
         m_trackSamplesCount = 0;
         updateWithStreamData();
@@ -602,7 +601,7 @@ void SigMFFileInputGUI::updateWithStreamTime()
     s_timems = t.toString("HH:mm:ss.zzz");
     ui->fullRelTimeText->setText(s_timems);
 
-	QDateTime dt = QDateTime::fromMSecsSinceEpoch(m_startingTimeStamp);
+    QDateTime dt = QDateTime(m_startingDateTime);
     dt = dt.addSecs(track_sec);
     dt = dt.addMSecs(track_msec);
 	QString s_date = dt.toString("yyyy-MM-dd HH:mm:ss.zzz");

--- a/plugins/samplesource/sigmffileinput/sigmffileinputgui.h
+++ b/plugins/samplesource/sigmffileinput/sigmffileinputgui.h
@@ -20,6 +20,7 @@
 
 #include <QTimer>
 #include <QWidget>
+#include <QDateTime>
 
 #include "device/devicegui.h"
 #include "util/messagequeue.h"
@@ -65,9 +66,9 @@ private:
 	quint32 m_sampleSize;
 	quint64 m_centerFrequency;
     quint64 m_recordLength;
-    quint64 m_startingTimeStamp;
-    quint64 m_samplesCount;
-    quint64 m_trackSamplesCount;
+	QDateTime m_startingDateTime;
+	quint64 m_samplesCount;
+	quint64 m_trackSamplesCount;
     quint64 m_trackTimeStart;
     int m_trackNumber;
 	std::size_t m_tickCount;

--- a/sdrbase/dsp/filerecord.cpp
+++ b/sdrbase/dsp/filerecord.cpp
@@ -206,3 +206,25 @@ void FileRecord::writeHeader(std::ofstream& sampleFile, Header& header)
     header.crc32 = crc32.checksum();
     sampleFile.write((const char *) &header, sizeof(Header));
 }
+
+QDateTime FileRecord::timeStampToDateTime(quint64 timeStamp)
+{
+    /* Roughly the start of this project, rounded down to look nicer. Taken from
+     * git log. */
+    const quint64 EARLIEST_POSSIBLE_TIMESTAMP_IN_MS = 1400000000000;
+
+    /* This heuristic breaks down if given a pre-v6.16.2 FileRecord, that was
+     * created after 46334-03-27. In such a case we would roll-back to
+     * 2014-05-13T16:53:20+00, roughly the date of the earliest commit to this
+     * project. Similarly, given a FileRecord created using v6.16.2 or later
+     * before 2014-05-13T16:53:20+00 this heuristic would falsly convert it to
+     * 1970-01-17T04:53:20+00 (if you happen to find a time-machine that is). */
+    if (timeStamp > EARLIEST_POSSIBLE_TIMESTAMP_IN_MS)
+    {
+        return QDateTime::fromMSecsSinceEpoch((qint64)timeStamp);
+    }
+    else
+    {
+        return QDateTime::fromSecsSinceEpoch((qint64)timeStamp);
+    }
+}

--- a/sdrbase/dsp/filerecord.h
+++ b/sdrbase/dsp/filerecord.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <fstream>
 #include <ctime>
+#include <QDateTime>
 
 #include "dsp/filerecordinterface.h"
 #include "export.h"
@@ -66,6 +67,25 @@ public:
 
     static bool readHeader(std::ifstream& samplefile, Header& header); //!< returns true if CRC checksum is correct else false
     static void writeHeader(std::ofstream& samplefile, Header& header);
+
+    /**
+     * @brief Convert integer timestamp to #QDateTime object.
+     *
+     * Intended to convert FileRecord#Header#startTimeStamp into an unambigous
+     * #QDateTime format to allow backward compatibility with older file
+     * formats.
+     *
+     * This function relies on heuristics, meaning the output should always be
+     * double-checked by a human observer.
+     *
+     * @param timeStamp
+     * Integer timestamp as either seconds <em>or milliseconds</em> since start
+     * of UNIX epoch.
+     *
+     * @return QDateTime
+     * A new QDateTime object representing the given @p timeStamp.
+     */
+    static QDateTime timeStampToDateTime(quint64 timeStamp);
 
 private:
 	QString m_fileBase;


### PR DESCRIPTION
Looking to improve backward compatibility with the previous `FileRecord::Header` format I provided a `FileRecord::timeStampToDateTime()` function, which takes in a `quint64` and tries to convert it into a sensible `QDateTime`. It uses a simple (and kinda hack'ish) heuristic to decide whether the timestamp is in seconds or milliseconds (old vs. new format).

This should now fix date-time displays in GUI when opening old file records.

Subsequent changes include switching the use of `quint64` timestamps as time-keepers to `QDateTime`. Done so, as to ensure clean interfaces without ambiguities (no more "seconds, milliseconds, which is it?" guessing).
Applied in:

* channeltx/filesource
* samplesink/fileoutput
* samplesource/fileinput
* samplesource/localinput
* samplesource/remoteinput
* samplesource/sigmffileinput

Most of which was done automated through an IDE.