### PR TITLE
Rotator controller - Don't round az/el received from Sat Tracker

### DIFF
--- a/plugins/feature/gs232controller/gs232controllergui.cpp
+++ b/plugins/feature/gs232controller/gs232controllergui.cpp
@@ -102,8 +102,8 @@ bool GS232ControllerGUI::handleMessage(const Message& message)
         MainCore::MsgTargetAzimuthElevation& msg = (MainCore::MsgTargetAzimuthElevation&) message;
         SWGSDRangel::SWGTargetAzimuthElevation *swgTarget = msg.getSWGTargetAzimuthElevation();
 
-        ui->azimuth->setValue(round(swgTarget->getAzimuth()));
-        ui->elevation->setValue(round(swgTarget->getElevation()));
+        ui->azimuth->setValue(swgTarget->getAzimuth());
+        ui->elevation->setValue(swgTarget->getElevation());
         ui->targetName->setText(*swgTarget->getName());
         return true;
     }


### PR DESCRIPTION
Don't round az/el received from Sat Tracker we now support higher precision rotators.

Fixes issue reported on mailing list.