### PR TITLE
Additional fix for #1004

### DIFF
--- a/sdrgui/gui/valuedialz.cpp
+++ b/sdrgui/gui/valuedialz.cpp
@@ -142,9 +142,9 @@ void ValueDialZ::setValueRange(bool positiveOnly, uint numDigits, qint64 min, qi
 	m_valueMin = positiveOnly ? (min < 0 ? 0 : min) : min;
 	m_valueMax = positiveOnly ? (max < 0 ? 0 : max) : max;
 
-	if(m_value < m_valueMin) {
+	if(m_valueNew < m_valueMin) {
 		setValue(m_valueMin);
-	} else if(m_value > m_valueMax) {
+	} else if(m_valueNew > m_valueMax) {
 		setValue(m_valueMax);
 	}
 }


### PR DESCRIPTION
In valuedialz.cpp check range against m_valueNew rather than m_value, as that holds the most recently set value. As it currently is, it can end up clipping when the last set value is within range.