### PR TITLE
Move Feature workers to thread

### DIFF
--- a/plugins/feature/afc/afc.cpp
+++ b/plugins/feature/afc/afc.cpp
@@ -52,6 +52,7 @@ AFC::AFC(WebAPIAdapterInterface *webAPIAdapterInterface) :
 {
     setObjectName(m_featureId);
     m_worker = new AFCWorker(webAPIAdapterInterface);
+    m_worker->moveToThread(&m_thread);
     m_state = StIdle;
     m_errorMessage = "AFC error";
     m_networkManager = new QNetworkAccessManager();

--- a/plugins/feature/afc/afcworker.cpp
+++ b/plugins/feature/afc/afcworker.cpp
@@ -46,6 +46,7 @@ AFCWorker::AFCWorker(WebAPIAdapterInterface *webAPIAdapterInterface) :
     m_freqTracker(nullptr),
     m_trackerDeviceFrequency(0),
     m_trackerChannelOffset(0),
+    m_updateTimer(this),
     m_mutex(QMutex::Recursive)
 {
     qDebug("AFCWorker::AFCWorker");

--- a/plugins/feature/aprs/aprs.cpp
+++ b/plugins/feature/aprs/aprs.cpp
@@ -46,6 +46,7 @@ APRS::APRS(WebAPIAdapterInterface *webAPIAdapterInterface) :
     qDebug("APRS::APRS: webAPIAdapterInterface: %p", webAPIAdapterInterface);
     setObjectName(m_featureId);
     m_worker = new APRSWorker(this, webAPIAdapterInterface);
+    m_worker->moveToThread(&m_thread);
     m_state = StIdle;
     m_errorMessage = "APRS error";
     connect(&m_updatePipesTimer, SIGNAL(timeout()), this, SLOT(updatePipes()));

--- a/plugins/feature/aprs/aprsworker.h
+++ b/plugins/feature/aprs/aprsworker.h
@@ -20,7 +20,6 @@
 #define INCLUDE_FEATURE_APRSWORKER_H_
 
 #include <QObject>
-#include <QTimer>
 #include <QTcpSocket>
 
 #include "util/message.h"
@@ -87,6 +86,8 @@ private:
     void send(const char *data, int length);
 
 private slots:
+    void started();
+    void finished();
     void handleInputMessages();
     void connected();
     void disconnected();

--- a/plugins/feature/demodanalyzer/demodanalyzer.cpp
+++ b/plugins/feature/demodanalyzer/demodanalyzer.cpp
@@ -55,6 +55,7 @@ DemodAnalyzer::DemodAnalyzer(WebAPIAdapterInterface *webAPIAdapterInterface) :
     qDebug("DemodAnalyzer::DemodAnalyzer: webAPIAdapterInterface: %p", webAPIAdapterInterface);
     setObjectName(m_featureId);
     m_worker = new DemodAnalyzerWorker();
+    m_worker->moveToThread(&m_thread);
     m_worker->setScopeVis(&m_scopeVis);
     m_state = StIdle;
     m_errorMessage = "DemodAnalyzer error";

--- a/plugins/feature/gs232controller/gs232controller.cpp
+++ b/plugins/feature/gs232controller/gs232controller.cpp
@@ -52,6 +52,7 @@ GS232Controller::GS232Controller(WebAPIAdapterInterface *webAPIAdapterInterface)
     qDebug("GS232Controller::GS232Controller: webAPIAdapterInterface: %p", webAPIAdapterInterface);
     setObjectName(m_featureId);
     m_worker = new GS232ControllerWorker();
+    m_worker->moveToThread(&m_thread);
     m_state = StIdle;
     m_errorMessage = "GS232Controller error";
     m_selectedPipe = nullptr;

--- a/plugins/feature/gs232controller/gs232controllerworker.cpp
+++ b/plugins/feature/gs232controller/gs232controllerworker.cpp
@@ -20,7 +20,6 @@
 #include <cmath>
 
 #include <QDebug>
-#include <QTimer>
 #include <QSerialPort>
 #include <QRegularExpression>
 
@@ -36,6 +35,9 @@ GS232ControllerWorker::GS232ControllerWorker() :
     m_running(false),
     m_mutex(QMutex::Recursive),
     m_device(nullptr),
+    m_serialPort(this),
+    m_socket(this),
+    m_pollTimer(this),
     m_lastAzimuth(-1.0f),
     m_lastElevation(-1.0f),
     m_spidSetOutstanding(false),

--- a/plugins/feature/pertester/pertester.cpp
+++ b/plugins/feature/pertester/pertester.cpp
@@ -52,6 +52,7 @@ PERTester::PERTester(WebAPIAdapterInterface *webAPIAdapterInterface) :
     qDebug("PERTester::PERTester: webAPIAdapterInterface: %p", webAPIAdapterInterface);
     setObjectName(m_featureId);
     m_worker = new PERTesterWorker();
+    m_worker->moveToThread(&m_thread);
     m_state = StIdle;
     m_errorMessage = "PERTester error";
     m_networkManager = new QNetworkAccessManager();
@@ -130,7 +131,9 @@ bool PERTester::handleMessage(const Message& cmd)
     {
         MsgReportWorker& report = (MsgReportWorker&) cmd;
         if (report.getMessage() == "Complete")
-            m_state = StIdle;
+        {
+            stop();
+        }
         else
         {
             m_state = StError;

--- a/plugins/feature/pertester/pertesterworker.h
+++ b/plugins/feature/pertester/pertesterworker.h
@@ -89,6 +89,8 @@ private:
     void resetStats();
 
 private slots:
+    void started();
+    void finished();
     void handleInputMessages();
     void rx();
     void tx();

--- a/plugins/feature/rigctlserver/rigctlserver.cpp
+++ b/plugins/feature/rigctlserver/rigctlserver.cpp
@@ -43,6 +43,7 @@ RigCtlServer::RigCtlServer(WebAPIAdapterInterface *webAPIAdapterInterface) :
     qDebug("RigCtlServer::RigCtlServer: webAPIAdapterInterface: %p", webAPIAdapterInterface);
     setObjectName(m_featureId);
     m_worker = new RigCtlServerWorker(webAPIAdapterInterface);
+    m_worker->moveToThread(&m_thread);
     m_state = StIdle;
     m_errorMessage = "RigCtlServer error";
     m_networkManager = new QNetworkAccessManager();

--- a/plugins/feature/rigctlserver/rigctlserverworker.h
+++ b/plugins/feature/rigctlserver/rigctlserverworker.h
@@ -20,7 +20,6 @@
 #define INCLUDE_FEATURE_RIGCTLSERVERWORKER_H_
 
 #include <QObject>
-#include <QTimer>
 
 #include "util/message.h"
 #include "util/messagequeue.h"

--- a/plugins/feature/satellitetracker/satellitetracker.cpp
+++ b/plugins/feature/satellitetracker/satellitetracker.cpp
@@ -51,6 +51,7 @@ SatelliteTracker::SatelliteTracker(WebAPIAdapterInterface *webAPIAdapterInterfac
     qDebug("SatelliteTracker::SatelliteTracker: webAPIAdapterInterface: %p", webAPIAdapterInterface);
     setObjectName(m_featureId);
     m_worker = new SatelliteTrackerWorker(this, webAPIAdapterInterface);
+    m_worker->moveToThread(&m_thread);
     m_state = StIdle;
     m_errorMessage = "SatelliteTracker error";
     m_networkManager = new QNetworkAccessManager();

--- a/plugins/feature/satellitetracker/satellitetrackerworker.h
+++ b/plugins/feature/satellitetracker/satellitetrackerworker.h
@@ -130,6 +130,8 @@ private:
     void calculateRotation(SatWorkerState *satWorkerState);
 
 private slots:
+    void started();
+    void finished();
     void handleInputMessages();
     void update();
     void aos(SatWorkerState *satWorkerState);

--- a/plugins/feature/simpleptt/simpleptt.cpp
+++ b/plugins/feature/simpleptt/simpleptt.cpp
@@ -44,6 +44,7 @@ SimplePTT::SimplePTT(WebAPIAdapterInterface *webAPIAdapterInterface) :
 {
     setObjectName(m_featureId);
     m_worker = new SimplePTTWorker(webAPIAdapterInterface);
+    m_worker->moveToThread(&m_thread);
     m_state = StIdle;
     m_errorMessage = "SimplePTT error";
     m_networkManager = new QNetworkAccessManager();

--- a/plugins/feature/simpleptt/simplepttworker.cpp
+++ b/plugins/feature/simpleptt/simplepttworker.cpp
@@ -34,6 +34,7 @@ SimplePTTWorker::SimplePTTWorker(WebAPIAdapterInterface *webAPIAdapterInterface)
     m_msgQueueToGUI(nullptr),
     m_running(false),
     m_tx(false),
+    m_updateTimer(this),
     m_mutex(QMutex::Recursive)
 {
     qDebug("SimplePTTWorker::SimplePTTWorker");

--- a/plugins/feature/startracker/startracker.cpp
+++ b/plugins/feature/startracker/startracker.cpp
@@ -49,6 +49,7 @@ StarTracker::StarTracker(WebAPIAdapterInterface *webAPIAdapterInterface) :
     qDebug("StarTracker::StarTracker: webAPIAdapterInterface: %p", webAPIAdapterInterface);
     setObjectName(m_featureId);
     m_worker = new StarTrackerWorker(this, webAPIAdapterInterface);
+    m_worker->moveToThread(&m_thread);
     m_state = StIdle;
     m_errorMessage = "StarTracker error";
     connect(&m_updatePipesTimer, SIGNAL(timeout()), this, SLOT(updatePipes()));

--- a/plugins/feature/startracker/startrackerworker.h
+++ b/plugins/feature/startracker/startrackerworker.h
@@ -97,6 +97,8 @@ private:
     void sendToMap(QList<MessageQueue*> *mapMessageQueues, QString id, QString image, QString text, double lat, double lon, double rotation=0.0);
 
 private slots:
+    void started();
+    void finished();
     void handleInputMessages();
     void update();
     void acceptConnection();

--- a/plugins/feature/vorlocalizer/vorlocalizer.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizer.cpp
@@ -51,6 +51,7 @@ VORLocalizer::VORLocalizer(WebAPIAdapterInterface *webAPIAdapterInterface) :
 {
     setObjectName(m_featureId);
     m_worker = new VorLocalizerWorker(webAPIAdapterInterface);
+    m_worker->moveToThread(&m_thread);
     m_state = StIdle;
     m_errorMessage = "VORLocalizer error";
     m_networkManager = new QNetworkAccessManager();

--- a/plugins/feature/vorlocalizer/vorlocalizerworker.h
+++ b/plugins/feature/vorlocalizer/vorlocalizerworker.h
@@ -167,6 +167,8 @@ private:
     static void getChannelsByDevice(const QHash<ChannelAPI*, VORLocalizerSettings::AvailableChannel> *availableChannels, std::vector<RRTurnPlan>& m_deviceChannels);
 
 private slots:
+    void started();
+    void finished();
     void handleInputMessages();
 	void updateHardware();
     void rrNextTurn();


### PR DESCRIPTION
I noticed a small bug in the first Feature that has been cut and paste to all of the others. A thread is created for the worker, but moveToThread was never called, so the worker remains on the main thread.

Aside from calling moveToThread, a few other changes needed to be made for QTimers and sockets in the workers, so they are on the correct thread:

- For those timers/sockets that are members of the worker, they needed to have their parent object set, so that they are moved to the correct thread when moveToThread is called.
- Starting of timers/opening sockets needs to occur on the worker thread rather than the main thread. So this code has been moved from startWork() / stopWork() in to the QThread::started() and QThread::finished slots.

I don't use the AFC / PTT features, so it would be good if you could check they work OK.
