### PR TITLE
Save/restore rollup state in channel plugins

### DIFF
--- a/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodgui.cpp
+++ b/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodgui.cpp
@@ -167,6 +167,7 @@ void BeamSteeringCWModGUI::displaySettings()
     ui->interpolationFactor->setCurrentIndex(m_settings.m_log2Interp);
     applyInterpolation();
     ui->steeringDegreesText->setText(tr("%1").arg(m_settings.m_steerDegrees));
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 
@@ -208,6 +209,9 @@ void BeamSteeringCWModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void BeamSteeringCWModGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodsettings.cpp
+++ b/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodsettings.cpp
@@ -58,6 +58,7 @@ QByteArray BeamSteeringCWModSettings::serialize() const
     s.writeU32(12, m_log2Interp);
     s.writeU32(13, m_filterChainHash);
     s.writeS32(14, m_channelOutput);
+    s.writeBlob(15, m_rollupState);
 
     return s.final();
 }
@@ -101,6 +102,7 @@ bool BeamSteeringCWModSettings::deserialize(const QByteArray& data)
         d.readU32(13, &m_filterChainHash, 0);
         d.readS32(14, &stmp, 0);
         m_channelOutput = stmp < 0 ? 0 : stmp > 2 ? 2 : stmp;
+        d.readBlob(15, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodsettings.h
+++ b/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodsettings.h
@@ -38,6 +38,7 @@ struct BeamSteeringCWModSettings
     uint16_t m_reverseAPIChannelIndex;
 
     Serializable *m_channelMarker;
+    QByteArray m_rollupState;
 
     BeamSteeringCWModSettings();
     void resetToDefaults();

--- a/plugins/channelmimo/interferometer/interferometergui.cpp
+++ b/plugins/channelmimo/interferometer/interferometergui.cpp
@@ -198,6 +198,7 @@ void InterferometerGUI::displaySettings()
     applyDecimation();
     ui->phaseCorrection->setValue(m_settings.m_phase);
     ui->phaseCorrectionText->setText(tr("%1").arg(m_settings.m_phase));
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 
@@ -241,6 +242,9 @@ void InterferometerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void InterferometerGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channelmimo/interferometer/interferometersettings.cpp
+++ b/plugins/channelmimo/interferometer/interferometersettings.cpp
@@ -70,6 +70,7 @@ QByteArray InterferometerSettings::serialize() const
     if (m_channelMarker) {
         s.writeBlob(22, m_channelMarker->serialize());
     }
+    s.writeBlob(23, m_rollupState);
 
     return s.final();
 }
@@ -125,9 +126,10 @@ bool InterferometerSettings::deserialize(const QByteArray& data)
         }
 
         if (m_channelMarker) {
-            d.readBlob(21, &bytetmp);
+            d.readBlob(22, &bytetmp);
             m_channelMarker->deserialize(bytetmp);
         }
+        d.readBlob(23, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelmimo/interferometer/interferometersettings.h
+++ b/plugins/channelmimo/interferometer/interferometersettings.h
@@ -52,6 +52,7 @@ struct InterferometerSettings
     Serializable *m_channelMarker;
     Serializable *m_spectrumGUI;
     Serializable *m_scopeGUI;
+    QByteArray m_rollupState;
 
     InterferometerSettings();
     void resetToDefaults();

--- a/plugins/channelrx/chanalyzer/chanalyzergui.cpp
+++ b/plugins/channelrx/chanalyzer/chanalyzergui.cpp
@@ -97,6 +97,7 @@ void ChannelAnalyzerGUI::displaySettings()
     QString rolloffStr = QString::number(m_settings.m_rrcRolloff/100.0, 'f', 2);
     ui->rrcRolloffText->setText(rolloffStr);
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 
@@ -432,6 +433,9 @@ void ChannelAnalyzerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void ChannelAnalyzerGUI::onMenuDialogCalled(const QPoint& p)

--- a/plugins/channelrx/chanalyzer/chanalyzersettings.cpp
+++ b/plugins/channelrx/chanalyzer/chanalyzersettings.cpp
@@ -79,6 +79,7 @@ QByteArray ChannelAnalyzerSettings::serialize() const
     s.writeFloat(19, m_pllDampingFactor);
     s.writeFloat(20, m_pllLoopGain);
     s.writeBool(21, m_costasLoop);
+    s.writeBlob(22, m_rollupState);
 
     return s.final();
 }
@@ -130,6 +131,7 @@ bool ChannelAnalyzerSettings::deserialize(const QByteArray& data)
         d.readFloat(19, &m_pllDampingFactor, 0.5f);
         d.readFloat(20, &m_pllLoopGain, 10.0f);
         d.readBool(21, &m_costasLoop, false);
+        d.readBlob(22, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/chanalyzer/chanalyzersettings.h
+++ b/plugins/channelrx/chanalyzer/chanalyzersettings.h
@@ -53,6 +53,7 @@ struct ChannelAnalyzerSettings
     Serializable *m_channelMarker;
     Serializable *m_spectrumGUI;
     Serializable *m_scopeGUI;
+    QByteArray m_rollupState;
 
     ChannelAnalyzerSettings();
     void resetToDefaults();

--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -1994,6 +1994,9 @@ void ADSBDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void ADSBDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -2775,6 +2778,7 @@ void ADSBDemodGUI::displaySettings()
 
     applyMapSettings();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
@@ -133,6 +133,7 @@ QByteArray ADSBDemodSettings::serialize() const
     s.writeS32(40, (int)m_mapType);
     s.writeBool(41, m_displayNavAids);
     s.writeBool(42, m_displayPhotos);
+    s.writeBlob(43, m_rollupState);
 
     for (int i = 0; i < ADSBDEMOD_COLUMNS; i++) {
         s.writeS32(100 + i, m_columnIndexes[i]);
@@ -231,6 +232,7 @@ bool ADSBDemodSettings::deserialize(const QByteArray& data)
         d.readS32(40, (int *)&m_mapType, (int)AVIATION_LIGHT);
         d.readBool(41, &m_displayNavAids, true);
         d.readBool(42, &m_displayPhotos, true);
+        d.readBlob(43, &m_rollupState);
 
         for (int i = 0; i < ADSBDEMOD_COLUMNS; i++) {
             d.readS32(100 + i, &m_columnIndexes[i], i);

--- a/plugins/channelrx/demodadsb/adsbdemodsettings.h
+++ b/plugins/channelrx/demodadsb/adsbdemodsettings.h
@@ -144,6 +144,7 @@ struct ADSBDemodSettings
     } m_mapType;
     bool m_displayNavAids;
     bool m_displayPhotos;
+    QByteArray m_rollupState;
 
     ADSBDemodSettings();
     void resetToDefaults();

--- a/plugins/channelrx/demodais/aisdemodgui.cpp
+++ b/plugins/channelrx/demodais/aisdemodgui.cpp
@@ -361,6 +361,9 @@ void AISDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
             setMinimumWidth(352);
         }
     }
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void AISDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -597,6 +600,7 @@ void AISDemodGUI::displaySettings()
     }
     filter();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodais/aisdemodsettings.cpp
+++ b/plugins/channelrx/demodais/aisdemodsettings.cpp
@@ -92,6 +92,7 @@ QByteArray AISDemodSettings::serialize() const
     s.writeString(22, m_logFilename);
     s.writeBool(23, m_logEnabled);
     s.writeS32(24, m_baud);
+    s.writeBlob(25, m_rollupState);
 
     for (int i = 0; i < AISDEMOD_MESSAGE_COLUMNS; i++)
         s.writeS32(100 + i, m_messageColumnIndexes[i]);
@@ -162,6 +163,7 @@ bool AISDemodSettings::deserialize(const QByteArray& data)
         d.readString(22, &m_logFilename, "ais_log.csv");
         d.readBool(23, &m_logEnabled, false);
         d.readS32(24, &m_baud, 9600);
+        d.readBlob(25, &m_rollupState);
 
         for (int i = 0; i < AISDEMOD_MESSAGE_COLUMNS; i++)
             d.readS32(100 + i, &m_messageColumnIndexes[i], i);

--- a/plugins/channelrx/demodais/aisdemodsettings.h
+++ b/plugins/channelrx/demodais/aisdemodsettings.h
@@ -60,6 +60,7 @@ struct AISDemodSettings
     uint16_t m_reverseAPIDeviceIndex;
     uint16_t m_reverseAPIChannelIndex;
     Serializable *m_scopeGUI;
+    QByteArray m_rollupState;
 
     int m_messageColumnIndexes[AISDEMOD_MESSAGE_COLUMNS];//!< How the columns are ordered in the table
     int m_messageColumnSizes[AISDEMOD_MESSAGE_COLUMNS];  //!< Size of the columns in the table

--- a/plugins/channelrx/demodam/amdemodgui.cpp
+++ b/plugins/channelrx/demodam/amdemodgui.cpp
@@ -180,6 +180,9 @@ void AMDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 	if((widget == ui->spectrumContainer) && (m_nfmDemod != NULL))
 		m_nfmDemod->setSpectrum(m_threadedSampleSink->getMessageQueue(), rollDown);
 	*/
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void AMDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -367,6 +370,7 @@ void AMDemodGUI::displaySettings()
 
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodam/amdemodsettings.cpp
+++ b/plugins/channelrx/demodam/amdemodsettings.cpp
@@ -73,6 +73,7 @@ QByteArray AMDemodSettings::serialize() const
     s.writeU32(16, m_reverseAPIPort);
     s.writeU32(17, m_reverseAPIDeviceIndex);
     s.writeU32(18, m_reverseAPIChannelIndex);
