### PR TITLE
Random bytes appended to rescuesdriq output and wrong timestamp

### DIFF
--- a/rescuesdriq/rescuesdriq.go
+++ b/rescuesdriq/rescuesdriq.go
@@ -130,6 +130,11 @@ func main() {
 		// make a read buffer
 		reader := bufio.NewReader(fi)
 		var headerOrigin HeaderStd = analyze(reader)
+
+		if !*assumeMilliseconds {
+			headerOrigin.StartTimestamp = headerOrigin.StartTimestamp * (int64(time.Second) / int64(time.Millisecond))
+		}
+
 		printHeader(&headerOrigin)
 
 		if flagSeen["out"] {
@@ -157,8 +162,6 @@ func main() {
 				}
 			} else if *timeNow {
 				headerOrigin.StartTimestamp = int64(time.Now().UnixNano() / int64(time.Millisecond))
-			} else if !*assumeMilliseconds {
-				headerOrigin.StartTimestamp = headerOrigin.StartTimestamp * (int64(time.Second) / int64(time.Millisecond))
 			}
 
 			fmt.Println("\nHeader is now")

--- a/rescuesdriq/rescuesdriq.go
+++ b/rescuesdriq/rescuesdriq.go
@@ -161,7 +161,7 @@ func main() {
 			} else if *timeNow {
 				headerOrigin.StartTimestamp = int64(time.Now().UnixNano() / int64(time.Millisecond))
 			} else if !*assumeMilliseconds {
-				headerOrigin.StartTimestamp = headerOrigin.StartTimestamp * (int64(time.Millisecond) / int64(time.Second))
+				headerOrigin.StartTimestamp = headerOrigin.StartTimestamp * (int64(time.Second) / int64(time.Millisecond))
 			}
 
 			fmt.Println("\nHeader is now")

--- a/rescuesdriq/rescuesdriq.go
+++ b/rescuesdriq/rescuesdriq.go
@@ -84,18 +84,15 @@ func copyContent(reader *bufio.Reader, writer *bufio.Writer, blockSize uint) {
 	for {
 		n, err := reader.Read(p)
 
-		if err != nil {
+		if err == nil || err == io.EOF {
+			writer.Write(p[0:n])
+			sz += int64(n)
 			if err == io.EOF {
-				writer.Write(p[0:n])
-				sz += int64(n)
-				break
-			} else {
-				fmt.Println("An error occurred during content copy. Aborting")
 				break
 			}
 		} else {
-			writer.Write(p)
-			sz += int64(blockSize) * 4096
+			fmt.Println("An error occurred during content copy. Aborting")
+			break
 		}
 
 		fmt.Printf("Wrote %d bytes\r", sz)


### PR DESCRIPTION
Fixes two major and one minor bug in rescuesdriq.

Closes #986.