### PR TITLE
SDRPlayV3: Take LIF downsampling into account when calculating the final bandwidth

### DIFF
--- a/plugins/samplesource/sdrplayv3/sdrplayv3input.cpp
+++ b/plugins/samplesource/sdrplayv3/sdrplayv3input.cpp
@@ -228,8 +228,23 @@ const QString& SDRPlayV3Input::getDeviceDescription() const
 
 int SDRPlayV3Input::getSampleRate() const
 {
-    int rate = m_settings.m_devSampleRate;
-    return rate / (1 << m_settings.m_log2Decim);
+    uint32_t fsHz = m_settings.m_devSampleRate;
+    sdrplay_api_Bw_MHzT bwType = SDRPlayV3Bandwidths::getBandwidthEnum(m_settings.m_bandwidthIndex);
+    sdrplay_api_If_kHzT ifType = SDRPlayV3IF::getIFEnum(m_settings.m_ifFrequencyIndex);
+
+    if(
+        ((fsHz == 8192000) && (bwType == sdrplay_api_BW_1_536) && (ifType == sdrplay_api_IF_2_048)) ||
+        ((fsHz == 8000000) && (bwType == sdrplay_api_BW_1_536) && (ifType == sdrplay_api_IF_2_048)) ||
+        ((fsHz == 8000000) && (bwType == sdrplay_api_BW_5_000) && (ifType == sdrplay_api_IF_2_048)) ||
+        ((fsHz == 2000000) && (bwType <= sdrplay_api_BW_0_300) && (ifType == sdrplay_api_IF_0_450))) {
+        fsHz /= 4;
+    } else if ((fsHz == 2000000) && (bwType == sdrplay_api_BW_0_600) && (ifType == sdrplay_api_IF_0_450)) {
+        fsHz /= 2;
+    }else if ((fsHz == 6000000) && (bwType <= sdrplay_api_BW_1_536) && (ifType == sdrplay_api_IF_1_620)) {
+        fsHz /= 3;
+    }
+
+    return fsHz / (1 << m_settings.m_log2Decim);
 }
 
 quint64 SDRPlayV3Input::getCenterFrequency() const


### PR DESCRIPTION
According to the API documentation and conversation with SDRplay support, I've implemented what I believe is a proper calculation of final bandwidth in LIF mode. This is only a temporary solution as in my opinion SDRPlayV3 configuration should be organized differently, as current implementation allows to set device in the way it wont work. API docs, mentions only 10 possible configuration of sample ratio, IF bandwidth and IF mode. Quite probably there is at least one more unmentioned and used in SDRuno, but this is under discussion with support.

Closes  #1194

[SDRplay API Specification v3.09](https://www.sdrplay.com/docs/SDRplay_API_Specification_v3.09.pdf)

@srcejon fyi