+    s.writeBlob(19, m_rollupState);
 
     return s.final();
 }
@@ -129,6 +130,7 @@ bool AMDemodSettings::deserialize(const QByteArray& data)
         m_reverseAPIDeviceIndex = utmp > 99 ? 99 : utmp;
         d.readU32(18, &utmp, 0);
         m_reverseAPIChannelIndex = utmp > 99 ? 99 : utmp;
+        d.readBlob(19, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/demodam/amdemodsettings.h
+++ b/plugins/channelrx/demodam/amdemodsettings.h
@@ -49,6 +49,7 @@ struct AMDemodSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIDeviceIndex;
     uint16_t m_reverseAPIChannelIndex;
+    QByteArray m_rollupState;
 
     AMDemodSettings();
     void resetToDefaults();

--- a/plugins/channelrx/demodapt/aptdemodgui.cpp
+++ b/plugins/channelrx/demodapt/aptdemodgui.cpp
@@ -389,6 +389,9 @@ void APTDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void APTDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -547,6 +550,7 @@ void APTDemodGUI::displaySettings()
 
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodapt/aptdemodsettings.cpp
+++ b/plugins/channelrx/demodapt/aptdemodsettings.cpp
@@ -90,6 +90,7 @@ QByteArray APTDemodSettings::serialize() const
     s.writeU32(25, m_reverseAPIPort);
     s.writeU32(26, m_reverseAPIDeviceIndex);
     s.writeU32(27, m_reverseAPIChannelIndex);
+    s.writeBlob(28, m_rollupState);
 
     return s.final();
 }
@@ -150,6 +151,7 @@ bool APTDemodSettings::deserialize(const QByteArray& data)
         m_reverseAPIDeviceIndex = utmp > 99 ? 99 : utmp;
         d.readU32(27, &utmp, 0);
         m_reverseAPIChannelIndex = utmp > 99 ? 99 : utmp;
+        d.readBlob(28, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/demodapt/aptdemodsettings.h
+++ b/plugins/channelrx/demodapt/aptdemodsettings.h
@@ -53,6 +53,7 @@ struct APTDemodSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIDeviceIndex;
     uint16_t m_reverseAPIChannelIndex;
+    QByteArray m_rollupState;
 
     APTDemodSettings();
     void resetToDefaults();

--- a/plugins/channelrx/demodatv/atvdemodgui.cpp
+++ b/plugins/channelrx/demodatv/atvdemodgui.cpp
@@ -119,6 +119,7 @@ void ATVDemodGUI::displaySettings()
     ui->amScaleOffsetText->setText(QString("%1").arg(m_settings.m_amOffsetFactor));
 
     applySampleRate();
+    restoreState(m_settings.m_rollupState);
 
     m_doApplySettings = true;
 }
@@ -206,6 +207,9 @@ void ATVDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 ATVDemodGUI::ATVDemodGUI(PluginAPI* objPluginAPI, DeviceUISet *deviceUISet, BasebandSampleSink *rxChannel, QWidget* objParent) :

--- a/plugins/channelrx/demodatv/atvdemodsettings.cpp
+++ b/plugins/channelrx/demodatv/atvdemodsettings.cpp
@@ -85,6 +85,7 @@ QByteArray ATVDemodSettings::serialize() const
     s.writeS32(22, m_amScalingFactor);
     s.writeS32(23, m_amOffsetFactor);
     s.writeBool(24, m_fftFiltering);
+    s.writeBlob(25, m_rollupState);
 
     return s.final();
 }
@@ -133,6 +134,7 @@ bool ATVDemodSettings::deserialize(const QByteArray& arrData)
         d.readS32(22, &m_amScalingFactor, 100);
         d.readS32(23, &m_amOffsetFactor, 0);
         d.readBool(24, &m_fftFiltering, false);
+        d.readBlob(25, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/demodatv/atvdemodsettings.h
+++ b/plugins/channelrx/demodatv/atvdemodsettings.h
@@ -74,6 +74,7 @@ struct ATVDemodSettings
     uint16_t m_udpPort;
     Serializable *m_channelMarker;
     int m_streamIndex;
+    QByteArray m_rollupState;
 
     ATVDemodSettings();
     void resetToDefaults();

--- a/plugins/channelrx/demodbfm/bfmdemodgui.cpp
+++ b/plugins/channelrx/demodbfm/bfmdemodgui.cpp
@@ -293,6 +293,9 @@ void BFMDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void BFMDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -462,6 +465,7 @@ void BFMDemodGUI::displaySettings()
 
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodbfm/bfmdemodsettings.cpp
+++ b/plugins/channelrx/demodbfm/bfmdemodsettings.cpp
@@ -86,6 +86,7 @@ QByteArray BFMDemodSettings::serialize() const
     s.writeU32(17, m_reverseAPIDeviceIndex);
     s.writeU32(18, m_reverseAPIChannelIndex);
     s.writeS32(19, m_streamIndex);
+    s.writeBlob(20, m_rollupState);
 
     return s.final();
 }
@@ -151,6 +152,7 @@ bool BFMDemodSettings::deserialize(const QByteArray& data)
         d.readU32(18, &utmp, 0);
         m_reverseAPIChannelIndex = utmp > 99 ? 99 : utmp;
         d.readS32(19, &m_streamIndex, 0);
+        d.readBlob(20, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/demodbfm/bfmdemodsettings.h
+++ b/plugins/channelrx/demodbfm/bfmdemodsettings.h
@@ -45,6 +45,7 @@ struct BFMDemodSettings
 
     Serializable *m_channelMarker;
     Serializable *m_spectrumGUI;
+    QByteArray m_rollupState;
 
     static const int m_nbRFBW;
     static const int m_rfBW[];

--- a/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
@@ -320,6 +320,9 @@ void ChirpChatDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void ChirpChatDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -492,6 +495,7 @@ void ChirpChatDemodGUI::displaySettings()
 
     displaySquelch();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodchirpchat/chirpchatdemodsettings.cpp
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemodsettings.cpp
@@ -127,6 +127,7 @@ QByteArray ChirpChatDemodSettings::serialize() const
     s.writeBool(26, m_sendViaUDP);
     s.writeString(27, m_udpAddress);
     s.writeU32(28, m_udpPort);
+    s.writeBlob(29, m_rollupState);
 
     return s.final();
 }
@@ -199,6 +200,7 @@ bool ChirpChatDemodSettings::deserialize(const QByteArray& data)
         } else {
             m_udpPort = 9999;
         }
+        d.readBlob(29, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/demodchirpchat/chirpchatdemodsettings.h
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemodsettings.h
@@ -66,6 +66,7 @@ struct ChirpChatDemodSettings
 
     Serializable *m_channelMarker;
     Serializable *m_spectrumGUI;
+    QByteArray m_rollupState;
 
     static const int bandwidths[];
     static const int nbBandwidths;

--- a/plugins/channelrx/demoddab/dabdemodgui.cpp
+++ b/plugins/channelrx/demoddab/dabdemodgui.cpp
@@ -375,6 +375,9 @@ void DABDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void DABDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -553,6 +556,7 @@ void DABDemodGUI::displaySettings()
 
     filter();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demoddab/dabdemodsettings.cpp
+++ b/plugins/channelrx/demoddab/dabdemodsettings.cpp
@@ -76,6 +76,7 @@ QByteArray DABDemodSettings::serialize() const
     s.writeU32(13, m_reverseAPIPort);
     s.writeU32(14, m_reverseAPIDeviceIndex);
     s.writeU32(15, m_reverseAPIChannelIndex);
+    s.writeBlob(16, m_rollupState);
 
     for (int i = 0; i < DABDEMOD_COLUMNS; i++)
         s.writeS32(100 + i, m_columnIndexes[i]);
@@ -131,6 +132,7 @@ bool DABDemodSettings::deserialize(const QByteArray& data)
         m_reverseAPIDeviceIndex = utmp > 99 ? 99 : utmp;
         d.readU32(15, &utmp, 0);
         m_reverseAPIChannelIndex = utmp > 99 ? 99 : utmp;
+        d.readBlob(16, &m_rollupState);
 
         for (int i = 0; i < DABDEMOD_COLUMNS; i++)
             d.readS32(100 + i, &m_columnIndexes[i], i);

--- a/plugins/channelrx/demoddab/dabdemodsettings.h
+++ b/plugins/channelrx/demoddab/dabdemodsettings.h
@@ -45,6 +45,7 @@ struct DABDemodSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIDeviceIndex;
     uint16_t m_reverseAPIChannelIndex;
+    QByteArray m_rollupState;
 
     int m_columnIndexes[DABDEMOD_COLUMNS];//!< How the columns are ordered in the table
     int m_columnSizes[DABDEMOD_COLUMNS];  //!< Size of the columns in the table

--- a/plugins/channelrx/demoddatv/datvdemodgui.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodgui.cpp
@@ -135,6 +135,9 @@ void DATVDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void DATVDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -387,6 +390,7 @@ void DATVDemodGUI::displaySettings()
         connect(m_datvDemod->getUDPStream(), &DATVUDPStream::fifoData, this, &DATVDemodGUI::on_StreamDataAvailable);
     }
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demoddatv/datvdemodsettings.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodsettings.cpp
@@ -113,6 +113,7 @@ QByteArray DATVDemodSettings::serialize() const
     s.writeString(34, m_softLDPCToolPath);
     s.writeS32(35, m_softLDPCMaxTrials);
     s.writeBool(36, m_playerEnable);
