### PR TITLE
#1031 - RemoteInput GUI - Use editingFinished signal rather than returnPressed

### DIFF
--- a/plugins/samplesource/remoteinput/remoteinputgui.cpp
+++ b/plugins/samplesource/remoteinput/remoteinputgui.cpp
@@ -330,7 +330,7 @@ void RemoteInputGui::on_dataApplyButton_clicked(bool checked)
     sendSettings();
 }
 
-void RemoteInputGui::on_apiAddress_returnPressed()
+void RemoteInputGui::on_apiAddress_editingFinished()
 {
     m_settings.m_apiAddress = ui->apiAddress->text();
 
@@ -341,14 +341,14 @@ void RemoteInputGui::on_apiAddress_returnPressed()
     sendSettings();
 }
 
-void RemoteInputGui::on_dataAddress_returnPressed()
+void RemoteInputGui::on_dataAddress_editingFinished()
 {
     m_settings.m_dataAddress = ui->dataAddress->text();
     ui->dataApplyButton->setEnabled(true);
     ui->dataApplyButton->setStyleSheet("QPushButton { background-color : green; }");
 }
 
-void RemoteInputGui::on_dataPort_returnPressed()
+void RemoteInputGui::on_dataPort_editingFinished()
 {
     bool ok;
     quint16 udpPort = ui->dataPort->text().toInt(&ok);
@@ -364,7 +364,7 @@ void RemoteInputGui::on_dataPort_returnPressed()
     ui->dataApplyButton->setStyleSheet("QPushButton { background-color : green; }");
 }
 
-void RemoteInputGui::on_multicastAddress_returnPressed()
+void RemoteInputGui::on_multicastAddress_editingFinished()
 {
     m_settings.m_multicastAddress = ui->multicastAddress->text();
     ui->dataApplyButton->setEnabled(true);
@@ -378,7 +378,7 @@ void RemoteInputGui::on_multicastJoin_toggled(bool checked)
     ui->dataApplyButton->setStyleSheet("QPushButton { background-color : green; }");
 }
 
-void RemoteInputGui::on_apiPort_returnPressed()
+void RemoteInputGui::on_apiPort_editingFinished()
 {
     bool ctlOk;
     int udpApiPort = ui->apiPort->text().toInt(&ctlOk);

--- a/plugins/samplesource/remoteinput/remoteinputgui.h
+++ b/plugins/samplesource/remoteinput/remoteinputgui.h
@@ -120,11 +120,11 @@ private slots:
     void on_dataApplyButton_clicked(bool checked);
 	void on_dcOffset_toggled(bool checked);
 	void on_iqImbalance_toggled(bool checked);
-	void on_apiAddress_returnPressed();
-	void on_apiPort_returnPressed();
-    void on_dataAddress_returnPressed();
-	void on_dataPort_returnPressed();
-    void on_multicastAddress_returnPressed();
+	void on_apiAddress_editingFinished();
+	void on_apiPort_editingFinished();
+    void on_dataAddress_editingFinished();
+	void on_dataPort_editingFinished();
+    void on_multicastAddress_editingFinished();
 	void on_multicastJoin_toggled(bool checked);
 	void on_startStop_toggled(bool checked);
     void on_eventCountsReset_clicked(bool checked);


### PR DESCRIPTION
So Set button is highlighted if focus is changed with mouse or tab as per #1031.