### PR TITLE
Save/restore rollup state in features

### DIFF
--- a/plugins/feature/afc/afcgui.cpp
+++ b/plugins/feature/afc/afcgui.cpp
@@ -113,6 +113,9 @@ void AFCGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 AFCGUI::AFCGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feature, QWidget* parent) :
@@ -175,6 +178,7 @@ void AFCGUI::displaySettings()
     ui->toleranceFrequency->setValue(m_settings.m_freqTolerance);
     ui->targetPeriod->setValue(m_settings.m_trackerAdjustPeriod);
     ui->targetPeriodText->setText(tr("%1").arg(m_settings.m_trackerAdjustPeriod));
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/feature/afc/afcsettings.cpp
+++ b/plugins/feature/afc/afcsettings.cpp
@@ -63,6 +63,7 @@ QByteArray AFCSettings::serialize() const
     s.writeU32(12, m_reverseAPIPort);
     s.writeU32(13, m_reverseAPIFeatureSetIndex);
     s.writeU32(14, m_reverseAPIFeatureIndex);
+    s.writeBlob(15, m_rollupState);
 
     return s.final();
 }
@@ -106,6 +107,7 @@ bool AFCSettings::deserialize(const QByteArray& data)
         m_reverseAPIFeatureSetIndex = utmp > 99 ? 99 : utmp;
         d.readU32(14, &utmp, 0);
         m_reverseAPIFeatureIndex = utmp > 99 ? 99 : utmp;
+        d.readBlob(15, &m_rollupState);
 
         return true;
     }

--- a/plugins/feature/afc/afcsettings.h
+++ b/plugins/feature/afc/afcsettings.h
@@ -39,6 +39,7 @@ struct AFCSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIFeatureSetIndex;
     uint16_t m_reverseAPIFeatureIndex;
+    QByteArray m_rollupState;
 
     AFCSettings();
     void resetToDefaults();

--- a/plugins/feature/ais/aisgui.cpp
+++ b/plugins/feature/ais/aisgui.cpp
@@ -114,6 +114,9 @@ void AISGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 AISGUI::AISGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feature, QWidget* parent) :
@@ -191,6 +194,7 @@ void AISGUI::displaySettings()
         header->moveSection(header->visualIndex(i), m_settings.m_vesselColumnIndexes[i]);
     }
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
     arrangeRollups();
 }

--- a/plugins/feature/ais/aissettings.cpp
+++ b/plugins/feature/ais/aissettings.cpp
@@ -64,6 +64,7 @@ QByteArray AISSettings::serialize() const
     s.writeU32(24, m_reverseAPIPort);
     s.writeU32(25, m_reverseAPIFeatureSetIndex);
     s.writeU32(26, m_reverseAPIFeatureIndex);
+    s.writeBlob(27, m_rollupState);
 
     for (int i = 0; i < AIS_VESSEL_COLUMNS; i++)
         s.writeS32(300 + i, m_vesselColumnIndexes[i]);
@@ -106,6 +107,7 @@ bool AISSettings::deserialize(const QByteArray& data)
         m_reverseAPIFeatureSetIndex = utmp > 99 ? 99 : utmp;
         d.readU32(26, &utmp, 0);
         m_reverseAPIFeatureIndex = utmp > 99 ? 99 : utmp;
+        d.readBlob(27, &m_rollupState);
 
         for (int i = 0; i < AIS_VESSEL_COLUMNS; i++)
             d.readS32(300 + i, &m_vesselColumnIndexes[i], i);

--- a/plugins/feature/ais/aissettings.h
+++ b/plugins/feature/ais/aissettings.h
@@ -38,6 +38,7 @@ struct AISSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIFeatureSetIndex;
     uint16_t m_reverseAPIFeatureIndex;
+    QByteArray m_rollupState;
 
     int m_vesselColumnIndexes[AIS_VESSEL_COLUMNS];
     int m_vesselColumnSizes[AIS_VESSEL_COLUMNS];

