### PR TITLE
Fix #1062 - Use C locale when parsing airport/navaid files

### DIFF
--- a/plugins/channelrx/demodadsb/ourairportsdb.h
+++ b/plugins/channelrx/demodadsb/ourairportsdb.h
@@ -24,6 +24,7 @@
 #include <QHash>
 #include <QList>
 #include <QDebug>
+#include <QLocale>
 
 #include <stdio.h>
 #include <string.h>
@@ -84,6 +85,7 @@ struct AirportInformation {
 
         FILE *file;
         QByteArray utfFilename = filename.toUtf8();
+        QLocale cLocale(QLocale::C);
         if ((file = fopen(utfFilename.constData(), "r")) != NULL)
         {
             char row[2048];
@@ -170,21 +172,21 @@ struct AirportInformation {
                             latitudeString = p;
                             latitudeLen = strlen(latitudeString)-1;
                             latitudeString[latitudeLen] = '\0';
-                            latitude = atof(latitudeString);
+                            latitude = cLocale.toFloat(latitudeString);
                         }
                         else if (idx == longitudeCol)
                         {
                             longitudeString = p;
                             longitudeLen = strlen(longitudeString)-1;
                             longitudeString[longitudeLen] = '\0';
-                            longitude = atof(longitudeString);
+                            longitude = cLocale.toFloat(longitudeString);
                         }
                         else if (idx == elevationCol)
                         {
                             elevationString = p;
                             elevationLen = strlen(elevationString)-1;
                             elevationString[elevationLen] = '\0';
-                            elevation = atof(elevationString);
+                            elevation = cLocale.toFloat(elevationString);
                         }
                         p = strtok(NULL, ",");
                         idx++;

--- a/plugins/channelrx/demodvor/navaid.h
+++ b/plugins/channelrx/demodvor/navaid.h
@@ -198,6 +198,7 @@ struct NavAid {
 
         FILE *file;
         QByteArray utfFilename = filename.toUtf8();
+        QLocale cLocale(QLocale::C);
         if ((file = fopen(utfFilename.constData(), "r")) != NULL)
         {
             char row[2048];
@@ -298,21 +299,21 @@ struct NavAid {
                             latitudeString = p;
                             latitudeLen = strlen(latitudeString)-1;
                             latitudeString[latitudeLen] = '\0';
-                            latitude = atof(latitudeString);
+                            latitude = cLocale.toFloat(latitudeString);
                         }
                         else if (idx == longitudeCol)
                         {
                             longitudeString = p;
                             longitudeLen = strlen(longitudeString)-1;
                             longitudeString[longitudeLen] = '\0';
-                            longitude = atof(longitudeString);
+                            longitude = cLocale.toFloat(longitudeString);
                         }
                         else if (idx == elevationCol)
                         {
                             elevationString = p;
                             elevationLen = strlen(elevationString)-1;
                             elevationString[elevationLen] = '\0';
-                            elevation = atof(elevationString);
+                            elevation = cLocale.toFloat(elevationString);
                         }
                         else if ((idx == powerCol) && (p[0] == '\"'))
                         {

--- a/plugins/channelrx/demodvor/vordemodgui.ui
+++ b/plugins/channelrx/demodvor/vordemodgui.ui
@@ -392,9 +392,9 @@
    <property name="geometry">
     <rect>
      <x>0</x>
-     <y>110</y>
+     <y>80</y>
      <width>391</width>
-     <height>140</height>
+     <height>141</height>
     </rect>
    </property>
    <property name="sizePolicy">
@@ -424,6 +424,12 @@
     </property>
     <item>
      <widget class="QTableWidget" name="vorData">
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>140</height>
+       </size>
+      </property>
       <property name="editTriggers">
        <set>QAbstractItemView::NoEditTriggers</set>
       </property>

--- a/plugins/feature/vorlocalizer/navaid.h
+++ b/plugins/feature/vorlocalizer/navaid.h
@@ -197,6 +197,7 @@ struct NavAid {
 
         FILE *file;
         QByteArray utfFilename = filename.toUtf8();
+        QLocale cLocale(QLocale::C);
         if ((file = fopen(utfFilename.constData(), "r")) != NULL)
         {
             char row[2048];
@@ -297,21 +298,21 @@ struct NavAid {
                             latitudeString = p;
                             latitudeLen = strlen(latitudeString)-1;
                             latitudeString[latitudeLen] = '\0';
-                            latitude = atof(latitudeString);
+                            latitude = cLocale.toFloat(latitudeString);
                         }
                         else if (idx == longitudeCol)
                         {
                             longitudeString = p;
                             longitudeLen = strlen(longitudeString)-1;
                             longitudeString[longitudeLen] = '\0';
-                            longitude = atof(longitudeString);
+                            longitude = cLocale.toFloat(longitudeString);
                         }
                         else if (idx == elevationCol)
                         {
                             elevationString = p;
                             elevationLen = strlen(elevationString)-1;
                             elevationString[elevationLen] = '\0';
-                            elevation = atof(elevationString);
+                            elevation = cLocale.toFloat(elevationString);
                         }
                         else if ((idx == powerCol) && (p[0] == '\"'))
                         {


### PR DESCRIPTION
Fixes #1062 and #732

Airport locations in ADS-B plugin were at wrong locations for users with locales where decimal point is , rather than . This should fix that, by using C locale when parsing the .csv files.

Also, updates VOR demod GUI so more than one row is visible.