+    s.writeBlob(37, m_rollupState);
 
     return s.final();
 }
@@ -201,6 +202,7 @@ bool DATVDemodSettings::deserialize(const QByteArray& data)
         d.readS32(35, &tmp, 8);
         m_softLDPCMaxTrials = tmp < 1 ? 1 : tmp > m_softLDPCMaxMaxTrials ? m_softLDPCMaxMaxTrials : tmp;
         d.readBool(36, &m_playerEnable, true);
+        d.readBlob(37, &m_rollupState);
 
         validateSystemConfiguration();
 

--- a/plugins/channelrx/demoddatv/datvdemodsettings.h
+++ b/plugins/channelrx/demoddatv/datvdemodsettings.h
@@ -107,6 +107,7 @@ struct DATVDemodSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIDeviceIndex;
     uint16_t m_reverseAPIChannelIndex;
+    QByteArray m_rollupState;
     static const int m_softLDPCMaxMaxTrials = 50;
 
     DATVDemodSettings();

--- a/plugins/channelrx/demoddsd/dsddemodgui.cpp
+++ b/plugins/channelrx/demoddsd/dsddemodgui.cpp
@@ -246,6 +246,9 @@ void DSDDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void DSDDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -457,6 +460,7 @@ void DSDDemodGUI::displaySettings()
 
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demoddsd/dsddemodsettings.cpp
+++ b/plugins/channelrx/demoddsd/dsddemodsettings.cpp
@@ -102,6 +102,7 @@ QByteArray DSDDemodSettings::serialize() const
     s.writeU32(28, m_reverseAPIChannelIndex);
     s.writeBool(29, m_audioMute);
     s.writeS32(30, m_streamIndex);
+    s.writeBlob(31, m_rollupState);
 
     return s.final();
 }
@@ -180,6 +181,7 @@ bool DSDDemodSettings::deserialize(const QByteArray& data)
         m_reverseAPIChannelIndex = utmp > 99 ? 99 : utmp;
         d.readBool(29, &m_audioMute, false);
         d.readS32(30, &m_streamIndex, 0);
+        d.readBlob(31, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/demoddsd/dsddemodsettings.h
+++ b/plugins/channelrx/demoddsd/dsddemodsettings.h
@@ -55,6 +55,7 @@ struct DSDDemodSettings
 
     Serializable *m_channelMarker;
     Serializable *m_scopeGUI;
+    QByteArray m_rollupState;
 
     DSDDemodSettings();
     void resetToDefaults();

--- a/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
@@ -233,6 +233,9 @@ void FreeDVDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 FreeDVDemodGUI::FreeDVDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSampleSink *rxChannel, QWidget* parent) :
@@ -386,6 +389,7 @@ void FreeDVDemodGUI::displaySettings()
 
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodfreedv/freedvdemodsettings.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemodsettings.cpp
@@ -80,6 +80,7 @@ QByteArray FreeDVDemodSettings::serialize() const
     s.writeU32(22, m_reverseAPIChannelIndex);
     s.writeS32(23, (int) m_freeDVMode);
     s.writeS32(24, m_streamIndex);
+    s.writeBlob(25, m_rollupState);
 
     return s.final();
 }
@@ -141,6 +142,7 @@ bool FreeDVDemodSettings::deserialize(const QByteArray& data)
         }
 
         d.readS32(24, &m_streamIndex, 0);
+        d.readBlob(25, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/demodfreedv/freedvdemodsettings.h
+++ b/plugins/channelrx/demodfreedv/freedvdemodsettings.h
@@ -54,6 +54,7 @@ struct FreeDVDemodSettings
 
     Serializable *m_channelMarker;
     Serializable *m_spectrumGUI;
+    QByteArray m_rollupState;
 
     FreeDVDemodSettings();
     void resetToDefaults();

--- a/plugins/channelrx/demodnfm/nfmdemodgui.cpp
+++ b/plugins/channelrx/demodnfm/nfmdemodgui.cpp
@@ -278,6 +278,9 @@ void NFMDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 	if((widget == ui->spectrumContainer) && (m_nfmDemod != NULL))
 		m_nfmDemod->setSpectrum(m_threadedSampleSink->getMessageQueue(), rollDown);
 	*/
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void NFMDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -503,6 +506,7 @@ void NFMDemodGUI::displaySettings()
     setDcsCode(m_reportedDcsCode);
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodnfm/nfmdemodsettings.cpp
+++ b/plugins/channelrx/demodnfm/nfmdemodsettings.cpp
@@ -107,6 +107,7 @@ QByteArray NFMDemodSettings::serialize() const
     s.writeBool(23, m_dcsOn);
     s.writeU32(24, m_dcsCode);
     s.writeBool(25, m_dcsPositive);
+    s.writeBlob(26, m_rollupState);
 
     return s.final();
 }
@@ -169,7 +170,8 @@ bool NFMDemodSettings::deserialize(const QByteArray& data)
         d.readBool(23, &m_dcsOn, false);
         d.readU32(24, &utmp, 0023);
         m_dcsCode = utmp < 511 ? utmp : 511;
-        d.readBool(26, &m_dcsPositive, false);
+        d.readBool(25, &m_dcsPositive, false);
+        d.readBlob(26, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/demodnfm/nfmdemodsettings.h
+++ b/plugins/channelrx/demodnfm/nfmdemodsettings.h
@@ -54,6 +54,7 @@ struct NFMDemodSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIDeviceIndex;
     uint16_t m_reverseAPIChannelIndex;
+    QByteArray m_rollupState;
 
     Serializable *m_channelMarker;
 

--- a/plugins/channelrx/demodpacket/packetdemodgui.cpp
+++ b/plugins/channelrx/demodpacket/packetdemodgui.cpp
@@ -360,6 +360,9 @@ void PacketDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void PacketDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -540,6 +543,7 @@ void PacketDemodGUI::displaySettings()
 
     filter();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodpacket/packetdemodsettings.cpp
+++ b/plugins/channelrx/demodpacket/packetdemodsettings.cpp
@@ -89,6 +89,7 @@ QByteArray PacketDemodSettings::serialize() const
 
     s.writeString(25, m_logFilename);
     s.writeBool(26, m_logEnabled);
+    s.writeBlob(27, m_rollupState);
 
     for (int i = 0; i < PACKETDEMOD_COLUMNS; i++)
         s.writeS32(100 + i, m_columnIndexes[i]);
@@ -156,6 +157,7 @@ bool PacketDemodSettings::deserialize(const QByteArray& data)
 
         d.readString(25, &m_logFilename, "pager_log.csv");
         d.readBool(26, &m_logEnabled, false);
+        d.readBlob(27, &m_rollupState);
 
         for (int i = 0; i < PACKETDEMOD_COLUMNS; i++)
             d.readS32(100 + i, &m_columnIndexes[i], i);

--- a/plugins/channelrx/demodpacket/packetdemodsettings.h
+++ b/plugins/channelrx/demodpacket/packetdemodsettings.h
@@ -56,6 +56,7 @@ struct PacketDemodSettings
 
     QString m_logFilename;
     bool m_logEnabled;
+    QByteArray m_rollupState;
 
     int m_columnIndexes[PACKETDEMOD_COLUMNS];//!< How the columns are ordered in the table
     int m_columnSizes[PACKETDEMOD_COLUMNS];  //!< Size of the columns in the table

--- a/plugins/channelrx/demodpager/pagerdemodgui.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodgui.cpp
@@ -410,6 +410,9 @@ void PagerDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
             setMinimumWidth(352);
         }
     }
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void PagerDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -629,6 +632,7 @@ void PagerDemodGUI::displaySettings()
     }
     filter();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodpager/pagerdemodsettings.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodsettings.cpp
@@ -96,6 +96,7 @@ QByteArray PagerDemodSettings::serialize() const
 
     s.writeString(25, m_logFilename);
     s.writeBool(26, m_logEnabled);