--- a/plugins/feature/antennatools/antennatoolsgui.cpp
+++ b/plugins/feature/antennatools/antennatoolsgui.cpp
@@ -101,6 +101,9 @@ void AntennaToolsGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 AntennaToolsGUI::AntennaToolsGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feature, QWidget* parent) :
@@ -164,6 +167,7 @@ void AntennaToolsGUI::displaySettings()
     calcDishBeamwidth();
     calcDishGain();
     calcDishEffectiveArea();
+    restoreState(m_settings.m_rollupState);
 }
 
 void AntennaToolsGUI::leaveEvent(QEvent*)

--- a/plugins/feature/antennatools/antennatoolssettings.cpp
+++ b/plugins/feature/antennatools/antennatoolssettings.cpp
@@ -76,6 +76,7 @@ QByteArray AntennaToolsSettings::serialize() const
     s.writeU32(15, m_reverseAPIPort);
     s.writeU32(16, m_reverseAPIFeatureSetIndex);
     s.writeU32(17, m_reverseAPIFeatureIndex);
+    s.writeBlob(19, m_rollupState);
 
     return s.final();
 }
@@ -125,6 +126,8 @@ bool AntennaToolsSettings::deserialize(const QByteArray& data)
         m_reverseAPIFeatureSetIndex = utmp > 99 ? 99 : utmp;
         d.readU32(17, &utmp, 0);
         m_reverseAPIFeatureIndex = utmp > 99 ? 99 : utmp;
+
+        d.readBlob(19, &m_rollupState);
 
         return true;
     }

--- a/plugins/feature/antennatools/antennatoolssettings.h
+++ b/plugins/feature/antennatools/antennatoolssettings.h
@@ -50,6 +50,7 @@ struct AntennaToolsSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIFeatureSetIndex;
     uint16_t m_reverseAPIFeatureIndex;
+    QByteArray m_rollupState;
 
     AntennaToolsSettings();
     void resetToDefaults();

--- a/plugins/feature/aprs/aprsgui.cpp
+++ b/plugins/feature/aprs/aprsgui.cpp
@@ -408,6 +408,9 @@ void APRSGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 APRSGUI::APRSGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feature, QWidget* parent) :
@@ -622,6 +625,8 @@ void APRSGUI::displaySettings()
     displayTableSettings(ui->messagesTable, messagesTableMenu, m_settings.m_messagesTableColumnSizes, m_settings.m_messagesTableColumnIndexes, APRS_MESSAGES_TABLE_COLUMNS);
     displayTableSettings(ui->telemetryTable, telemetryTableMenu, m_settings.m_telemetryTableColumnSizes, m_settings.m_telemetryTableColumnIndexes, APRS_TELEMETRY_TABLE_COLUMNS);
     displayTableSettings(ui->motionTable, motionTableMenu, m_settings.m_motionTableColumnSizes, m_settings.m_motionTableColumnIndexes, APRS_MOTION_TABLE_COLUMNS);
+
+    restoreState(m_settings.m_rollupState);
 
     blockApplySettings(false);
 }

--- a/plugins/feature/aprs/aprssettings.cpp
+++ b/plugins/feature/aprs/aprssettings.cpp
@@ -131,6 +131,7 @@ QByteArray APRSSettings::serialize() const
     s.writeS32(17, (int)m_speedUnits);
     s.writeS32(18, (int)m_temperatureUnits);
     s.writeS32(19, (int)m_rainfallUnits);
+    s.writeBlob(20, m_rollupState);
 
     for (int i = 0; i < APRS_PACKETS_TABLE_COLUMNS; i++)
         s.writeS32(100 + i, m_packetsTableColumnIndexes[i]);
@@ -206,6 +207,8 @@ bool APRSSettings::deserialize(const QByteArray& data)
         d.readS32(17, (int *)&m_speedUnits, (int)KNOTS);
         d.readS32(18, (int *)&m_temperatureUnits, (int)FAHRENHEIT);
         d.readS32(19, (int *)&m_rainfallUnits, (int)HUNDREDTHS_OF_AN_INCH);
