### PR TITLE
Display warnings in ADS-B and DAB if sample rate is too low

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemod.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemod.cpp
@@ -150,6 +150,10 @@ bool ADSBDemod::handleMessage(const Message& cmd)
         DSPSignalNotification* rep = new DSPSignalNotification(notif); // make a copy
         qDebug() << "ADSBDemod::handleMessage: DSPSignalNotification";
         m_basebandSink->getInputMessageQueue()->push(rep);
+        // Forward to GUI if any
+        if (m_guiMessageQueue) {
+            m_guiMessageQueue->push(new DSPSignalNotification(notif));
+        }
 
         return true;
     }

--- a/plugins/channelrx/demodadsb/adsbdemodgui.ui
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.ui
@@ -744,6 +744,13 @@
       </item>
      </layout>
     </item>
+    <item>
+     <widget class="QLabel" name="warning">
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QWidget" name="dataContainer" native="true">
@@ -1277,11 +1284,6 @@
    <header>gui/buttonswitch.h</header>
   </customwidget>
   <customwidget>
-   <class>ClickableLabel</class>
-   <extends>QLabel</extends>
-   <header>gui/clickablelabel.h</header>
-  </customwidget>
-  <customwidget>
    <class>ValueDialZ</class>
    <extends>QWidget</extends>
    <header>gui/valuedialz.h</header>
@@ -1292,6 +1294,11 @@
    <extends>QWidget</extends>
    <header>gui/levelmeter.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ClickableLabel</class>
+   <extends>QLabel</extends>
+   <header>gui/clickablelabel.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/plugins/channelrx/demoddab/dabdemodgui.cpp
+++ b/plugins/channelrx/demoddab/dabdemodgui.cpp
@@ -35,7 +35,6 @@
 #include "gui/audioselectdialog.h"
 #include "gui/basicchannelsettingsdialog.h"
 #include "gui/devicestreamselectiondialog.h"
-#include "dsp/dspengine.h"
 #include "gui/crightclickenabler.h"
 #include "channel/channelwebapiutils.h"
 #include "maincore.h"
@@ -202,6 +201,14 @@ bool DABDemodGUI::handleMessage(const Message& message)
     {
         DSPSignalNotification& notif = (DSPSignalNotification&) message;
         m_basebandSampleRate = notif.getSampleRate();
+        bool srTooLow = m_basebandSampleRate < 2048000;
+        ui->warning->setVisible(srTooLow);
+        if (srTooLow) {
+            ui->warning->setText("Sample rate must be >= 2048000");
+        } else {
+            ui->warning->setText("");
+        }
+        arrangeRollups();
         return true;
     }
     else if (DABDemod::MsgDABEnsembleName::match(message))
@@ -449,6 +456,9 @@ DABDemodGUI::DABDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     connect(audioMuteRightClickEnabler, SIGNAL(rightClick(const QPoint &)), this, SLOT(audioSelect()));
 
     connect(&MainCore::instance()->getMasterTimer(), SIGNAL(timeout()), this, SLOT(tick())); // 50 ms
+
+    ui->warning->setVisible(false);
+    ui->warning->setStyleSheet("QLabel { background-color: red; }");
 
     ui->deltaFrequencyLabel->setText(QString("%1f").arg(QChar(0x94, 0x03)));
     ui->deltaFrequency->setColorMapper(ColorMapper(ColorMapper::GrayGold));

--- a/plugins/channelrx/demoddab/dabdemodgui.ui
+++ b/plugins/channelrx/demoddab/dabdemodgui.ui
@@ -43,7 +43,7 @@
      <x>0</x>
      <y>0</y>
      <width>390</width>
-     <height>131</height>
+     <height>151</height>
     </rect>
    </property>
    <property name="minimumSize">
@@ -610,13 +610,20 @@
       </item>
      </layout>
     </item>
+    <item>
+     <widget class="QLabel" name="warning">
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QWidget" name="programContainer" native="true">
    <property name="geometry">
     <rect>
      <x>0</x>
-     <y>140</y>
+     <y>160</y>
      <width>381</width>
      <height>211</height>
     </rect>


### PR DESCRIPTION
As we've had several bug reports about them not working.

![image](https://user-images.githubusercontent.com/57259258/145780008-671bd0a3-e5d9-4dde-a42c-cd9a931d98e0.png)