+    s.writeBlob(27, m_rollupState);
 
     for (int i = 0; i < PAGERDEMOD_MESSAGE_COLUMNS; i++) {
         s.writeS32(100 + i, m_messageColumnIndexes[i]);
@@ -173,6 +174,7 @@ bool PagerDemodSettings::deserialize(const QByteArray& data)
 
         d.readString(25, &m_logFilename, "pager_log.csv");
         d.readBool(26, &m_logEnabled, false);
+        d.readBlob(27, &m_rollupState);
 
         for (int i = 0; i < PAGERDEMOD_MESSAGE_COLUMNS; i++) {
             d.readS32(100 + i, &m_messageColumnIndexes[i], i);

--- a/plugins/channelrx/demodpager/pagerdemodsettings.h
+++ b/plugins/channelrx/demodpager/pagerdemodsettings.h
@@ -66,6 +66,7 @@ struct PagerDemodSettings
 
     QString m_logFilename;
     bool m_logEnabled;
+    QByteArray m_rollupState;
 
     int m_messageColumnIndexes[PAGERDEMOD_MESSAGE_COLUMNS];//!< How the columns are ordered in the table
     int m_messageColumnSizes[PAGERDEMOD_MESSAGE_COLUMNS];  //!< Size of the columns in the table

--- a/plugins/channelrx/demodssb/ssbdemodgui.cpp
+++ b/plugins/channelrx/demodssb/ssbdemodgui.cpp
@@ -273,6 +273,9 @@ void SSBDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 SSBDemodGUI::SSBDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSampleSink *rxChannel, QWidget* parent) :
@@ -568,6 +571,7 @@ void SSBDemodGUI::displaySettings()
 
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodssb/ssbdemodsettings.cpp
+++ b/plugins/channelrx/demodssb/ssbdemodsettings.cpp
@@ -94,6 +94,7 @@ QByteArray SSBDemodSettings::serialize() const
     s.writeU32(21, m_reverseAPIDeviceIndex);
     s.writeU32(22, m_reverseAPIChannelIndex);
     s.writeS32(23, m_streamIndex);
+    s.writeBlob(24, m_rollupState);
 
     return s.final();
 }
@@ -155,6 +156,7 @@ bool SSBDemodSettings::deserialize(const QByteArray& data)
         d.readU32(22, &utmp, 0);
         m_reverseAPIChannelIndex = utmp > 99 ? 99 : utmp;
         d.readS32(23, &m_streamIndex, 0);
+        d.readBlob(24, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/demodssb/ssbdemodsettings.h
+++ b/plugins/channelrx/demodssb/ssbdemodsettings.h
@@ -50,6 +50,7 @@ struct SSBDemodSettings
 
     Serializable *m_channelMarker;
     Serializable *m_spectrumGUI;
+    QByteArray m_rollupState;
 
     SSBDemodSettings();
     void resetToDefaults();

--- a/plugins/channelrx/demodvor/vordemodgui.cpp
+++ b/plugins/channelrx/demodvor/vordemodgui.cpp
@@ -1104,6 +1104,9 @@ void VORDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void VORDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -1328,6 +1331,7 @@ void VORDemodGUI::displaySettings()
         header->moveSection(header->visualIndex(i), m_settings.m_columnIndexes[i]);
     }
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodvor/vordemodsettings.cpp
+++ b/plugins/channelrx/demodvor/vordemodsettings.cpp
@@ -80,6 +80,7 @@ QByteArray VORDemodSettings::serialize() const
     s.writeReal(21, m_refThresholdDB);
     s.writeReal(22, m_varThresholdDB);
     s.writeBool(23, m_magDecAdjust);
+    s.writeBlob(24, m_rollupState);
 
     for (int i = 0; i < VORDEMOD_COLUMNS; i++)
         s.writeS32(100 + i, m_columnIndexes[i]);
@@ -139,6 +140,7 @@ bool VORDemodSettings::deserialize(const QByteArray& data)
         d.readReal(21, &m_refThresholdDB, -45.0);
         d.readReal(22, &m_varThresholdDB, -90.0);
         d.readBool(23, &m_magDecAdjust, true);
+        d.readBlob(24, &m_rollupState);
 
         for (int i = 0; i < VORDEMOD_COLUMNS; i++)
             d.readS32(100 + i, &m_columnIndexes[i], i);

--- a/plugins/channelrx/demodvor/vordemodsettings.h
+++ b/plugins/channelrx/demodvor/vordemodsettings.h
@@ -53,6 +53,7 @@ struct VORDemodSettings
     Real m_refThresholdDB;              //!< Threshold in dB for valid VOR reference signal
     Real m_varThresholdDB;              //!< Threshold in dB for valid VOR variable signal
     bool m_magDecAdjust;                //!< Adjust for magnetic declination when drawing radials on the map
+    QByteArray m_rollupState;
 
     int m_columnIndexes[VORDEMOD_COLUMNS];//!< How the columns are ordered in the table
     int m_columnSizes[VORDEMOD_COLUMNS];  //!< Size of the coumns in the table

--- a/plugins/channelrx/demodvorsc/vordemodscgui.cpp
+++ b/plugins/channelrx/demodvorsc/vordemodscgui.cpp
@@ -222,6 +222,9 @@ void VORDemodSCGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void VORDemodSCGUI::onMenuDialogCalled(const QPoint &p)
@@ -367,6 +370,7 @@ void VORDemodSCGUI::displaySettings()
 
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodvorsc/vordemodscsettings.cpp
+++ b/plugins/channelrx/demodvorsc/vordemodscsettings.cpp
@@ -75,6 +75,7 @@ QByteArray VORDemodSCSettings::serialize() const
     s.writeReal(20, m_identThreshold);
     s.writeReal(21, m_refThresholdDB);
     s.writeReal(22, m_varThresholdDB);
+    s.writeBlob(23, m_rollupState);
 
     return s.final();
 }
@@ -129,6 +130,7 @@ bool VORDemodSCSettings::deserialize(const QByteArray& data)
         d.readReal(20, &m_identThreshold, 2.0);
         d.readReal(21, &m_refThresholdDB, -45.0);
         d.readReal(22, &m_varThresholdDB, -90.0);
+        d.readBlob(23, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/demodvorsc/vordemodscsettings.h
+++ b/plugins/channelrx/demodvorsc/vordemodscsettings.h
@@ -45,6 +45,7 @@ struct VORDemodSCSettings
     Real m_identThreshold;              //!< Linear SNR threshold for Morse demodulator
     Real m_refThresholdDB;              //!< Threshold in dB for valid VOR reference signal
     Real m_varThresholdDB;              //!< Threshold in dB for valid VOR variable signal
+    QByteArray m_rollupState;
 
     // Highest frequency is the FM subcarrier at up to ~11kHz
     // However, old VORs can have 0.005% frequency offset, which is 6kHz

--- a/plugins/channelrx/demodwfm/wfmdemodgui.cpp
+++ b/plugins/channelrx/demodwfm/wfmdemodgui.cpp
@@ -143,6 +143,9 @@ void WFMDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void WFMDemodGUI::onMenuDialogCalled(const QPoint &p)
@@ -289,6 +292,7 @@ void WFMDemodGUI::displaySettings()
 
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/demodwfm/wfmdemodsettings.cpp
+++ b/plugins/channelrx/demodwfm/wfmdemodsettings.cpp
@@ -75,6 +75,7 @@ QByteArray WFMDemodSettings::serialize() const
     s.writeU32(15, m_reverseAPIDeviceIndex);
     s.writeU32(16, m_reverseAPIChannelIndex);
     s.writeS32(17, m_streamIndex);
+    s.writeBlob(18, m_rollupState);
 
     return s.final();
 }
@@ -131,6 +132,7 @@ bool WFMDemodSettings::deserialize(const QByteArray& data)
         d.readU32(16, &utmp, 0);
         m_reverseAPIChannelIndex = utmp > 99 ? 99 : utmp;
         d.readS32(17, &m_streamIndex, 0);
+        d.readBlob(18, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/demodwfm/wfmdemodsettings.h
+++ b/plugins/channelrx/demodwfm/wfmdemodsettings.h
@@ -40,6 +40,7 @@ struct WFMDemodSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIDeviceIndex;
     uint16_t m_reverseAPIChannelIndex;
+    QByteArray m_rollupState;
 
     Serializable *m_channelMarker;
 

--- a/plugins/channelrx/filesink/filesinkgui.cpp
+++ b/plugins/channelrx/filesink/filesinkgui.cpp
@@ -275,6 +275,7 @@ void FileSinkGUI::displaySettings()
     displayStreamIndex();
     setPosFromFrequency();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 
@@ -344,6 +345,9 @@ void FileSinkGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void FileSinkGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channelrx/filesink/filesinksettings.cpp
+++ b/plugins/channelrx/filesink/filesinksettings.cpp
@@ -72,6 +72,7 @@ QByteArray FileSinkSettings::serialize() const
     s.writeS32(16, m_preRecordTime);
     s.writeS32(17, m_squelchPostRecordTime);
     s.writeBool(18, m_squelchRecordingEnable);
+    s.writeBlob(19, m_rollupState);
 
     return s.final();
 }
@@ -127,6 +128,7 @@ bool FileSinkSettings::deserialize(const QByteArray& data)
         d.readS32(16, &m_preRecordTime, 0);
         d.readS32(17, &m_squelchPostRecordTime, 0);
         d.readBool(18, &m_squelchRecordingEnable, false);
+        d.readBlob(19, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/filesink/filesinksettings.h
+++ b/plugins/channelrx/filesink/filesinksettings.h
@@ -43,6 +43,7 @@ struct FileSinkSettings
     uint16_t m_reverseAPIChannelIndex;
 
     Serializable *m_spectrumGUI;
+    QByteArray m_rollupState;
 
     FileSinkSettings();
     void resetToDefaults();

--- a/plugins/channelrx/freqtracker/freqtrackergui.cpp
+++ b/plugins/channelrx/freqtracker/freqtrackergui.cpp
@@ -248,6 +248,9 @@ void FreqTrackerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void FreqTrackerGUI::onMenuDialogCalled(const QPoint &p)
@@ -426,6 +429,7 @@ void FreqTrackerGUI::displaySettings()
     displaySpectrumBandwidth(m_settings.m_spanLog2);
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/freqtracker/freqtrackersettings.cpp
+++ b/plugins/channelrx/freqtracker/freqtrackersettings.cpp
@@ -85,6 +85,7 @@ QByteArray FreqTrackerSettings::serialize() const
     s.writeU32(20, m_reverseAPIChannelIndex);
     s.writeS32(21, m_squelchGate);
     s.writeS32(22, m_streamIndex);
+    s.writeBlob(23, m_rollupState);
 
     return s.final();
 }