+
+        d.readBlob(20, &m_rollupState);
 
         for (int i = 0; i < APRS_PACKETS_TABLE_COLUMNS; i++)
             d.readS32(100 + i, &m_packetsTableColumnIndexes[i], i);

--- a/plugins/feature/aprs/aprssettings.h
+++ b/plugins/feature/aprs/aprssettings.h
@@ -65,6 +65,7 @@ struct APRSSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIFeatureSetIndex;
     uint16_t m_reverseAPIFeatureIndex;
+    QByteArray m_rollupState;
 
     int m_packetsTableColumnIndexes[APRS_PACKETS_TABLE_COLUMNS];//!< How the columns are ordered in the table
     int m_packetsTableColumnSizes[APRS_PACKETS_TABLE_COLUMNS];  //!< Size of the columns in the table

--- a/plugins/feature/demodanalyzer/demodanalyzergui.cpp
+++ b/plugins/feature/demodanalyzer/demodanalyzergui.cpp
@@ -122,6 +122,9 @@ void DemodAnalyzerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 DemodAnalyzerGUI::DemodAnalyzerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feature, QWidget* parent) :
@@ -188,6 +191,7 @@ void DemodAnalyzerGUI::displaySettings()
     setWindowTitle(m_settings.m_title);
     blockApplySettings(true);
     ui->log2Decim->setCurrentIndex(m_settings.m_log2Decim);
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/feature/demodanalyzer/demodanalyzersettings.cpp
+++ b/plugins/feature/demodanalyzer/demodanalyzersettings.cpp
@@ -89,6 +89,7 @@ QByteArray DemodAnalyzerSettings::serialize() const
     s.writeU32(9, m_reverseAPIPort);
     s.writeU32(10, m_reverseAPIFeatureSetIndex);
     s.writeU32(11, m_reverseAPIFeatureIndex);
+    s.writeBlob(12, m_rollupState);
 
     return s.final();
 }
@@ -138,6 +139,7 @@ bool DemodAnalyzerSettings::deserialize(const QByteArray& data)
         m_reverseAPIFeatureSetIndex = utmp > 99 ? 99 : utmp;
         d.readU32(11, &utmp, 0);
         m_reverseAPIFeatureIndex = utmp > 99 ? 99 : utmp;
+        d.readBlob(12, &m_rollupState);
 
         return true;
     }

--- a/plugins/feature/demodanalyzer/demodanalyzersettings.h
+++ b/plugins/feature/demodanalyzer/demodanalyzersettings.h
@@ -51,6 +51,7 @@ struct DemodAnalyzerSettings
     uint16_t m_reverseAPIFeatureIndex;
     Serializable *m_spectrumGUI;
     Serializable *m_scopeGUI;
+    QByteArray m_rollupState;
 
     DemodAnalyzerSettings();
     void resetToDefaults();

--- a/plugins/feature/pertester/pertestergui.cpp
+++ b/plugins/feature/pertester/pertestergui.cpp
@@ -113,6 +113,9 @@ void PERTesterGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 PERTesterGUI::PERTesterGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feature, QWidget* parent) :
@@ -170,6 +173,7 @@ void PERTesterGUI::displaySettings()
     ui->txUDPPort->setText(QString::number(m_settings.m_txUDPPort));
     ui->rxUDPAddress->setText(m_settings.m_rxUDPAddress);
     ui->rxUDPPort->setText(QString::number(m_settings.m_rxUDPPort));
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
     arrangeRollups();
 }

--- a/plugins/feature/pertester/pertestersettings.cpp
+++ b/plugins/feature/pertester/pertestersettings.cpp
@@ -73,6 +73,7 @@ QByteArray PERTesterSettings::serialize() const
     s.writeU32(24, m_reverseAPIPort);
     s.writeU32(25, m_reverseAPIFeatureSetIndex);
     s.writeU32(26, m_reverseAPIFeatureIndex);
