### PR TITLE
Map/ADS-B: Update station icon on map when My Position preference changes

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemodgui.h
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.h
@@ -942,6 +942,7 @@ private slots:
     virtual bool eventFilter(QObject *obj, QEvent *event);
     void import();
     void handleImportReply(QNetworkReply* reply);
+    void preferenceChanged(int elementType);
 
 signals:
     void homePositionChanged();

--- a/plugins/channelrx/demodadsb/readme.md
+++ b/plugins/channelrx/demodadsb/readme.md
@@ -275,7 +275,7 @@ The map displays aircraft locations and data geographically. Four types of map c
 
 ![ADS-B Demodulator Map](../../../doc/img/ADSBDemod_plugin_map2.png)
 
-The initial antenna location is placed according to My Position set under the Preferences > My Position menu. The position is only updated when the ADS-B demodulator plugin is first opened.
+The antenna location is placed according to My Position set under the Preferences > My Position menu.
 If My Position is not set correctly, the position of aircraft may not be computed correctly.
 
 Aircraft are only placed upon the map when a position can be calculated, which can require several frames to be received.

--- a/plugins/feature/map/mapgui.cpp
+++ b/plugins/feature/map/mapgui.cpp
@@ -232,7 +232,6 @@ MapGUI::MapGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *featur
     }
 
     // Create antenna at My Position
-    //m_antennaMapItem.setName(new QString(MainCore::instance()->getSettings().getStationName()));
     m_antennaMapItem.setName(new QString("Station"));
     m_antennaMapItem.setLatitude(stationLatitude);
     m_antennaMapItem.setLongitude(stationLongitude);

--- a/plugins/feature/map/mapgui.h
+++ b/plugins/feature/map/mapgui.h
@@ -103,6 +103,7 @@ private:
     MessageQueue m_inputMessageQueue;
     MapModel m_mapModel;
     AzEl m_azEl;                        // Position of station
+    SWGSDRangel::SWGMapItem m_antennaMapItem;
     QList<Beacon *> *m_beacons;
     MapBeaconDialog m_beaconDialog;
     MapIBPBeaconDialog m_ibpBeaconDialog;
@@ -158,6 +159,7 @@ private slots:
     virtual void showEvent(QShowEvent *event);
     virtual bool eventFilter(QObject *obj, QEvent *event);
     void fullScreenRequested(QWebEngineFullScreenRequest fullScreenRequest);
+    void preferenceChanged(int elementType);
 
 };
 

--- a/plugins/feature/map/mapmodel.cpp
+++ b/plugins/feature/map/mapmodel.cpp
@@ -231,7 +231,7 @@ void MapModel::update(const PipeEndPoint *sourcePipe, SWGSDRangel::SWGMapItem *s
             remove(item);
             // Need to call update, for it to be removed in 3D map
             // Item is set to not be available from this point in time
-            // It will still be avialable if time is set in the past
+            // It will still be available if time is set in the past
             item->update(swgMapItem);
         }
         else
@@ -508,11 +508,12 @@ QVariant MapModel::data(const QModelIndex &index, int role) const
     else if (role == MapModel::mapTextRole)
     {
         // Create the text to go in the bubble next to the image
+        QString name = m_items[row]->m_label.isEmpty() ? m_items[row]->m_name : m_items[row]->m_label;
         if (row == m_target)
         {
             AzEl *azEl = m_gui->getAzEl();
             QString text = QString("%1<br>Az: %2%5 El: %3%5 Dist: %4 km")
-                                .arg(m_selected[row] ? m_items[row]->m_text : m_items[row]->m_name)
+                                .arg(m_selected[row] ? m_items[row]->m_text : name)
                                 .arg(std::round(azEl->getAzimuth()))
                                 .arg(std::round(azEl->getElevation()))
                                 .arg(std::round(azEl->getDistance() / 1000.0))
@@ -525,7 +526,7 @@ QVariant MapModel::data(const QModelIndex &index, int role) const
         }
         else
         {
-            return QVariant::fromValue(m_items[row]->m_name);
+            return QVariant::fromValue(name);
         }
     }
     else if (role == MapModel::mapTextVisibleRole)

--- a/plugins/feature/map/mapsettings.cpp
+++ b/plugins/feature/map/mapsettings.cpp
@@ -69,7 +69,9 @@ MapSettings::MapSettings() :
     m_itemSettings.insert("RadioSonde", new MapItemSettings("RadioSonde", QColor(102, 0, 102), false, 11, modelMinPixelSize));
     m_itemSettings.insert("Radio Time Transmitters", new MapItemSettings("Radio Time Transmitters", QColor(255, 0, 0), true, 8));
     m_itemSettings.insert("Radar", new MapItemSettings("Radar", QColor(255, 0, 0), true, 8));
-    m_itemSettings.insert("Station", new MapItemSettings("Station", QColor(255, 0, 0), true, 11));
+    MapItemSettings *stationItemSettings = new MapItemSettings("Station", QColor(255, 0, 0), true, 11);
+    stationItemSettings->m_display2DTrack = false;
+    m_itemSettings.insert("Station", stationItemSettings);
     resetToDefaults();
 }
 

--- a/plugins/feature/map/readme.md
+++ b/plugins/feature/map/readme.md
@@ -141,7 +141,7 @@ These are not included with the SDRangel distribution, so must be downloaded.
 
 The map feature displays a 2D and a 3D map overlaid with objects reported by other SDRangel channels and features, as well as beacon locations.
 
-* The "Home Station" antenna location is placed according to My Position set under the Preferences > My Position menu. The position is only updated when the Map plugin is first opened.
+* The "Home Station" antenna location is placed according to My Position set under the Preferences > My Position menu.
 * To pan around the map, click the left mouse button and drag. To zoom in or out, use the mouse scroll wheel.
 * Single clicking on an object in the map will display a text bubble with additional information about the object.
 * Right clicking on a object on the 2D map will open a context menu, which allows:


### PR DESCRIPTION
Update station icon on map when My Position preference changes using new signal from #1139 

Also, 2D map uses label rather than name, if available, to be consistent with 3D map.
