### PR TITLE
APT demod fixes.

### DIFF
--- a/plugins/channelrx/demodapt/aptdemod.cpp
+++ b/plugins/channelrx/demodapt/aptdemod.cpp
@@ -72,6 +72,8 @@ APTDemod::APTDemod(DeviceAPI *deviceAPI) :
 
     m_networkManager = new QNetworkAccessManager();
     connect(m_networkManager, SIGNAL(finished(QNetworkReply*)), this, SLOT(networkManagerFinished(QNetworkReply*)));
+
+    startImageWorker();
 }
 
 APTDemod::~APTDemod()
@@ -109,7 +111,6 @@ void APTDemod::feed(const SampleVector::const_iterator& begin, const SampleVecto
 void APTDemod::start()
 {
     startBasebandSink();
-    startImageWorker();
 }
 
 void APTDemod::startBasebandSink()
@@ -141,7 +142,6 @@ void APTDemod::startImageWorker()
 
 void APTDemod::stop()
 {
-    stopImageWorker();
     stopBasebandSink();
 }
 
@@ -594,7 +594,7 @@ int APTDemod::webapiActionsPost(
                     m_basebandSink->getInputMessageQueue()->push(APTDemod::MsgResetDecoder::create());
 
                     // Save satellite name
-                    m_satelliteName = *satelliteName;
+                    m_imageWorker->getInputMessageQueue()->push(APTDemodImageWorker::MsgSetSatelliteName::create(*satelliteName));
 
                     // Enable decoder and set direction of pass
                     APTDemodSettings settings = m_settings;

--- a/plugins/channelrx/demodapt/aptdemod.h
+++ b/plugins/channelrx/demodapt/aptdemod.h
@@ -250,8 +250,6 @@ private:
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;
 
-    QString m_satelliteName;
-
     void applySettings(const APTDemodSettings& settings, bool force = false);
     void webapiReverseSendSettings(QList<QString>& channelSettingsKeys, const APTDemodSettings& settings, bool force);
     void webapiFormatChannelSettings(

--- a/plugins/channelrx/demodapt/aptdemodimageworker.cpp
+++ b/plugins/channelrx/demodapt/aptdemodimageworker.cpp
@@ -26,6 +26,7 @@
 
 MESSAGE_CLASS_DEFINITION(APTDemodImageWorker::MsgConfigureAPTDemodImageWorker, Message)
 MESSAGE_CLASS_DEFINITION(APTDemodImageWorker::MsgSaveImageToDisk, Message)
+MESSAGE_CLASS_DEFINITION(APTDemodImageWorker::MsgSetSatelliteName, Message)
 
 APTDemodImageWorker::APTDemodImageWorker() :
     m_messageQueueToGUI(nullptr),
@@ -97,6 +98,12 @@ bool APTDemodImageWorker::handleMessage(const Message& cmd)
     else if (MsgSaveImageToDisk::match(cmd))
     {
         saveImageToDisk();
+        return true;
+    }
+    else if (MsgSetSatelliteName::match(cmd))
+    {
+        MsgSetSatelliteName& msg = (MsgSetSatelliteName&) cmd;
+        m_satelliteName = msg.getSatelliteName();
         return true;
     }
     else if (APTDemod::MsgPixels::match(cmd))
@@ -336,7 +343,7 @@ void APTDemodImageWorker::saveImageToDisk()
     {
         QString filename;
         QDateTime datetime = QDateTime::currentDateTime();
-        filename = QString("apt_%1_%2.png").arg(m_satelliteName).arg(datetime.toString("yyyyMMdd_hhmm"));
+        filename = QString("apt_%1_%2.png").arg(m_satelliteName.replace(" ", "_")).arg(datetime.toString("yyyyMMdd_hhmm"));
 
         if (!m_settings.m_autoSavePath.isEmpty())
         {

--- a/plugins/channelrx/demodapt/aptdemodimageworker.h
+++ b/plugins/channelrx/demodapt/aptdemodimageworker.h
@@ -74,6 +74,27 @@ public:
         }
     };
 
+    class MsgSetSatelliteName : public Message {
+        MESSAGE_CLASS_DECLARATION
+
+    public:
+        QString getSatelliteName() const { return m_satelliteName; }
+
+        static MsgSetSatelliteName* create(const QString &satelliteName)
+        {
+            return new MsgSetSatelliteName(satelliteName);
+        }
+
+    private:
+        QString m_satelliteName;
+
+        MsgSetSatelliteName(const QString &satelliteName) :
+            Message(),
+            m_satelliteName(satelliteName)
+        {
+        }
+    };
+
     APTDemodImageWorker();
     ~APTDemodImageWorker();
     void reset();


### PR DESCRIPTION
Pass satellite name to image worker thread (so it appears in filename and GUI).
Don't stop image worker thread when device stopped, as this prevents the image processing controls in the GUI from working.