+    s.writeBlob(27, m_rollupState);
 
     return s.final();
 }
@@ -132,6 +133,8 @@ bool PERTesterSettings::deserialize(const QByteArray& data)
         m_reverseAPIFeatureSetIndex = utmp > 99 ? 99 : utmp;
         d.readU32(26, &utmp, 0);
         m_reverseAPIFeatureIndex = utmp > 99 ? 99 : utmp;
+
+        d.readBlob(27, &m_rollupState);
 
         return true;
     }

--- a/plugins/feature/pertester/pertestersettings.h
+++ b/plugins/feature/pertester/pertestersettings.h
@@ -47,6 +47,7 @@ struct PERTesterSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIFeatureSetIndex;
     uint16_t m_reverseAPIFeatureIndex;
+    QByteArray m_rollupState;
 
     PERTesterSettings();
     void resetToDefaults();

--- a/plugins/feature/rigctlserver/rigctlservergui.cpp
+++ b/plugins/feature/rigctlserver/rigctlservergui.cpp
@@ -113,6 +113,9 @@ void RigCtlServerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 RigCtlServerGUI::RigCtlServerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feature, QWidget* parent) :
@@ -160,6 +163,7 @@ void RigCtlServerGUI::displaySettings()
     blockApplySettings(true);
     ui->rigCtrlPort->setValue(m_settings.m_rigCtlPort);
     ui->maxFrequencyOffset->setValue(m_settings.m_maxFrequencyOffset);
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/feature/rigctlserver/rigctlserversettings.cpp
+++ b/plugins/feature/rigctlserver/rigctlserversettings.cpp
@@ -60,6 +60,7 @@ QByteArray RigCtlServerSettings::serialize() const
     s.writeU32(9, m_reverseAPIPort);
     s.writeU32(10, m_reverseAPIFeatureSetIndex);
     s.writeU32(11, m_reverseAPIFeatureIndex);
+    s.writeBlob(12, m_rollupState);
 
     return s.final();
 }
@@ -107,6 +108,7 @@ bool RigCtlServerSettings::deserialize(const QByteArray& data)
         m_reverseAPIFeatureSetIndex = utmp > 99 ? 99 : utmp;
         d.readU32(11, &utmp, 0);
         m_reverseAPIFeatureIndex = utmp > 99 ? 99 : utmp;
+        d.readBlob(12, &m_rollupState);
 
         return true;
     }

--- a/plugins/feature/rigctlserver/rigctlserversettings.h
+++ b/plugins/feature/rigctlserver/rigctlserversettings.h
@@ -59,6 +59,7 @@ struct RigCtlServerSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIFeatureSetIndex;
     uint16_t m_reverseAPIFeatureIndex;
+    QByteArray m_rollupState;
 
     RigCtlServerSettings();
     void resetToDefaults();

--- a/plugins/feature/satellitetracker/satellitetrackergui.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackergui.cpp
@@ -226,6 +226,9 @@ void SatelliteTrackerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 SatelliteTrackerGUI::SatelliteTrackerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feature, QWidget* parent) :
@@ -333,6 +336,7 @@ void SatelliteTrackerGUI::displaySettings()
     }
     ui->autoTarget->setChecked(m_settings.m_autoTarget);
     ui->darkTheme->setChecked(m_settings.m_chartsDarkTheme);
+    restoreState(m_settings.m_rollupState);
     plotChart();
     blockApplySettings(false);
 }

--- a/plugins/feature/satellitetracker/satellitetrackersettings.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackersettings.cpp
@@ -120,6 +120,7 @@ QByteArray SatelliteTrackerSettings::serialize() const
     s.writeU32(34, m_reverseAPIFeatureSetIndex);
     s.writeU32(35, m_reverseAPIFeatureIndex);
     s.writeBool(36, m_chartsDarkTheme);