@@ -157,6 +158,7 @@ bool FreqTrackerSettings::deserialize(const QByteArray& data)
         d.readS32(21, &tmp, 5);
         m_squelchGate = tmp < 0 ? 0 : tmp > 99 ? 99 : tmp;
         d.readS32(22, &m_streamIndex, 0);
+        d.readBlob(23, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/freqtracker/freqtrackersettings.h
+++ b/plugins/channelrx/freqtracker/freqtrackersettings.h
@@ -56,6 +56,7 @@ struct FreqTrackerSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIDeviceIndex;
     uint16_t m_reverseAPIChannelIndex;
+    QByteArray m_rollupState;
 
     FreqTrackerSettings();
     void resetToDefaults();

--- a/plugins/channelrx/localsink/localsinkgui.cpp
+++ b/plugins/channelrx/localsink/localsinkgui.cpp
@@ -173,6 +173,7 @@ void LocalSinkGUI::displaySettings()
     applyDecimation();
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 
@@ -249,6 +250,9 @@ void LocalSinkGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void LocalSinkGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channelrx/localsink/localsinksettings.cpp
+++ b/plugins/channelrx/localsink/localsinksettings.cpp
@@ -59,6 +59,7 @@ QByteArray LocalSinkSettings::serialize() const
     s.writeU32(12, m_log2Decim);
     s.writeU32(13, m_filterChainHash);
     s.writeS32(14, m_streamIndex);
+    s.writeBlob(15, m_rollupState);
 
     return s.final();
 }
@@ -99,6 +100,7 @@ bool LocalSinkSettings::deserialize(const QByteArray& data)
         m_log2Decim = tmp > 6 ? 6 : tmp;
         d.readU32(13, &m_filterChainHash, 0);
         d.readS32(14, &m_streamIndex, 0);
+        d.readBlob(15, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/localsink/localsinksettings.h
+++ b/plugins/channelrx/localsink/localsinksettings.h
@@ -39,6 +39,7 @@ struct LocalSinkSettings
     uint16_t m_reverseAPIChannelIndex;
 
     Serializable *m_channelMarker;
+    QByteArray m_rollupState;
 
     LocalSinkSettings();
     void resetToDefaults();

--- a/plugins/channelrx/noisefigure/noisefiguregui.cpp
+++ b/plugins/channelrx/noisefigure/noisefiguregui.cpp
@@ -549,6 +549,9 @@ void NoiseFigureGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void NoiseFigureGUI::onMenuDialogCalled(const QPoint &p)
@@ -755,6 +758,7 @@ void NoiseFigureGUI::displaySettings()
         header->moveSection(header->visualIndex(i), m_settings.m_resultsColumnIndexes[i]);
     }
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/noisefigure/noisefiguresettings.cpp
+++ b/plugins/channelrx/noisefigure/noisefiguresettings.cpp
@@ -111,6 +111,7 @@ QByteArray NoiseFigureSettings::serialize() const
     s.writeS32(26, (int)m_interpolation);
 
     s.writeString(27, m_setting);
+    s.writeBlob(28, m_rollupState);
 
     for (int i = 0; i < NOISEFIGURE_COLUMNS; i++) {
         s.writeS32(100 + i, m_resultsColumnIndexes[i]);
@@ -183,6 +184,7 @@ bool NoiseFigureSettings::deserialize(const QByteArray& data)
         d.readS32(26, (int*)&m_interpolation, LINEAR);
 
         d.readString(27, &m_setting, "centerFrequency");
+        d.readBlob(28, &m_rollupState);
 
         for (int i = 0; i < NOISEFIGURE_COLUMNS; i++) {
             d.readS32(100 + i, &m_resultsColumnIndexes[i], i);

--- a/plugins/channelrx/noisefigure/noisefiguresettings.h
+++ b/plugins/channelrx/noisefigure/noisefiguresettings.h
@@ -85,6 +85,7 @@ struct NoiseFigureSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIDeviceIndex;
     uint16_t m_reverseAPIChannelIndex;
+    QByteArray m_rollupState;
 
     int m_resultsColumnIndexes[NOISEFIGURE_COLUMNS];//!< How the columns are ordered in the table
     int m_resultsColumnSizes[NOISEFIGURE_COLUMNS];  //!< Size of the columns in the table

--- a/plugins/channelrx/radioclock/radioclockgui.cpp
+++ b/plugins/channelrx/radioclock/radioclockgui.cpp
@@ -208,6 +208,9 @@ void RadioClockGUI::onWidgetRolled(QWidget* widget, bool rollDown)
             setMinimumWidth(352);
         }
     }
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void RadioClockGUI::onMenuDialogCalled(const QPoint &p)
@@ -360,6 +363,7 @@ void RadioClockGUI::displaySettings()
 
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channelrx/radioclock/radioclocksettings.cpp
+++ b/plugins/channelrx/radioclock/radioclocksettings.cpp
@@ -68,6 +68,7 @@ QByteArray RadioClockSettings::serialize() const
     s.writeU32(19, m_reverseAPIDeviceIndex);
     s.writeU32(20, m_reverseAPIChannelIndex);
     s.writeBlob(21, m_scopeGUI->serialize());
+    s.writeBlob(22, m_rollupState);
 
     return s.final();
 }
@@ -118,6 +119,7 @@ bool RadioClockSettings::deserialize(const QByteArray& data)
             d.readBlob(21, &bytetmp);
             m_scopeGUI->deserialize(bytetmp);
         }
+        d.readBlob(22, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/radioclock/radioclocksettings.h
+++ b/plugins/channelrx/radioclock/radioclocksettings.h
@@ -53,6 +53,7 @@ struct RadioClockSettings
     uint16_t m_reverseAPIDeviceIndex;
     uint16_t m_reverseAPIChannelIndex;
     Serializable *m_scopeGUI;
+    QByteArray m_rollupState;
     static const int RADIOCLOCK_CHANNEL_SAMPLE_RATE = 1000;
     static const int m_scopeStreams = 8;
 

--- a/plugins/channelrx/remotesink/remotesinkgui.cpp
+++ b/plugins/channelrx/remotesink/remotesinkgui.cpp
@@ -172,6 +172,7 @@ void RemoteSinkGUI::displaySettings()
     updateTxDelayTime();
     applyDecimation();
     displayStreamIndex();
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 
@@ -222,6 +223,9 @@ void RemoteSinkGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void RemoteSinkGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channelrx/remotesink/remotesinksettings.cpp
+++ b/plugins/channelrx/remotesink/remotesinksettings.cpp
@@ -70,6 +70,7 @@ QByteArray RemoteSinkSettings::serialize() const
     s.writeU32(12, m_log2Decim);
     s.writeU32(13, m_filterChainHash);
     s.writeS32(14, m_streamIndex);
+    s.writeBlob(15, m_rollupState);
 
     return s.final();
 }
@@ -127,6 +128,7 @@ bool RemoteSinkSettings::deserialize(const QByteArray& data)
         m_log2Decim = tmp > 6 ? 6 : tmp;
         d.readU32(13, &m_filterChainHash, 0);
         d.readS32(14, &m_streamIndex, 0);
+        d.readBlob(15, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/remotesink/remotesinksettings.h
+++ b/plugins/channelrx/remotesink/remotesinksettings.h
@@ -47,6 +47,7 @@ struct RemoteSinkSettings
     uint16_t m_reverseAPIChannelIndex;
 
     Serializable *m_channelMarker;
+    QByteArray m_rollupState;
 
     RemoteSinkSettings();
     void resetToDefaults();

--- a/plugins/channelrx/sigmffilesink/sigmffilesinkgui.cpp
+++ b/plugins/channelrx/sigmffilesink/sigmffilesinkgui.cpp
@@ -268,6 +268,7 @@ void SigMFFileSinkGUI::displaySettings()
     displayStreamIndex();
     setPosFromFrequency();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 
@@ -337,6 +338,9 @@ void SigMFFileSinkGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void SigMFFileSinkGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channelrx/sigmffilesink/sigmffilesinksettings.cpp
+++ b/plugins/channelrx/sigmffilesink/sigmffilesinksettings.cpp
@@ -74,6 +74,7 @@ QByteArray SigMFFileSinkSettings::serialize() const
     s.writeS32(16, m_preRecordTime);
     s.writeS32(17, m_squelchPostRecordTime);
     s.writeBool(18, m_squelchRecordingEnable);
+    s.writeBlob(19, m_rollupState);
 
     return s.final();
 }
@@ -130,6 +131,7 @@ bool SigMFFileSinkSettings::deserialize(const QByteArray& data)
         d.readS32(16, &m_preRecordTime, 0);
         d.readS32(17, &m_squelchPostRecordTime, 0);
         d.readBool(18, &m_squelchRecordingEnable, false);
