### PR TITLE
RTLSDR: Restore biasT widget state in displaySettings

### DIFF
--- a/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
@@ -299,6 +299,7 @@ void RTLSDRGui::displaySettings()
 	ui->agc->setChecked(m_settings.m_agc);
 	ui->lowSampleRate->setChecked(m_settings.m_lowSampleRate);
 	ui->offsetTuning->setChecked(m_settings.m_offsetTuning);
+	ui->biasT->setChecked(m_settings.m_biasTee);
 }
 
 void RTLSDRGui::sendSettings()


### PR DESCRIPTION
Currently the biasT setting in the GUI isn't being restored to what is saved in the preset. This should fix that.