### PR TITLE
Add links to documentation

### DIFF
--- a/plugins/channelrx/chanalyzer/chanalyzergui.cpp
+++ b/plugins/channelrx/chanalyzer/chanalyzergui.cpp
@@ -465,6 +465,7 @@ ChannelAnalyzerGUI::ChannelAnalyzerGUI(PluginAPI* pluginAPI, DeviceUISet *device
 	m_basebandSampleRate(48000)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/chanalyzer/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -2511,6 +2511,7 @@ ADSBDemodGUI::ADSBDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
     m_progressDialog(nullptr)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodadsb/readme.md";
 
     m_osmPort = 0; // Pick a free port
     m_templateServer = new ADSBOSMTemplateServer("q2RVNAe3eFKCH4XsrE3r", m_osmPort);

--- a/plugins/channelrx/demodais/aisdemodgui.cpp
+++ b/plugins/channelrx/demodais/aisdemodgui.cpp
@@ -417,6 +417,7 @@ AISDemodGUI::AISDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     m_tickCount(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodais/readme.md";
 
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channelrx/demodam/amdemodgui.cpp
+++ b/plugins/channelrx/demodam/amdemodgui.cpp
@@ -240,6 +240,7 @@ AMDemodGUI::AMDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandS
 	m_tickCount(0)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodam/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channelrx/demodapt/aptdemodgui.cpp
+++ b/plugins/channelrx/demodapt/aptdemodgui.cpp
@@ -447,6 +447,7 @@ APTDemodGUI::APTDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     m_pixmapItem(nullptr)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodapt/readme.md";
 
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channelrx/demodatv/atvdemodgui.cpp
+++ b/plugins/channelrx/demodatv/atvdemodgui.cpp
@@ -219,6 +219,7 @@ ATVDemodGUI::ATVDemodGUI(PluginAPI* objPluginAPI, DeviceUISet *deviceUISet, Base
         m_basebandSampleRate(48000)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodatv/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
@@ -378,6 +378,7 @@ ChirpChatDemodGUI::ChirpChatDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUI
     m_tickCount(0)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodchirpchat/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channelrx/demoddab/dabdemodgui.cpp
+++ b/plugins/channelrx/demoddab/dabdemodgui.cpp
@@ -432,6 +432,7 @@ DABDemodGUI::DABDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     m_channelFreq(0.0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demoddab/readme.md";
 
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channelrx/demoddatv/datvdemodgui.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodgui.cpp
@@ -195,6 +195,7 @@ DATVDemodGUI::DATVDemodGUI(PluginAPI* objPluginAPI, DeviceUISet *deviceUISet, Ba
         m_cstlnSetByModcod(false)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demoddatv/readme.md";
     ui->screenTV->setColor(true);
     ui->screenTV->resizeTVScreen(256,256);
     setAttribute(Qt::WA_DeleteOnClose, true);

--- a/plugins/channelrx/demoddsd/dsddemodgui.cpp
+++ b/plugins/channelrx/demoddsd/dsddemodgui.cpp
@@ -318,6 +318,7 @@ DSDDemodGUI::DSDDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
 	m_dsdStatusTextDialog(0)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demoddsd/readme.md";
 	ui->screenTV->setColor(true);
 	ui->screenTV->resizeTVScreen(200,200);
 	setAttribute(Qt::WA_DeleteOnClose, true);

--- a/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
@@ -250,6 +250,7 @@ FreeDVDemodGUI::FreeDVDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
     m_audioSampleRate(-1)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodfreedv/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 	connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channelrx/demodnfm/nfmdemodgui.cpp
+++ b/plugins/channelrx/demodnfm/nfmdemodgui.cpp
@@ -340,6 +340,7 @@ NFMDemodGUI::NFMDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
 	m_tickCount(0)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodnfm/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channelrx/demodpacket/packetdemodgui.cpp
+++ b/plugins/channelrx/demodpacket/packetdemodgui.cpp
@@ -416,6 +416,7 @@ PacketDemodGUI::PacketDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
     m_tickCount(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodpacket/readme.md";
 
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channelrx/demodpager/pagerdemodgui.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodgui.cpp
@@ -466,6 +466,7 @@ PagerDemodGUI::PagerDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Bas
     m_tickCount(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodpager/readme.md";
 
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channelrx/demodssb/ssbdemodgui.cpp
+++ b/plugins/channelrx/demodssb/ssbdemodgui.cpp
@@ -290,6 +290,7 @@ SSBDemodGUI::SSBDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     m_audioSampleRate(-1)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodssb/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 	connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channelrx/demodvor/vordemodgui.cpp
+++ b/plugins/channelrx/demodvor/vordemodgui.cpp
@@ -1164,6 +1164,7 @@ VORDemodGUI::VORDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     m_vors(nullptr)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodvor/readme.md";
 
     ui->map->rootContext()->setContextProperty("vorModel", &m_vorModel);
     ui->map->setSource(QUrl(QStringLiteral("qrc:/demodvor/map/map.qml")));

--- a/plugins/channelrx/demodvorsc/vordemodscgui.cpp
+++ b/plugins/channelrx/demodvorsc/vordemodscgui.cpp
@@ -279,6 +279,7 @@ VORDemodSCGUI::VORDemodSCGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Bas
     m_tickCount(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodvorsc/readme.md";
 
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channelrx/demodwfm/wfmdemodgui.cpp
+++ b/plugins/channelrx/demodwfm/wfmdemodgui.cpp
@@ -202,6 +202,7 @@ WFMDemodGUI::WFMDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     m_audioSampleRate(-1)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/demodwfm/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channelrx/filesink/filesinkgui.cpp
+++ b/plugins/channelrx/filesink/filesinkgui.cpp
@@ -183,6 +183,7 @@ FileSinkGUI::FileSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
         m_tickCount(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/filesink/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channelrx/freqtracker/freqtrackergui.cpp
+++ b/plugins/channelrx/freqtracker/freqtrackergui.cpp
@@ -308,6 +308,7 @@ FreqTrackerGUI::FreqTrackerGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
 	m_tickCount(0)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/freqtracker/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channelrx/localsink/localsinkgui.cpp
+++ b/plugins/channelrx/localsink/localsinkgui.cpp
@@ -101,6 +101,7 @@ LocalSinkGUI::LocalSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
         m_tickCount(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/localsink/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channelrx/noisefigure/noisefiguregui.cpp
+++ b/plugins/channelrx/noisefigure/noisefiguregui.cpp
@@ -608,6 +608,7 @@ NoiseFigureGUI::NoiseFigureGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
     m_chart(nullptr)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/noisefigure/readme.md";
 
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channelrx/radioclock/radioclockgui.cpp
+++ b/plugins/channelrx/radioclock/radioclockgui.cpp
@@ -264,6 +264,7 @@ RadioClockGUI::RadioClockGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Bas
     m_tickCount(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/radioclock/readme.md";
 
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channelrx/remotesink/remotesinkgui.cpp
+++ b/plugins/channelrx/remotesink/remotesinkgui.cpp
@@ -100,6 +100,7 @@ RemoteSinkGUI::RemoteSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Bas
         m_tickCount(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/remotesink/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channelrx/sigmffilesink/sigmffilesinkgui.cpp
+++ b/plugins/channelrx/sigmffilesink/sigmffilesinkgui.cpp
@@ -170,6 +170,7 @@ SigMFFileSinkGUI::SigMFFileSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISe
         m_tickCount(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/sigmffilesink/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channelrx/udpsink/udpsinkgui.cpp
+++ b/plugins/channelrx/udpsink/udpsinkgui.cpp
@@ -146,6 +146,7 @@ UDPSinkGUI::UDPSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandS
     m_rfBandwidthChanged(false)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channelrx/udpsink/readme.md";
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));
 	setAttribute(Qt::WA_DeleteOnClose, true);

--- a/plugins/channeltx/filesource/filesourcegui.cpp
+++ b/plugins/channeltx/filesource/filesourcegui.cpp
@@ -179,6 +179,7 @@ FileSourceGUI::FileSourceGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Bas
     (void) channelTx;
 
     ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/filesource/readme.md";
     ui->channelPowerMeter->setColorTheme(LevelMeterSignalDB::ColorGreenAndBlue);
 
     setAttribute(Qt::WA_DeleteOnClose, true);

--- a/plugins/channeltx/localsource/localsourcegui.cpp
+++ b/plugins/channeltx/localsource/localsourcegui.cpp
@@ -95,6 +95,7 @@ LocalSourceGUI::LocalSourceGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
         m_tickCount(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/localsource/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_modgui.cpp
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_modgui.cpp
@@ -376,6 +376,7 @@ IEEE_802_15_4_ModGUI::IEEE_802_15_4_ModGUI(PluginAPI* pluginAPI, DeviceUISet *de
     m_basebandSampleRate(12000000)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/mod802.15.4/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
 
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channeltx/modais/aismodgui.cpp
+++ b/plugins/channeltx/modais/aismodgui.cpp
@@ -385,6 +385,7 @@ AISModGUI::AISModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSam
     m_doApplySettings(true)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/modais/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
 
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channeltx/modam/ammodgui.cpp
+++ b/plugins/channeltx/modam/ammodgui.cpp
@@ -332,6 +332,7 @@ AMModGUI::AMModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSampl
     m_enableNavTime(false)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/modam/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 	connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channeltx/modatv/atvmodgui.cpp
+++ b/plugins/channeltx/modatv/atvmodgui.cpp
@@ -64,6 +64,7 @@ ATVModGUI::ATVModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSam
     m_rfSliderDivisor(100000)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/modatv/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 	connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channeltx/modchirpchat/chirpchatmodgui.cpp
+++ b/plugins/channeltx/modchirpchat/chirpchatmodgui.cpp
@@ -413,6 +413,7 @@ ChirpChatModGUI::ChirpChatModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet,
     m_tickCount(0)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/modchirpchat/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channeltx/moddatv/datvmodgui.cpp
+++ b/plugins/channeltx/moddatv/datvmodgui.cpp
@@ -64,6 +64,7 @@ DATVModGUI::DATVModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandS
     m_enableNavTime(false)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/moddatv/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channeltx/modfreedv/freedvmodgui.cpp
+++ b/plugins/channeltx/modfreedv/freedvmodgui.cpp
@@ -345,6 +345,7 @@ FreeDVModGUI::FreeDVModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
     m_enableNavTime(false)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/modfreedv/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 	connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channeltx/modnfm/nfmmodgui.cpp
+++ b/plugins/channeltx/modnfm/nfmmodgui.cpp
@@ -405,6 +405,7 @@ NFMModGUI::NFMModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSam
     m_dcsCodeValidator(QRegExp("[0-7]{1,3}"))
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/modnfm/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 
     ui->channelSpacing->blockSignals(true);

--- a/plugins/channeltx/modpacket/packetmodgui.cpp
+++ b/plugins/channeltx/modpacket/packetmodgui.cpp
@@ -422,6 +422,7 @@ PacketModGUI::PacketModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
     m_doApplySettings(true)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/modpacket/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
 
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/channeltx/modssb/ssbmodgui.cpp
+++ b/plugins/channeltx/modssb/ssbmodgui.cpp
@@ -410,6 +410,7 @@ SSBModGUI::SSBModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSam
     m_enableNavTime(false)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/modssb/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 	connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channeltx/modwfm/wfmmodgui.cpp
+++ b/plugins/channeltx/modwfm/wfmmodgui.cpp
@@ -339,6 +339,7 @@ WFMModGUI::WFMModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSam
     m_enableNavTime(false)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/modwfm/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 
     blockApplySettings(true);

--- a/plugins/channeltx/remotesource/remotesourcegui.cpp
+++ b/plugins/channeltx/remotesource/remotesourcegui.cpp
@@ -159,6 +159,7 @@ RemoteSourceGUI::RemoteSourceGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet,
 {
     (void) channelTx;
     ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/remotesource/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));

--- a/plugins/channeltx/udpsource/udpsourcegui.cpp
+++ b/plugins/channeltx/udpsource/udpsourcegui.cpp
@@ -106,6 +106,7 @@ UDPSourceGUI::UDPSourceGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
         m_doApplySettings(true)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/channeltx/udpsource/readme.md";
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onMenuDialogCalled(const QPoint &)));
     setAttribute(Qt::WA_DeleteOnClose, true);

--- a/plugins/feature/afc/afcgui.cpp
+++ b/plugins/feature/afc/afcgui.cpp
@@ -127,6 +127,7 @@ AFCGUI::AFCGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *featur
     m_lastFeatureState(0)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/feature/afc/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
 
     ui->targetFrequency->setColorMapper(ColorMapper(ColorMapper::GrayGold));

--- a/plugins/feature/ais/aisgui.cpp
+++ b/plugins/feature/ais/aisgui.cpp
@@ -128,6 +128,7 @@ AISGUI::AISGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *featur
     m_lastFeatureState(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/feature/ais/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     setChannelWidget(false);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/feature/antennatools/antennatoolsgui.cpp
+++ b/plugins/feature/antennatools/antennatoolsgui.cpp
@@ -115,6 +115,7 @@ AntennaToolsGUI::AntennaToolsGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISe
     m_deviceSets(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/feature/antennatools/readme.md";
 
     setAttribute(Qt::WA_DeleteOnClose, true);
     setChannelWidget(false);

--- a/plugins/feature/aprs/aprsgui.cpp
+++ b/plugins/feature/aprs/aprsgui.cpp
@@ -422,6 +422,7 @@ APRSGUI::APRSGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feat
     m_lastFeatureState(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/feature/aprs/readme.md";
 
     setAttribute(Qt::WA_DeleteOnClose, true);
     setChannelWidget(false);

--- a/plugins/feature/demodanalyzer/demodanalyzergui.cpp
+++ b/plugins/feature/demodanalyzer/demodanalyzergui.cpp
@@ -138,6 +138,7 @@ DemodAnalyzerGUI::DemodAnalyzerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUI
     m_selectedChannel(nullptr)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/feature/demodanalyzer/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
     setChannelWidget(false);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/feature/gs232controller/gs232controllergui.cpp
+++ b/plugins/feature/gs232controller/gs232controllergui.cpp
@@ -141,6 +141,7 @@ GS232ControllerGUI::GS232ControllerGUI(PluginAPI* pluginAPI, FeatureUISet *featu
     m_lastOnTarget(false)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/feature/gs232controller/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     setChannelWidget(false);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/feature/map/mapgui.cpp
+++ b/plugins/feature/map/mapgui.cpp
@@ -686,6 +686,7 @@ MapGUI::MapGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *featur
     m_radioTimeDialog(this)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/feature/map/readme.md";
 
     quint16 port = 0; // Pick a free port
     // Free keys, so no point in stealing them :)

--- a/plugins/feature/pertester/pertestergui.cpp
+++ b/plugins/feature/pertester/pertestergui.cpp
@@ -127,6 +127,7 @@ PERTesterGUI::PERTesterGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Fea
     m_lastFeatureState(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/feature/pertester/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     setChannelWidget(false);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/feature/rigctlserver/rigctlservergui.cpp
+++ b/plugins/feature/rigctlserver/rigctlservergui.cpp
@@ -127,6 +127,7 @@ RigCtlServerGUI::RigCtlServerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISe
     m_lastFeatureState(0)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/feature/rigctlserver/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
     setChannelWidget(false);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/feature/satellitetracker/satellitetrackergui.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackergui.cpp
@@ -246,6 +246,7 @@ SatelliteTrackerGUI::SatelliteTrackerGUI(PluginAPI* pluginAPI, FeatureUISet *fea
     m_geostationarySatVisible(false)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/feature/satellitetracker/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     setChannelWidget(false);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/feature/simpleptt/simplepttgui.cpp
+++ b/plugins/feature/simpleptt/simplepttgui.cpp
@@ -134,6 +134,7 @@ SimplePTTGUI::SimplePTTGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Fea
     m_lastFeatureState(0)
 {
 	ui->setupUi(this);
+    m_helpURL = "plugins/feature/simpleptt/readme.md";
 	setAttribute(Qt::WA_DeleteOnClose, true);
     setChannelWidget(false);
 	connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/feature/startracker/startrackergui.cpp
+++ b/plugins/feature/startracker/startrackergui.cpp
@@ -255,6 +255,7 @@ StarTrackerGUI::StarTrackerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet,
     m_moonDec(0.0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/feature/startracker/readme.md";
     setAttribute(Qt::WA_DeleteOnClose, true);
     setChannelWidget(false);
     connect(this, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));

--- a/plugins/feature/vorlocalizer/vorlocalizergui.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizergui.cpp
@@ -1226,6 +1226,7 @@ VORLocalizerGUI::VORLocalizerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISe
     m_rrSecondsCount(0)
 {
     ui->setupUi(this);
+    m_helpURL = "plugins/feature/vorlocalizer/readme.md";
 
     ui->map->rootContext()->setContextProperty("vorModel", &m_vorModel);
     ui->map->setSource(QUrl(QStringLiteral("qrc:/demodvor/map/map.qml")));

--- a/sdrgui/gui/rollupwidget.h
+++ b/sdrgui/gui/rollupwidget.h
@@ -52,6 +52,7 @@ protected:
     bool m_highlighted;
     ContextMenuType m_contextMenuType;
     QString m_streamIndicator;
+    QString m_helpURL;
 
     int arrangeRollups();
 

--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -29,6 +29,7 @@
 #include <QResource>
 #include <QFontDatabase>
 #include <QStandardPaths>
+#include <QDesktopServices>
 
 #include "device/devicegui.h"
 #include "device/deviceapi.h"
@@ -1751,6 +1752,16 @@ void MainWindow::on_presetTree_itemActivated(QTreeWidgetItem *item, int column)
     (void) item;
     (void) column;
 	on_presetLoad_clicked();
+}
+
+void MainWindow::on_action_Quick_Start_triggered()
+{
+    QDesktopServices::openUrl(QUrl("https://github.com/f4exb/sdrangel/wiki/Quick-start"));
+}
+
+void MainWindow::on_action_Main_Window_triggered()
+{
+    QDesktopServices::openUrl(QUrl("https://github.com/f4exb/sdrangel/blob/master/sdrgui/readme.md"));
 }
 
 void MainWindow::on_action_Loaded_Plugins_triggered()

--- a/sdrgui/mainwindow.h
+++ b/sdrgui/mainwindow.h
@@ -184,6 +184,8 @@ private slots:
     void samplingDeviceChanged(int deviceType, int tabIndex, int newDeviceIndex);
     void channelAddClicked(int channelIndex);
     void featureAddClicked(int featureIndex);
+    void on_action_Quick_Start_triggered();
+    void on_action_Main_Window_triggered();
 	void on_action_Loaded_Plugins_triggered();
 	void on_action_About_triggered();
 	void on_action_addSourceDevice_triggered();

--- a/sdrgui/mainwindow.ui
+++ b/sdrgui/mainwindow.ui
@@ -64,7 +64,7 @@
      <x>0</x>
      <y>0</y>
      <width>1012</width>
-     <height>27</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -92,6 +92,9 @@
     <property name="title">
      <string>&amp;Help</string>
     </property>
+    <addaction name="action_Quick_Start"/>
+    <addaction name="action_Main_Window"/>
+    <addaction name="separator"/>
     <addaction name="action_Loaded_Plugins"/>
     <addaction name="separator"/>
     <addaction name="action_About"/>
@@ -976,6 +979,16 @@
   <action name="action_FFT">
    <property name="text">
     <string>FFT</string>
+   </property>
+  </action>
+  <action name="action_Quick_Start">
+   <property name="text">
+    <string>&amp;Quick Start...</string>
+   </property>
+  </action>
+  <action name="action_Main_Window">
+   <property name="text">
+    <string>&amp;Main Window...</string>
    </property>
   </action>
   <zorder>presetDock</zorder>


### PR DESCRIPTION
SDRangel has good documentation, but it seems users struggle to find it.

This PR adds a small help button in Channels & Features that links to the relevant docs:

![image](https://user-images.githubusercontent.com/57259258/143231699-effce91a-213a-4965-8c17-6bf736059fb3.png)

And also a couple of new items in the Help menu that link to the main docs:

![image](https://user-images.githubusercontent.com/57259258/143231818-dec8110a-b3d7-4c16-a76f-c841ce0cbbc7.png)
