### PR TITLE
Restore cursor when move from border to child widget

### DIFF
--- a/sdrgui/channel/channelgui.cpp
+++ b/sdrgui/channel/channelgui.cpp
@@ -184,6 +184,8 @@ ChannelGUI::ChannelGUI(QWidget *parent) :
         this,
         &ChannelGUI::onWidgetRolled
     );
+
+    m_resizer.enableChildMouseTracking();
 }
 
 ChannelGUI::~ChannelGUI()

--- a/sdrgui/device/devicegui.cpp
+++ b/sdrgui/device/devicegui.cpp
@@ -193,6 +193,8 @@ DeviceGUI::DeviceGUI(QWidget *parent) :
         this,
         &DeviceGUI::addChannelEmitted
     );
+
+    m_resizer.enableChildMouseTracking();
 }
 
 DeviceGUI::~DeviceGUI()

--- a/sdrgui/feature/featuregui.cpp
+++ b/sdrgui/feature/featuregui.cpp
@@ -141,6 +141,8 @@ FeatureGUI::FeatureGUI(QWidget *parent) :
         this,
         &FeatureGUI::onWidgetRolled
     );
+
+    m_resizer.enableChildMouseTracking();
 }
 
 FeatureGUI::~FeatureGUI()

--- a/sdrgui/gui/framelesswindowresizer.cpp
+++ b/sdrgui/gui/framelesswindowresizer.cpp
@@ -34,6 +34,14 @@ FramelessWindowResizer::FramelessWindowResizer(QWidget *widget) :
 {
 }
 
+void FramelessWindowResizer::enableChildMouseTracking()
+{
+    QList<QWidget *> widgets = m_widget->findChildren<QWidget *>();
+    for (auto widget : widgets) {
+        widget->setMouseTracking(true);
+    }
+}
+
 bool FramelessWindowResizer::mouseOnTopBorder(QPoint pos) const
 {
     return (pos.y() >= 0) && (pos.y() < m_gripSize);

--- a/sdrgui/gui/framelesswindowresizer.h
+++ b/sdrgui/gui/framelesswindowresizer.h
@@ -28,6 +28,8 @@
 // by clicking and draging on the border
 // The window needs to forward the mousePressEvent, mouseReleaseEvent, mouseMoveEvent
 // and leaveEvent events to this class
+// Child widgets should have mouse tracking enabled, so cursor can be controlled properly
+// This can be achieved by calling enableChildMouseTracking
 class SDRGUI_API FramelessWindowResizer
 {
 private:
@@ -49,6 +51,7 @@ private:
 
 public:
     FramelessWindowResizer(QWidget *widget);
+    void enableChildMouseTracking();
     void mousePressEvent(QMouseEvent* event);
     void mouseReleaseEvent(QMouseEvent* event);
     void mouseMoveEvent(QMouseEvent* event);

--- a/sdrgui/gui/glspectrum.cpp
+++ b/sdrgui/gui/glspectrum.cpp
@@ -2565,6 +2565,8 @@ void GLSpectrum::mouseMoveEvent(QMouseEvent* event)
 
         return;
     }
+
+    event->setAccepted(false);
 }
 
 void GLSpectrum::mousePressEvent(QMouseEvent* event)

--- a/sdrgui/mainspectrum/mainspectrumgui.cpp
+++ b/sdrgui/mainspectrum/mainspectrumgui.cpp
@@ -140,6 +140,7 @@ MainSpectrumGUI::MainSpectrumGUI(GLSpectrum *spectrum, GLSpectrumGUI *spectrumGU
     connect(this, SIGNAL(forceShrink()), this, SLOT(shrinkWindow()));
     connect(m_hideButton, SIGNAL(clicked()), this, SLOT(hide()));
 
+    m_resizer.enableChildMouseTracking();
     shrinkWindow();
 }
 


### PR DESCRIPTION
There's currently a small issue with the cursor not being restored after hovering over the border (which changes it to the resize cursor) then being moved immediately over a child widget. In this situation, the FramelessWindowResizer doesn't get a MouseMoveEvent.

This patch fixes this, by enabling mouse tracking on all child widgets.

A small change is also made to GLSpectrum, to enable propagation of MouseMoveEvents to the parent widget.
