### PR TITLE
Fix for #1087. Support compilation with Boost >= 1.77

### DIFF
--- a/plugins/channelrx/noisefigure/noisefigure.cpp
+++ b/plugins/channelrx/noisefigure/noisefigure.cpp
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.          //
 ///////////////////////////////////////////////////////////////////////////////////
 
+#include <boost/version.hpp>
 #include <boost/math/interpolators/barycentric_rational.hpp>
 
 #include "noisefigure.h"
@@ -40,6 +41,12 @@
 #include "util/interpolation.h"
 #include "channel/channelwebapiutils.h"
 #include "maincore.h"
+
+#if BOOST_VERSION < 107700
+using namespace boost::math;
+#else
+using namespace boost::math::interpolators;
+#endif
 
 MESSAGE_CLASS_DEFINITION(NoiseFigure::MsgConfigureNoiseFigure, Message)
 MESSAGE_CLASS_DEFINITION(NoiseFigure::MsgPowerMeasurement, Message)
@@ -180,7 +187,7 @@ double NoiseFigure::calcENR(double frequency)
         else
         {
             int order = size - 1;
-            boost::math::barycentric_rational<double> interpolant(std::move(x), std::move(y), order);
+            barycentric_rational<double> interpolant(std::move(x), std::move(y), order);
             enr = interpolant(frequency);
         }
     }

--- a/plugins/channelrx/noisefigure/noisefigureenrdialog.cpp
+++ b/plugins/channelrx/noisefigure/noisefigureenrdialog.cpp
@@ -17,10 +17,19 @@
 
 #include <QDebug>
 
+#include <array>
+
+#include <boost/version.hpp>
 #include <boost/math/interpolators/barycentric_rational.hpp>
 
 #include "noisefigureenrdialog.h"
 #include "util/interpolation.h"
+
+#if BOOST_VERSION < 107700
+using namespace boost::math;
+#else
+using namespace boost::math::interpolators;
+#endif
 
 NoiseFigureENRDialog::NoiseFigureENRDialog(NoiseFigureSettings *settings, QWidget* parent) :
     QDialog(parent),
@@ -153,7 +162,7 @@ void NoiseFigureENRDialog::plotChart()
             y[i] = points[i][1];
         }
         int order = size - 1;
-        boost::math::barycentric_rational<double> interpolant(std::move(x), std::move(y), order);
+        barycentric_rational<double> interpolant(std::move(x), std::move(y), order);
 
         x.resize(size);
         y.resize(size);


### PR DESCRIPTION
Fix for #1087. Support compilation with Boost >= 1.77 while maintaining compatibility with 1.70.