### PR TITLE
ADS-B: Remove refresh button

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -4397,7 +4397,7 @@ void ADSBDemodGUI::showEvent(QShowEvent *event)
     {
         // Workaround for https://bugreports.qt.io/browse/QTBUG-100333
         // MapQuickItems can be in wrong position when window is first displayed
-        m_redrawMapTimer.start(500);        
+        m_redrawMapTimer.start(500);
     }
 }
 

--- a/plugins/channelrx/demodadsb/adsbdemodgui.h
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.h
@@ -827,6 +827,7 @@ private:
     QHash<QString, float> m_labelAltitudeOffset;
 
     QTimer m_importTimer;
+    QTimer m_redrawMapTimer;
     QNetworkAccessManager *m_networkManager;
 
     explicit ADSBDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSampleSink *rxChannel, QWidget* parent = 0);
@@ -926,7 +927,6 @@ private slots:
     void tick();
     void updateDownloadProgress(qint64 bytesRead, qint64 totalBytes);
     void downloadFinished(const QString& filename, bool success);
-    void on_devicesRefresh_clicked();
     void on_device_currentIndexChanged(int index);
     void feedSelect();
     void on_displaySettings_clicked();

--- a/plugins/channelrx/demodadsb/adsbdemodgui.ui
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.ui
@@ -729,20 +729,6 @@
        </spacer>
       </item>
       <item>
-       <widget class="QToolButton" name="devicesRefresh">
-        <property name="toolTip">
-         <string>Refresh device list</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../../../sdrgui/resources/res.qrc">
-          <normaloff>:/recycle.png</normaloff>:/recycle.png</iconset>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Device</string>
@@ -1334,7 +1320,6 @@
   <tabstop>logFilename</tabstop>
   <tabstop>logOpen</tabstop>
   <tabstop>findOnMapFeature</tabstop>
-  <tabstop>devicesRefresh</tabstop>
   <tabstop>device</tabstop>
   <tabstop>adsbData</tabstop>
   <tabstop>map</tabstop>

--- a/plugins/feature/map/mapgui.cpp
+++ b/plugins/feature/map/mapgui.cpp
@@ -285,7 +285,6 @@ MapGUI::~MapGUI()
         delete m_webServer;
     }
     delete ui;
-    ui = nullptr;
 }
 
 // Update a map item or image

--- a/plugins/feature/map/mapgui.cpp
+++ b/plugins/feature/map/mapgui.cpp
@@ -263,11 +263,15 @@ MapGUI::MapGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *featur
     displaySettings();
     applySettings(true);
 
+    connect(&m_redrawMapTimer, &QTimer::timeout, this, &MapGUI::redrawMap);
+    m_redrawMapTimer.setSingleShot(true);
     ui->map->installEventFilter(this);
 }
 
 MapGUI::~MapGUI()
 {
+    disconnect(&m_redrawMapTimer, &QTimer::timeout, this, &MapGUI::redrawMap);
+    m_redrawMapTimer.stop();
     //m_cesium->deleteLater();
     delete m_cesium;
     if (m_templateServer)
@@ -281,6 +285,7 @@ MapGUI::~MapGUI()
         delete m_webServer;
     }
     delete ui;
+    ui = nullptr;
 }
 
 // Update a map item or image
@@ -707,9 +712,7 @@ void MapGUI::showEvent(QShowEvent *event)
     {
         // Workaround for https://bugreports.qt.io/browse/QTBUG-100333
         // MapQuickItems can be in wrong position when window is first displayed
-        QTimer::singleShot(500, [this] {
-            redrawMap();
-        });
+        m_redrawMapTimer.start(500);
     }
 }
 

--- a/plugins/feature/map/mapgui.h
+++ b/plugins/feature/map/mapgui.h
@@ -110,6 +110,7 @@ private:
     MapRadioTimeDialog m_radioTimeDialog;
     quint16 m_osmPort;
     OSMTemplateServer *m_templateServer;
+    QTimer m_redrawMapTimer;
 
     CesiumInterface *m_cesium;
     WebServer *m_webServer;


### PR DESCRIPTION
Remove refresh button as now automatic.

Also fix potential crash when ADS-B or Map GUI is closed.