### PR TITLE
Spectrum Marker GUI small tweaks

### DIFF
--- a/sdrgui/gui/glspectrumgui.ui
+++ b/sdrgui/gui/glspectrumgui.ui
@@ -564,7 +564,7 @@
         </iconset>
        </property>
        <property name="checkable">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
       </widget>
      </item>

--- a/sdrgui/gui/spectrummarkersdialog.cpp
+++ b/sdrgui/gui/spectrummarkersdialog.cpp
@@ -110,6 +110,8 @@ void SpectrumMarkersDialog::displayHistogramMarker()
         ui->markerColor->setStyleSheet(tr("QLabel { background-color : rgb(%1,%2,%3); }").arg(r).arg(g).arg(b));
         ui->showMarker->setChecked(m_histogramMarkers[m_histogramMarkerIndex].m_show);
     }
+    ui->fixedPower->setVisible(m_histogramMarkers[m_histogramMarkerIndex].m_markerType == SpectrumHistogramMarker::SpectrumMarkerTypeManual);
+    ui->fixedPowerUnits->setVisible(m_histogramMarkers[m_histogramMarkerIndex].m_markerType == SpectrumHistogramMarker::SpectrumMarkerTypeManual);
 
     ui->markerFrequency->blockSignals(false);
     ui->centerFrequency->blockSignals(false);
@@ -379,6 +381,9 @@ void SpectrumMarkersDialog::on_powerMode_currentIndexChanged(int index)
     }
 
     SpectrumHistogramMarker::SpectrumMarkerType newType = (SpectrumHistogramMarker::SpectrumMarkerType) index;
+
+    ui->fixedPower->setVisible(newType == SpectrumHistogramMarker::SpectrumMarkerTypeManual);
+    ui->fixedPowerUnits->setVisible(newType == SpectrumHistogramMarker::SpectrumMarkerTypeManual);
 
     if ((m_histogramMarkers[m_histogramMarkerIndex].m_markerType != newType)
        && (newType == SpectrumHistogramMarker::SpectrumMarkerTypePowerMax))

--- a/sdrgui/gui/spectrummarkersdialog.ui
+++ b/sdrgui/gui/spectrummarkersdialog.ui
@@ -35,6 +35,9 @@
       <attribute name="title">
        <string>Hist</string>
       </attribute>
+      <attribute name="toolTip">
+       <string>Histogram (spectrum line) markers</string>
+      </attribute>
       <widget class="QWidget" name="layoutWidget">
        <property name="geometry">
         <rect>
@@ -413,6 +416,11 @@
               <height>16777215</height>
              </size>
             </property>
+            <property name="toolTip">
+             <string>Man - Set marker power to fixed level
+Cur - Marker will move according to current power at the marker frequency
+Max - Marker will move according to the maximum power at the marker frequency</string>
+            </property>
             <item>
              <property name="text">
               <string>Man</string>
@@ -498,6 +506,9 @@
      <widget class="QWidget" name="watTab">
       <attribute name="title">
        <string>Wat</string>
+      </attribute>
+      <attribute name="toolTip">
+       <string>Waterfall markers</string>
       </attribute>
       <widget class="QWidget" name="layoutWidget">
        <property name="geometry">
@@ -1014,6 +1025,9 @@
      <widget class="QWidget" name="anoTab">
       <attribute name="title">
        <string>Anno</string>
+      </attribute>
+      <attribute name="toolTip">
+       <string>Annotation markers</string>
       </attribute>
       <widget class="QWidget" name="layoutWidget_2">
        <property name="geometry">
@@ -1712,7 +1726,11 @@
      <item>
       <widget class="QComboBox" name="showSelect">
        <property name="toolTip">
-        <string>Select which set of markers to show</string>
+        <string>Select which set of markers to show
+
+None - Hide all markers
+Spec - Show histogram and waterfall markers
+Anno - Show annotation markers</string>
        </property>
        <item>
         <property name="text">


### PR DESCRIPTION
Here are a few small changes to the Spectrum Marker GUI.

I've removed the checkable flag from the Open Spectrum Markers Dialog button.
I've added some additional tooltips to the Spectrum Markers Dialog, to explain some of the abbreviations.
I've hidden the fixed power level widget when the combo box is set to Cur or Max, as this setting isn't relevant for those options. I don't know if you prefer setting controls as disabled rather than hiding them, but some widgets do not appear different visually when disabled, so I thought I'd hide it instead.