+        d.readBlob(19, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/sigmffilesink/sigmffilesinksettings.h
+++ b/plugins/channelrx/sigmffilesink/sigmffilesinksettings.h
@@ -44,6 +44,7 @@ struct SigMFFileSinkSettings
     uint16_t m_reverseAPIChannelIndex;
 
     Serializable *m_spectrumGUI;
+    QByteArray m_rollupState;
 
     SigMFFileSinkSettings();
     void resetToDefaults();

--- a/plugins/channelrx/udpsink/udpsinkgui.cpp
+++ b/plugins/channelrx/udpsink/udpsinkgui.cpp
@@ -254,6 +254,7 @@ void UDPSinkGUI::displaySettings()
 
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 
     ui->glSpectrum->setSampleRate(m_settings.m_outputSampleRate);
@@ -584,6 +585,9 @@ void UDPSinkGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 	if ((widget == ui->spectrumBox) && (m_udpSink)) {
         m_udpSink->enableSpectrum(rollDown);
 	}
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void UDPSinkGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channelrx/udpsink/udpsinksettings.cpp
+++ b/plugins/channelrx/udpsink/udpsinksettings.cpp
@@ -93,6 +93,7 @@ QByteArray UDPSinkSettings::serialize() const
     s.writeU32(26, m_reverseAPIDeviceIndex);
     s.writeU32(27, m_reverseAPIChannelIndex);
     s.writeS32(28, m_streamIndex);
+    s.writeBlob(29, m_rollupState);
 
     return s.final();
 
@@ -183,6 +184,7 @@ bool UDPSinkSettings::deserialize(const QByteArray& data)
         d.readU32(27, &u32tmp, 0);
         m_reverseAPIChannelIndex = u32tmp > 99 ? 99 : u32tmp;
         d.readS32(28, &m_streamIndex, 0);
+        d.readBlob(29, &m_rollupState);
 
         return true;
     }

--- a/plugins/channelrx/udpsink/udpsinksettings.h
+++ b/plugins/channelrx/udpsink/udpsinksettings.h
@@ -72,6 +72,7 @@ struct UDPSinkSettings
 
     Serializable *m_channelMarker;
     Serializable *m_spectrumGUI;
+    QByteArray m_rollupState;
 
     UDPSinkSettings();
     void resetToDefaults();

--- a/plugins/channeltx/filesource/filesourcegui.cpp
+++ b/plugins/channeltx/filesource/filesourcegui.cpp
@@ -307,6 +307,7 @@ void FileSourceGUI::displaySettings()
     ui->gainText->setText(tr("%1 dB").arg(m_settings.m_gainDB));
     ui->interpolationFactor->setCurrentIndex(m_settings.m_log2Interp);
     applyInterpolation();
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 
@@ -357,6 +358,9 @@ void FileSourceGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void FileSourceGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channeltx/filesource/filesourcesettings.cpp
+++ b/plugins/channeltx/filesource/filesourcesettings.cpp
@@ -62,6 +62,7 @@ QByteArray FileSourceSettings::serialize() const
     s.writeU32(11, m_reverseAPIDeviceIndex);
     s.writeU32(12, m_reverseAPIChannelIndex);
     s.writeS32(13, m_streamIndex);
+    s.writeBlob(14, m_rollupState);
 
     return s.final();
 }
@@ -106,6 +107,7 @@ bool FileSourceSettings::deserialize(const QByteArray& data)
         d.readU32(12, &tmp, 0);
         m_reverseAPIChannelIndex = tmp > 99 ? 99 : tmp;
         d.readS32(13, &m_streamIndex, 0);
+        d.readBlob(14, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/filesource/filesourcesettings.h
+++ b/plugins/channeltx/filesource/filesourcesettings.h
@@ -40,6 +40,7 @@ struct FileSourceSettings
     uint16_t m_reverseAPIChannelIndex;
 
     Serializable *m_channelMarker;
+    QByteArray m_rollupState;
 
     FileSourceSettings();
     void resetToDefaults();

--- a/plugins/channeltx/localsource/localsourcegui.cpp
+++ b/plugins/channeltx/localsource/localsourcegui.cpp
@@ -161,6 +161,7 @@ void LocalSourceGUI::displaySettings()
     ui->interpolationFactor->setCurrentIndex(m_settings.m_log2Interp);
     ui->localDevicePlay->setChecked(m_settings.m_play);
     applyInterpolation();
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 
@@ -223,6 +224,9 @@ void LocalSourceGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void LocalSourceGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channeltx/localsource/localsourcesettings.cpp
+++ b/plugins/channeltx/localsource/localsourcesettings.cpp
@@ -59,6 +59,7 @@ QByteArray LocalSourceSettings::serialize() const
     s.writeU32(12, m_log2Interp);
     s.writeU32(13, m_filterChainHash);
     s.writeS32(14, m_streamIndex);
+    s.writeBlob(15, m_rollupState);
 
     return s.final();
 }
@@ -99,6 +100,7 @@ bool LocalSourceSettings::deserialize(const QByteArray& data)
         m_log2Interp = tmp > 6 ? 6 : tmp;
         d.readU32(13, &m_filterChainHash, 0);
         d.readS32(14, &m_streamIndex, 0);
+        d.readBlob(15, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/localsource/localsourcesettings.h
+++ b/plugins/channeltx/localsource/localsourcesettings.h
@@ -39,6 +39,7 @@ struct LocalSourceSettings
     uint16_t m_reverseAPIChannelIndex;
 
     Serializable *m_channelMarker;
+    QByteArray m_rollupState;
 
     LocalSourceSettings();
     void resetToDefaults();

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_modgui.cpp
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_modgui.cpp
@@ -319,6 +319,9 @@ void IEEE_802_15_4_ModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void IEEE_802_15_4_ModGUI::onMenuDialogCalled(const QPoint &p)
@@ -561,6 +564,7 @@ void IEEE_802_15_4_ModGUI::displaySettings()
     ui->udpAddress->setText(m_settings.m_udpAddress);
     ui->udpPort->setText(QString::number(m_settings.m_udpPort));
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_modsettings.cpp
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_modsettings.cpp
@@ -193,6 +193,7 @@ QByteArray IEEE_802_15_4_ModSettings::serialize() const
     s.writeString(35, m_udpAddress);
     s.writeU32(36, m_udpPort);
     s.writeBool(37, m_udpBytesFormat);
+    s.writeBlob(38, m_rollupState);
 
     return s.final();
 }
@@ -271,6 +272,7 @@ bool IEEE_802_15_4_ModSettings::deserialize(const QByteArray& data)
             m_udpPort = 9998;
         }
         d.readBool(37, &m_udpBytesFormat);
+        d.readBlob(38, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_modsettings.h
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_modsettings.h
@@ -76,6 +76,7 @@ struct IEEE_802_15_4_ModSettings
     bool m_udpBytesFormat; //!< true for bytes payload
     QString m_udpAddress;
     uint16_t m_udpPort;
+    QByteArray m_rollupState;
     static const int m_udpBufferSize = 100000;
 
     IEEE_802_15_4_ModSettings();

--- a/plugins/channeltx/modais/aismodgui.cpp
+++ b/plugins/channeltx/modais/aismodgui.cpp
@@ -329,6 +329,9 @@ void AISModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void AISModGUI::onMenuDialogCalled(const QPoint &p)
@@ -546,6 +549,7 @@ void AISModGUI::displaySettings()
     ui->heading->setValue(m_settings.m_heading);
     ui->message->setText(m_settings.m_data);
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channeltx/modais/aismodsettings.cpp
+++ b/plugins/channeltx/modais/aismodsettings.cpp
@@ -171,6 +171,7 @@ QByteArray AISModSettings::serialize() const
     s.writeBool(37, m_udpEnabled);
     s.writeString(38, m_udpAddress);
     s.writeU32(39, m_udpPort);
+    s.writeBlob(40, m_rollupState);
 
     return s.final();
 }
@@ -246,6 +247,7 @@ bool AISModSettings::deserialize(const QByteArray& data)
         } else {
             m_udpPort = 9998;
         }
+        d.readBlob(40, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/modais/aismodsettings.h
+++ b/plugins/channeltx/modais/aismodsettings.h
@@ -86,6 +86,7 @@ struct AISModSettings
     bool m_udpEnabled;
     QString m_udpAddress;
     uint16_t m_udpPort;
+    QByteArray m_rollupState;
 
     // Sample rate is multiple of 9600 baud rate (use even multiple so Gausian filter has odd number of taps)
     // Is there any benefit to having this higher?

--- a/plugins/channeltx/modam/ammodgui.cpp
+++ b/plugins/channeltx/modam/ammodgui.cpp
@@ -269,6 +269,9 @@ void AMModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void AMModGUI::onMenuDialogCalled(const QPoint &p)
@@ -451,6 +454,7 @@ void AMModGUI::displaySettings()
 
     displayStreamIndex();
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channeltx/modam/ammodsettings.cpp
+++ b/plugins/channeltx/modam/ammodsettings.cpp
@@ -86,6 +86,7 @@ QByteArray AMModSettings::serialize() const
     s.writeReal(18, m_feedbackVolumeFactor);
     s.writeBool(19, m_feedbackAudioEnable);
     s.writeS32(20, m_streamIndex);
+    s.writeBlob(21, m_rollupState);
 
     return s.final();
 }
