### PR TITLE
DATV Demod - Make AVCodecs const

### DIFF
--- a/plugins/channelrx/demoddatv/datvideorender.cpp
+++ b/plugins/channelrx/demoddatv/datvideorender.cpp
@@ -160,8 +160,8 @@ void DATVideoRender::resetMetaData()
 bool DATVideoRender::preprocessStream()
 {
     AVDictionary *opts = nullptr;
-    AVCodec *videoCodec = nullptr;
-    AVCodec *audioCodec = nullptr;
+    const AVCodec *videoCodec = nullptr;
+    const AVCodec *audioCodec = nullptr;
 
     int intRet = -1;
     char *buffer = nullptr;


### PR DESCRIPTION
As a guess at fixing the compilation issue reported on the mailing list, make AVCodecs const. Looks like the FFMpeg API has been updated.
