### PR TITLE
Set DATV GUI to be minimum sized rather than expanding. 

### DIFF
--- a/plugins/channelrx/demoddatv/datvdemodgui.ui
+++ b/plugins/channelrx/demoddatv/datvdemodgui.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -20,6 +20,12 @@
    <size>
     <width>530</width>
     <height>442</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>530</width>
+    <height>476</height>
    </size>
   </property>
   <property name="font">
@@ -191,6 +197,12 @@
      <height>431</height>
     </rect>
    </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
    <property name="minimumSize">
     <size>
      <width>526</width>
@@ -207,6 +219,12 @@
     <number>1</number>
    </property>
    <widget class="QWidget" name="datvTab">
+    <property name="minimumSize">
+     <size>
+      <width>0</width>
+      <height>0</height>
+     </size>
+    </property>
     <attribute name="title">
      <string>DATV</string>
     </attribute>
@@ -1074,10 +1092,16 @@
    </widget>
    <widget class="QWidget" name="videoTab">
     <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
       <horstretch>0</horstretch>
       <verstretch>0</verstretch>
      </sizepolicy>
+    </property>
+    <property name="minimumSize">
+     <size>
+      <width>526</width>
+      <height>400</height>
+     </size>
     </property>
     <attribute name="title">
      <string>Video</string>
@@ -1090,6 +1114,12 @@
        <width>496</width>
        <height>111</height>
       </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="title">
       <string>VIDEO Stream</string>
@@ -1338,15 +1368,21 @@
       <item>
        <widget class="DATVideoRender" name="screenTV_2" native="true">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>493</width>
+          <height>279</height>
+         </size>
+        </property>
         <property name="maximumSize">
          <size>
-          <width>490</width>
-          <height>270</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
        </widget>


### PR DESCRIPTION
Set minimum size constraint on videoTab not just tabWidget so that window isn't too small. Let me know if it fixes the probem - it seems to for me.

(This assumes the other earlier PR is applied).