### PR TITLE
Display OpenGL version in status bar. 

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -40,6 +40,7 @@ static int runQtApplication(int argc, char* argv[], qtwebapp::LoggerWithFile *lo
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
 	QApplication::setAttribute(Qt::AA_EnableHighDpiScaling); // DPI support
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps); //HiDPI pixmaps
+    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts); // Needed for WebGL in QWebEngineView and MainWindow::openGLVersion
 #endif
 
 	QApplication a(argc, argv);

--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -865,14 +865,43 @@ void MainWindow::saveCommandSettings()
 {
 }
 
+QString MainWindow::openGLVersion()
+{
+    QOpenGLContext *glCurrentContext = QOpenGLContext::globalShareContext();
+    if (glCurrentContext)
+    {
+        if (glCurrentContext->isValid())
+        {
+            int major = glCurrentContext->format().majorVersion();
+            int minor = glCurrentContext->format().minorVersion();
+            bool es = glCurrentContext->isOpenGLES();
+            QString version = QString("%1.%2%3").arg(major).arg(minor).arg(es ? " ES" : "");
+            // Waterfall doesn't work if major version is less than 3, so display in red
+            if (major < 3) {
+                version = "<span style=\"color:red\">" + version + "</span>";
+            }
+            return version;
+        }
+        else
+        {
+            return "N/A";
+        }
+    }
+    else
+    {
+        return "N/A";
+    }
+}
+
 void MainWindow::createStatusBar()
 {
     QString qtVersionStr = QString("Qt %1 ").arg(QT_VERSION_STR);
+    QString openGLVersionStr = QString("OpenGL %1 ").arg(openGLVersion());
 #if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
-    m_showSystemWidget = new QLabel("SDRangel " + qApp->applicationVersion() + " " + qtVersionStr
+    m_showSystemWidget = new QLabel("SDRangel " + qApp->applicationVersion() + " " + qtVersionStr + openGLVersionStr
             + QSysInfo::currentCpuArchitecture() + " " + QSysInfo::prettyProductName(), this);
 #else
-    m_showSystemWidget = new QLabel("SDRangel " + qApp->applicationVersion() + " " + qtVersionStr, this);
+    m_showSystemWidget = new QLabel("SDRangel " + qApp->applicationVersion() + " " + qtVersionStr + openGLVersionStr, this);
 #endif
     statusBar()->addPermanentWidget(m_showSystemWidget);
 

--- a/sdrgui/mainwindow.h
+++ b/sdrgui/mainwindow.h
@@ -129,6 +129,7 @@ private:
 	void saveFeatureSetPresetSettings(FeatureSetPreset* preset, int featureSetIndex);
 	void saveCommandSettings();
 
+	QString openGLVersion();
 	void createStatusBar();
 	void closeEvent(QCloseEvent*);
 	void updatePresetControls();


### PR DESCRIPTION
This patch displays the OpenGL version in the status bar, alongside the other version information. I've added this as we've had a couple of bug reports where this information seems relevant.

It is displayed in red if less than version 3, as the waterfall is unlikely to work.

![image](https://user-images.githubusercontent.com/57259258/145797143-c4f59b6f-379c-4a56-9733-9a8ea55086c2.png)