+    s.writeBlob(37, m_rollupState);
 
     for (int i = 0; i < SAT_COL_COLUMNS; i++)
         s.writeS32(100 + i, m_columnIndexes[i]);
@@ -197,6 +198,7 @@ bool SatelliteTrackerSettings::deserialize(const QByteArray& data)
         d.readU32(35, &utmp, 0);
         m_reverseAPIFeatureIndex = utmp > 99 ? 99 : utmp;
         d.readBool(36, &m_chartsDarkTheme, true);
+        d.readBlob(37, &m_rollupState);
 
         for (int i = 0; i < SAT_COL_COLUMNS; i++)
             d.readS32(100 + i, &m_columnIndexes[i], i);

--- a/plugins/feature/satellitetracker/satellitetrackersettings.h
+++ b/plugins/feature/satellitetracker/satellitetrackersettings.h
@@ -87,6 +87,7 @@ struct SatelliteTrackerSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIFeatureSetIndex;
     uint16_t m_reverseAPIFeatureIndex;
+    QByteArray m_rollupState;
 
     SatelliteTrackerSettings();
     void resetToDefaults();

--- a/plugins/feature/satellitetracker/satellitetrackersgp4.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackersgp4.cpp
@@ -112,6 +112,11 @@ void getPassAzEl(QLineSeries* azimuth, QLineSeries* elevation, QLineSeries* pola
         int steps = 20;
 
         double timeStep = (losTime - aosTime).TotalSeconds() / steps;
+        if (timeStep <= 0.0)
+        {
+            qDebug() << "getPassAzEl: AOS is the same as or after LOS";
+            return;
+        }
 
         while (currentTime <= losTime)
         {

--- a/plugins/feature/simpleptt/simplepttgui.cpp
+++ b/plugins/feature/simpleptt/simplepttgui.cpp
@@ -120,6 +120,9 @@ void SimplePTTGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 SimplePTTGUI::SimplePTTGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feature, QWidget* parent) :
@@ -175,6 +178,7 @@ void SimplePTTGUI::displaySettings()
     blockApplySettings(true);
     ui->rxtxDelay->setValue(m_settings.m_rx2TxDelayMs);
     ui->txrxDelay->setValue(m_settings.m_tx2RxDelayMs);
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/feature/simpleptt/simplepttsettings.cpp
+++ b/plugins/feature/simpleptt/simplepttsettings.cpp
@@ -57,6 +57,7 @@ QByteArray SimplePTTSettings::serialize() const
     s.writeU32(9, m_reverseAPIPort);
     s.writeU32(10, m_reverseAPIFeatureSetIndex);
     s.writeU32(11, m_reverseAPIFeatureIndex);
+    s.writeBlob(12, m_rollupState);
 
     return s.final();
 }
@@ -97,6 +98,7 @@ bool SimplePTTSettings::deserialize(const QByteArray& data)
         m_reverseAPIFeatureSetIndex = utmp > 99 ? 99 : utmp;
         d.readU32(11, &utmp, 0);
         m_reverseAPIFeatureIndex = utmp > 99 ? 99 : utmp;
+        d.readBlob(12, &m_rollupState);
 
         return true;
     }

--- a/plugins/feature/simpleptt/simplepttsettings.h
+++ b/plugins/feature/simpleptt/simplepttsettings.h
@@ -36,6 +36,7 @@ struct SimplePTTSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIFeatureSetIndex;
     uint16_t m_reverseAPIFeatureIndex;
+    QByteArray m_rollupState;
 
     SimplePTTSettings();
     void resetToDefaults();

--- a/plugins/feature/startracker/startrackergui.cpp
+++ b/plugins/feature/startracker/startrackergui.cpp
@@ -223,6 +223,9 @@ void StarTrackerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 StarTrackerGUI::StarTrackerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feature, QWidget* parent) :
@@ -430,6 +433,7 @@ void StarTrackerGUI::displaySettings()
     ui->frequency->setValue(m_settings.m_frequency/1000000.0);
     ui->beamwidth->setValue(m_settings.m_beamwidth);
     updateForTarget();