@@ -154,6 +155,7 @@ bool AMModSettings::deserialize(const QByteArray& data)
         d.readReal(18, &m_feedbackVolumeFactor, 1.0);
         d.readBool(19, &m_feedbackAudioEnable, false);
         d.readS32(20, &m_streamIndex, 0);
+        d.readBlob(21, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/modam/ammodsettings.h
+++ b/plugins/channeltx/modam/ammodsettings.h
@@ -60,6 +60,7 @@ struct AMModSettings
     Serializable *m_cwKeyerGUI;
 
     CWKeyerSettings m_cwKeyerSettings; //!< For standalone deserialize operation (without m_cwKeyerGUI)
+    QByteArray m_rollupState;
 
     AMModSettings();
     void resetToDefaults();

--- a/plugins/channeltx/modatv/atvmodgui.cpp
+++ b/plugins/channeltx/modatv/atvmodgui.cpp
@@ -667,6 +667,9 @@ void ATVModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void ATVModGUI::onMenuDialogCalled(const QPoint &p)
@@ -790,6 +793,7 @@ void ATVModGUI::displaySettings()
     ui->playVideo->setChecked(m_settings.m_videoPlay);
     ui->playLoop->setChecked(m_settings.m_videoPlayLoop);
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channeltx/modatv/atvmodsettings.cpp
+++ b/plugins/channeltx/modatv/atvmodsettings.cpp
@@ -91,6 +91,7 @@ QByteArray ATVModSettings::serialize() const
     s.writeString(22, m_imageFileName);
     s.writeString(23, m_videoFileName);
     s.writeS32(24, m_streamIndex);
+    s.writeBlob(25, m_rollupState);
 
     return s.final();
 }
@@ -157,6 +158,7 @@ bool ATVModSettings::deserialize(const QByteArray& data)
         d.readString(22, &m_imageFileName);
         d.readString(23, &m_videoFileName);
         d.readS32(24, &m_streamIndex, 0);
+        d.readBlob(25, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/modatv/atvmodsettings.h
+++ b/plugins/channeltx/modatv/atvmodsettings.h
@@ -91,6 +91,7 @@ struct ATVModSettings
     uint16_t      m_reverseAPIChannelIndex;
 
     Serializable *m_channelMarker;
+    QByteArray m_rollupState;
 
     ATVModSettings();
     void resetToDefaults();

--- a/plugins/channeltx/modchirpchat/chirpchatmodgui.cpp
+++ b/plugins/channeltx/modchirpchat/chirpchatmodgui.cpp
@@ -355,6 +355,9 @@ void ChirpChatModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void ChirpChatModGUI::onMenuDialogCalled(const QPoint &p)
@@ -519,6 +522,7 @@ void ChirpChatModGUI::displaySettings()
     ui->udpEnabled->setChecked(m_settings.m_udpEnabled);
     ui->udpAddress->setText(m_settings.m_udpAddress);
     ui->udpPort->setText(QString::number(m_settings.m_udpPort));
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channeltx/modchirpchat/chirpchatmodsettings.cpp
+++ b/plugins/channeltx/modchirpchat/chirpchatmodsettings.cpp
@@ -195,6 +195,7 @@ QByteArray ChirpChatModSettings::serialize() const
     s.writeBool(56, m_udpEnabled);
     s.writeString(57, m_udpAddress);
     s.writeU32(58, m_udpPort);
+    s.writeBlob(59, m_rollupState);
 
     return s.final();
 }
@@ -293,6 +294,7 @@ bool ChirpChatModSettings::deserialize(const QByteArray& data)
         } else {
             m_udpPort = 9998;
         }
+        d.readBlob(59, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/modchirpchat/chirpchatmodsettings.h
+++ b/plugins/channeltx/modchirpchat/chirpchatmodsettings.h
@@ -90,6 +90,7 @@ struct ChirpChatModSettings
     uint16_t m_reverseAPIChannelIndex;
 
     Serializable *m_channelMarker;
+    QByteArray m_rollupState;
 
     static const int bandwidths[];
     static const int nbBandwidths;

--- a/plugins/channeltx/moddatv/datvmodgui.cpp
+++ b/plugins/channeltx/moddatv/datvmodgui.cpp
@@ -469,6 +469,9 @@ void DATVModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void DATVModGUI::onMenuDialogCalled(const QPoint &p)
@@ -575,6 +578,7 @@ void DATVModGUI::displaySettings()
     ui->udpAddress->setText(m_settings.m_udpAddress);
     ui->udpPort->setValue(m_settings.m_udpPort);
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channeltx/moddatv/datvmodsettings.cpp
+++ b/plugins/channeltx/moddatv/datvmodsettings.cpp
@@ -88,6 +88,7 @@ QByteArray DATVModSettings::serialize() const
     s.writeU32(26, m_reverseAPIDeviceIndex);
     s.writeU32(27, m_reverseAPIChannelIndex);
     s.writeS32(28, m_streamIndex);
+    s.writeBlob(29, m_rollupState);
 
     return s.final();
 }
@@ -149,6 +150,7 @@ bool DATVModSettings::deserialize(const QByteArray& data)
         d.readU32(27, &utmp, 0);
         m_reverseAPIChannelIndex = utmp > 99 ? 99 : utmp;
         d.readS32(28, &m_streamIndex, 0);
+        d.readBlob(29, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/moddatv/datvmodsettings.h
+++ b/plugins/channeltx/moddatv/datvmodsettings.h
@@ -96,6 +96,7 @@ struct DATVModSettings
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIDeviceIndex;
     uint16_t m_reverseAPIChannelIndex;
+    QByteArray m_rollupState;
 
     DATVModSettings();
     void resetToDefaults();

--- a/plugins/channeltx/modfreedv/freedvmodgui.cpp
+++ b/plugins/channeltx/modfreedv/freedvmodgui.cpp
@@ -281,6 +281,9 @@ void FreeDVModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void FreeDVModGUI::onMenuDialogCalled(const QPoint &p)
@@ -494,6 +497,7 @@ void FreeDVModGUI::displaySettings()
     ui->play->setChecked(m_settings.m_modAFInput == FreeDVModSettings::FreeDVModInputAF::FreeDVModInputFile);
     ui->morseKeyer->setChecked(m_settings.m_modAFInput == FreeDVModSettings::FreeDVModInputAF::FreeDVModInputCWTone);
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channeltx/modfreedv/freedvmodsettings.cpp
+++ b/plugins/channeltx/modfreedv/freedvmodsettings.cpp
@@ -88,6 +88,7 @@ QByteArray FreeDVModSettings::serialize() const
     s.writeU32(25, m_reverseAPIDeviceIndex);
     s.writeU32(26, m_reverseAPIChannelIndex);
     s.writeS32(27, m_streamIndex);
+    s.writeBlob(28, m_rollupState);
 
     return s.final();
 }
@@ -169,6 +170,7 @@ bool FreeDVModSettings::deserialize(const QByteArray& data)
         d.readU32(26, &utmp, 0);
         m_reverseAPIChannelIndex = utmp > 99 ? 99 : utmp;
         d.readS32(27, &m_streamIndex, 0);
+        d.readBlob(28, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/modfreedv/freedvmodsettings.h
+++ b/plugins/channeltx/modfreedv/freedvmodsettings.h
@@ -72,6 +72,7 @@ struct FreeDVModSettings
     Serializable *m_cwKeyerGUI;
 
     CWKeyerSettings m_cwKeyerSettings; //!< For standalone deserialize operation (without m_cwKeyerGUI)
+    QByteArray m_rollupState;
 
     FreeDVModSettings();
     void resetToDefaults();

--- a/plugins/channeltx/modnfm/nfmmodgui.cpp
+++ b/plugins/channeltx/modnfm/nfmmodgui.cpp
@@ -341,6 +341,9 @@ void NFMModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void NFMModGUI::onMenuDialogCalled(const QPoint &p)
@@ -550,6 +553,7 @@ void NFMModGUI::displaySettings()
     ui->feedbackVolume->setValue(roundf(m_settings.m_feedbackVolumeFactor * 100.0));
     ui->feedbackVolumeText->setText(QString("%1").arg(m_settings.m_feedbackVolumeFactor, 0, 'f', 2));
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channeltx/modnfm/nfmmodsettings.cpp
+++ b/plugins/channeltx/modnfm/nfmmodsettings.cpp
@@ -119,6 +119,7 @@ QByteArray NFMModSettings::serialize() const
     s.writeBool(24, m_dcsOn);
     s.writeS32(25, m_dcsCode);
     s.writeBool(26, m_dcsPositive);
+    s.writeBlob(27, m_rollupState);
 
     return s.final();
 }
@@ -196,6 +197,7 @@ bool NFMModSettings::deserialize(const QByteArray& data)
         d.readS32(25, &tmp, 0023);
         m_dcsCode = tmp < 0 ? 0 : tmp > 511 ? 511 : tmp;
         d.readBool(26, &m_dcsPositive, false);
