### PR TITLE
Support pre- and post-v6.16.2 file formats in rescuesdriq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,20 @@ obj-x86_64-linux-gnu/*
 **/venv*/
 *.pyc
 .DS_Store
+
+### Go ###
+# Binaries for programs and plugins
+/rescuesdriq/*.exe
+/rescuesdriq/*.exe~
+/rescuesdriq/*.dll
+/rescuesdriq/*.so
+/rescuesdriq/*.dylib
+
+# Test binary, built with `go test -c`
+/rescuesdriq/*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+/rescuesdriq/*.out
+
+/rescuesdriq/vendor/
+/rescuesdriq/Godeps/

--- a/rescuesdriq/go.mod
+++ b/rescuesdriq/go.mod
@@ -1,0 +1,9 @@
+module github.com/f4exb/sdrangel/rescuesdriq
+
+go 1.13
+
+require (
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
+	github.com/smartystreets/assertions v1.2.0 // indirect
+	github.com/smartystreets/goconvey v1.6.2
+)

--- a/rescuesdriq/go.sum
+++ b/rescuesdriq/go.sum
@@ -1,0 +1,6 @@
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=
+github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
+github.com/smartystreets/goconvey v1.6.2 h1:R44Anr1ZQYKSh9jBN8v2++vtyDnZsoQifO6MZsJdCDU=
+github.com/smartystreets/goconvey v1.6.2/go.mod h1:XDJAKZRPZ1CvBcN2aX5YOUTYGHki24fSF0Iv48Ibg0s=

--- a/rescuesdriq/readme.md
+++ b/rescuesdriq/readme.md
@@ -2,7 +2,7 @@
 
 <h2>Usage</h2>
 
-This utility attempts to repair .sdriq files that have their header corrupted or with a pre version 4.2.1 header. Since version 4.2.1 a CRC32 checksum is present and the file will not be played if the check of the header content against the CRC32 fails.
+This utility attempts to repair .sdriq files, that have their header corrupted, or were created using old versions of SDRangel. Since version 4.2.1 a CRC32 checksum is present and the file will not be played if the check of the header content against the CRC32 fails. In version 6.16.2 the timestamp resolution was increased from seconds to milliseconds since 1970-01-01 00:00:00.000.
 
 The header is composed as follows:
 
@@ -18,30 +18,32 @@ The header size is 32 bytes in total which is a multiple of 8 bytes thus occupie
 You can replace values in the header with the following options:
 
   - -sr uint
-    	Sample rate (S/s)
+      Sample rate (S/s)
   - -cf uint
-    	Center frequency (Hz)
+      Center frequency (Hz)
   - -ts string
-    	start time RFC3339 (ex: 2006-01-02T15:04:05Z)
+      start time RFC3339 (ex: 2006-01-02T15:04:05Z)
   - -now
-    	use now for start time
+      use now for start time
+  - -msec
+      assume timestamp read from input file is in milliseconds (by default seconds will be assumed)
   - -sz uint
-    	Sample size (16 or 24) (default 16)
+      Sample size (16 or 24) (default 16)
 
 You need to specify an input file. If no output file is specified the current header values are printed to the console and the program exits:
 
   - -in string
-    	input file (default "foo")
+      input file (default "foo")
 
 To convert to a new file you need to specify the output file:
 
   - -out string
-    	output file (default "foo")
+      output file (default "foo")
 
 You can specify a block size in multiples of 4k for the copy. Large blocks will yield a faster copy but a larger output file. With the default of 1 (4k) the copy does not take much time anyway:
 
   - -bz uint
-    	Copy block size in multiple of 4k (default 1)
+      Copy block size in multiple of 4k (default 1)
 
 <h2>Build</h2>
 

--- a/rescuesdriq/rescuesdriq.go
+++ b/rescuesdriq/rescuesdriq.go
@@ -112,6 +112,7 @@ func main() {
 	sampleSize := flag.Uint("sz", 16, "Sample size (16 or 24)")
 	timeStr := flag.String("ts", "", "start time RFC3339 (ex: 2006-01-02T15:04:05Z)")
 	timeNow := flag.Bool("now", false, "use now for start time")
+	assumeMilliseconds := flag.Bool("msec", false, "assume timestamp read from input file is in milliseconds (by default seconds will be assumed)")
 	blockSize := flag.Uint("bz", 1, "Copy block size in multiple of 4k")
 
 	flag.Parse()
@@ -158,7 +159,9 @@ func main() {
 					headerOrigin.StartTimestamp = int64(time.Now().UnixNano() / int64(time.Millisecond))
 				}
 			} else if *timeNow {
-				headerOrigin.StartTimestamp = int64(time.Now().Unix() * 1000)
+				headerOrigin.StartTimestamp = int64(time.Now().UnixNano() / int64(time.Millisecond))
+			} else if !*assumeMilliseconds {
+				headerOrigin.StartTimestamp = headerOrigin.StartTimestamp * (int64(time.Millisecond) / int64(time.Second))
 			}
 
 			fmt.Println("\nHeader is now")


### PR DESCRIPTION
Enable `rescuesdriq` tool to adapt pre-v6.16.2 records to the new header format (turning seconds into milliseconds). By default, timestamps read from input files will be assumed to be in seconds and subsequently converted to milliseconds. The command-line option `-msec` disables this behavior and assumes the timestamp to already be in the desired format.

Some minimal go-project files were provided to allow easy building. Additional documentation can be found in the `/rescuesdriq/readme.md`.