+    restoreState(m_settings.m_rollupState);
     plotChart();
     blockApplySettings(false);
 }

--- a/plugins/feature/startracker/startrackersettings.cpp
+++ b/plugins/feature/startracker/startrackersettings.cpp
@@ -130,6 +130,7 @@ QByteArray StarTrackerSettings::serialize() const
     s.writeDouble(41, m_elOffset);
     s.writeBool(42, m_drawSunOnSkyTempChart);
     s.writeBool(43, m_drawMoonOnSkyTempChart);
+    s.writeBlob(44, m_rollupState);
 
     return s.final();
 }
@@ -213,6 +214,8 @@ bool StarTrackerSettings::deserialize(const QByteArray& data)
 
         d.readBool(42, &m_drawSunOnSkyTempChart, true);
         d.readBool(43, &m_drawMoonOnSkyTempChart, true);
+
+        d.readBlob(44, &m_rollupState);
 
         return true;
     }

--- a/plugins/feature/startracker/startrackersettings.h
+++ b/plugins/feature/startracker/startrackersettings.h
@@ -71,6 +71,7 @@ struct StarTrackerSettings
     double m_elOffset;
     bool m_drawSunOnSkyTempChart;
     bool m_drawMoonOnSkyTempChart;
+    QByteArray m_rollupState;
 
     StarTrackerSettings();
     void resetToDefaults();

--- a/plugins/feature/vorlocalizer/vorlocalizergui.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizergui.cpp
@@ -1173,6 +1173,9 @@ void VORLocalizerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void VORLocalizerGUI::onMenuDialogCalled(const QPoint &p)
@@ -1373,6 +1376,7 @@ void VORLocalizerGUI::displaySettings()
     ui->centerShift->setValue(m_settings.m_centerShift/1000);
     ui->forceRRAveraging->setChecked(m_settings.m_forceRRAveraging);
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/feature/vorlocalizer/vorlocalizersettings.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizersettings.cpp
@@ -63,6 +63,7 @@ QByteArray VORLocalizerSettings::serialize() const
     s.writeU32(16, m_reverseAPIPort);
     s.writeU32(17, m_reverseAPIFeatureSetIndex);
     s.writeU32(18, m_reverseAPIFeatureIndex);
+    s.writeBlob(19, m_rollupState);
 
     for (int i = 0; i < VORDEMOD_COLUMNS; i++) {
         s.writeS32(100 + i, m_columnIndexes[i]);
@@ -111,6 +112,7 @@ bool VORLocalizerSettings::deserialize(const QByteArray& data)
         m_reverseAPIFeatureSetIndex = utmp > 99 ? 99 : utmp;
         d.readU32(18, &utmp, 0);
         m_reverseAPIFeatureIndex = utmp > 99 ? 99 : utmp;
+        d.readBlob(19, &m_rollupState);
 
         for (int i = 0; i < VORDEMOD_COLUMNS; i++) {
             d.readS32(100 + i, &m_columnIndexes[i], i);

--- a/plugins/feature/vorlocalizer/vorlocalizersettings.h
+++ b/plugins/feature/vorlocalizer/vorlocalizersettings.h
@@ -73,6 +73,7 @@ struct VORLocalizerSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIFeatureSetIndex;
     uint16_t m_reverseAPIFeatureIndex;
+    QByteArray m_rollupState;
 
 
     static const int VORDEMOD_COLUMNS  = 11;


### PR DESCRIPTION
This PR saves and restores the rollup state for Features, allowing GUI elements to be automatically hidden when loading a preset.

I'll add another patch for Channels if this is accepted.

Note, this is already included for the Rotator Controller in the other PR. Map feature will follow separately.