+        d.readBlob(27, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/modnfm/nfmmodsettings.h
+++ b/plugins/channeltx/modnfm/nfmmodsettings.h
@@ -72,6 +72,7 @@ struct NFMModSettings
     Serializable *m_cwKeyerGUI;
 
     CWKeyerSettings m_cwKeyerSettings; //!< For standalone deserialize operation (without m_cwKeyerGUI)
+    QByteArray m_rollupState;
 
     NFMModSettings();
     void resetToDefaults();

--- a/plugins/channeltx/modpacket/packetmodgui.cpp
+++ b/plugins/channeltx/modpacket/packetmodgui.cpp
@@ -366,6 +366,9 @@ void PacketModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void PacketModGUI::onMenuDialogCalled(const QPoint &p)
@@ -566,6 +569,7 @@ void PacketModGUI::displaySettings()
     ui->via->lineEdit()->setText(m_settings.m_via);
     ui->packet->setText(m_settings.m_data);
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channeltx/modpacket/packetmodsettings.cpp
+++ b/plugins/channeltx/modpacket/packetmodsettings.cpp
@@ -224,6 +224,7 @@ QByteArray PacketModSettings::serialize() const
     s.writeBool(51, m_udpEnabled);
     s.writeString(52, m_udpAddress);
     s.writeU32(53, m_udpPort);
+    s.writeBlob(54, m_rollupState);
 
     return s.final();
 }
@@ -318,6 +319,7 @@ bool PacketModSettings::deserialize(const QByteArray& data)
         } else {
             m_udpPort = 9998;
         }
+        d.readBlob(54, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/modpacket/packetmodsettings.h
+++ b/plugins/channeltx/modpacket/packetmodsettings.h
@@ -82,6 +82,7 @@ struct PacketModSettings
     bool m_udpEnabled;
     QString m_udpAddress;
     uint16_t m_udpPort;
+    QByteArray m_rollupState;
 
     PacketModSettings();
     void resetToDefaults();

--- a/plugins/channeltx/modssb/ssbmodgui.cpp
+++ b/plugins/channeltx/modssb/ssbmodgui.cpp
@@ -345,6 +345,9 @@ void SSBModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void SSBModGUI::onMenuDialogCalled(const QPoint &p)
@@ -708,6 +711,7 @@ void SSBModGUI::displaySettings()
     ui->feedbackVolume->setValue(roundf(m_settings.m_feedbackVolumeFactor * 100.0));
     ui->feedbackVolumeText->setText(QString("%1").arg(m_settings.m_feedbackVolumeFactor, 0, 'f', 2));
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channeltx/modssb/ssbmodsettings.cpp
+++ b/plugins/channeltx/modssb/ssbmodsettings.cpp
@@ -121,6 +121,7 @@ QByteArray SSBModSettings::serialize() const
     s.writeReal(28, m_feedbackVolumeFactor);
     s.writeBool(29, m_feedbackAudioEnable);
     s.writeS32(30, m_streamIndex);
+    s.writeBlob(31, m_rollupState);
 
     return s.final();
 }
@@ -209,6 +210,7 @@ bool SSBModSettings::deserialize(const QByteArray& data)
         d.readReal(28, &m_feedbackVolumeFactor, 1.0);
         d.readBool(29, &m_feedbackAudioEnable, false);
         d.readS32(30, &m_streamIndex, 0);
+        d.readBlob(31, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/modssb/ssbmodsettings.h
+++ b/plugins/channeltx/modssb/ssbmodsettings.h
@@ -76,6 +76,7 @@ struct SSBModSettings
     Serializable *m_cwKeyerGUI;
 
     CWKeyerSettings m_cwKeyerSettings; //!< For standalone deserialize operation (without m_cwKeyerGUI)
+    QByteArray m_rollupState;
 
     SSBModSettings();
     void resetToDefaults();

--- a/plugins/channeltx/modwfm/wfmmodgui.cpp
+++ b/plugins/channeltx/modwfm/wfmmodgui.cpp
@@ -275,6 +275,9 @@ void WFMModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void WFMModGUI::onMenuDialogCalled(const QPoint &p)
@@ -469,6 +472,7 @@ void WFMModGUI::displaySettings()
     ui->feedbackVolume->setValue(roundf(m_settings.m_feedbackVolumeFactor * 100.0));
     ui->feedbackVolumeText->setText(QString("%1").arg(m_settings.m_feedbackVolumeFactor, 0, 'f', 2));
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 

--- a/plugins/channeltx/modwfm/wfmmodsettings.cpp
+++ b/plugins/channeltx/modwfm/wfmmodsettings.cpp
@@ -95,6 +95,7 @@ QByteArray WFMModSettings::serialize() const
     s.writeString(19, m_feedbackAudioDeviceName);
     s.writeReal(20, m_feedbackVolumeFactor);
     s.writeBool(21, m_feedbackAudioEnable);
+    s.writeBlob(22, m_rollupState);
 
     return s.final();
 }
@@ -164,6 +165,7 @@ bool WFMModSettings::deserialize(const QByteArray& data)
         d.readString(19, &m_feedbackAudioDeviceName, AudioDeviceManager::m_defaultDeviceName);
         d.readReal(20, &m_feedbackVolumeFactor, 1.0);
         d.readBool(21, &m_feedbackAudioEnable, false);
+        d.readBlob(22, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/modwfm/wfmmodsettings.h
+++ b/plugins/channeltx/modwfm/wfmmodsettings.h
@@ -64,6 +64,7 @@ struct WFMModSettings
     Serializable *m_cwKeyerGUI;
 
     CWKeyerSettings m_cwKeyerSettings; //!< For standalone deserialize operation (without m_cwKeyerGUI)
+    QByteArray m_rollupState;
 
     WFMModSettings();
     void resetToDefaults();

--- a/plugins/channeltx/remotesource/remotesourcegui.cpp
+++ b/plugins/channeltx/remotesource/remotesourcegui.cpp
@@ -227,6 +227,7 @@ void RemoteSourceGUI::displaySettings()
     blockApplySettings(true);
     ui->dataAddress->setText(m_settings.m_dataAddress);
     ui->dataPort->setText(tr("%1").arg(m_settings.m_dataPort));
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 
@@ -266,6 +267,9 @@ void RemoteSourceGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void RemoteSourceGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channeltx/remotesource/remotesourcesettings.cpp
+++ b/plugins/channeltx/remotesource/remotesourcesettings.cpp
@@ -56,6 +56,7 @@ QByteArray RemoteSourceSettings::serialize() const
     s.writeU32(8, m_reverseAPIDeviceIndex);
     s.writeU32(9, m_reverseAPIChannelIndex);
     s.writeS32(10, m_streamIndex);
+    s.writeBlob(11, m_rollupState);
 
     return s.final();
 }
@@ -101,6 +102,7 @@ bool RemoteSourceSettings::deserialize(const QByteArray& data)
         d.readU32(9, &tmp, 0);
         m_reverseAPIChannelIndex = tmp > 99 ? 99 : tmp;
         d.readS32(10, &m_streamIndex, 0);
+        d.readBlob(11, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/remotesource/remotesourcesettings.h
+++ b/plugins/channeltx/remotesource/remotesourcesettings.h
@@ -37,6 +37,7 @@ struct RemoteSourceSettings
     uint16_t m_reverseAPIChannelIndex;
 
     Serializable *m_channelMarker;
+    QByteArray m_rollupState;
 
     RemoteSourceSettings();
     void resetToDefaults();

--- a/plugins/channeltx/udpsource/udpsourcegui.cpp
+++ b/plugins/channeltx/udpsource/udpsourcegui.cpp
@@ -229,6 +229,7 @@ void UDPSourceGUI::displaySettings()
     ui->applyBtn->setEnabled(false);
     ui->applyBtn->setStyleSheet("QPushButton { background:rgb(79,79,79); }");
 
+    restoreState(m_settings.m_rollupState);
     blockApplySettings(false);
 }
 
@@ -463,6 +464,9 @@ void UDPSourceGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     {
         m_udpSource->setSpectrum(rollDown);
     }
+
+    m_settings.m_rollupState = saveState();
+    applySettings();
 }
 
 void UDPSourceGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channeltx/udpsource/udpsourcesettings.cpp
+++ b/plugins/channeltx/udpsource/udpsourcesettings.cpp
@@ -96,6 +96,7 @@ QByteArray UDPSourceSettings::serialize() const
     s.writeU32(24, m_reverseAPIDeviceIndex);
     s.writeU32(25, m_reverseAPIChannelIndex);
     s.writeS32(26, m_streamIndex);
+    s.writeBlob(27, m_rollupState);
 
     return s.final();
 }
@@ -190,6 +191,7 @@ bool UDPSourceSettings::deserialize(const QByteArray& data)
         d.readU32(25, &u32tmp, 0);
         m_reverseAPIChannelIndex = u32tmp > 99 ? 99 : u32tmp;
         d.readS32(26, &m_streamIndex, 0);
+        d.readBlob(27, &m_rollupState);
 
         return true;
     }

--- a/plugins/channeltx/udpsource/udpsourcesettings.h
+++ b/plugins/channeltx/udpsource/udpsourcesettings.h
@@ -70,6 +70,7 @@ struct UDPSourceSettings
 
     Serializable *m_channelMarker;
     Serializable *m_spectrumGUI;
+    QByteArray m_rollupState;
 
     UDPSourceSettings();
     void resetToDefaults();


### PR DESCRIPTION
Also fix saving/restore of m_dcsPositive in NFM demod and channel marker in Interferometer.