### PR TITLE
DATV Demod increase RF bandwidth to 50MHz

### DIFF
--- a/plugins/channelrx/demoddatv/datvdemodgui.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodgui.cpp
@@ -248,7 +248,7 @@ DATVDemodGUI::DATVDemodGUI(PluginAPI* objPluginAPI, DeviceUISet *deviceUISet, Ba
     ui->deltaFrequency->setValueRange(false, 8, -99999999, 99999999);
 
     ui->rfBandwidth->setColorMapper(ColorMapper(ColorMapper::GrayYellow));
-    ui->rfBandwidth->setValueRange(true, 7, 0, 9999999);
+    ui->rfBandwidth->setValueRange(true, 8, 0, 50000000);
 
     m_objChannelMarker.blockSignals(true);
     m_objChannelMarker.setColor(Qt::magenta);

--- a/plugins/channeltx/moddatv/datvmodgui.ui
+++ b/plugins/channeltx/moddatv/datvmodgui.ui
@@ -24,6 +24,7 @@
   </property>
   <property name="font">
    <font>
+    <family>Liberation Sans</family>
     <pointsize>9</pointsize>
    </font>
   </property>
@@ -97,6 +98,7 @@
           </property>
           <property name="font">
            <font>
+            <family>Liberation Mono</family>
             <pointsize>12</pointsize>
            </font>
           </property>


### PR DESCRIPTION
For #1136, increase DATV Demod bandwidth max to 50MHz.
