### PR TITLE
V7: Add stack window layout

### DIFF
--- a/plugins/channelrx/demodais/aisdemodgui.ui
+++ b/plugins/channelrx/demodais/aisdemodgui.ui
@@ -487,7 +487,7 @@
        <widget class="QComboBox" name="udpFormat">
         <property name="minimumSize">
          <size>
-          <width>60</width>
+          <width>66</width>
           <height>0</height>
          </size>
         </property>

--- a/plugins/feature/antennatools/antennatoolsgui.ui
+++ b/plugins/feature/antennatools/antennatoolsgui.ui
@@ -6,25 +6,25 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>374</width>
+    <width>360</width>
     <height>584</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
   <property name="minimumSize">
    <size>
-    <width>374</width>
+    <width>360</width>
     <height>584</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>374</width>
+    <width>560</width>
     <height>584</height>
    </size>
   </property>
@@ -59,7 +59,7 @@
     <string>Calculators</string>
    </property>
    <property name="currentIndex">
-    <number>1</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="dipoleTab">
     <attribute name="title">
@@ -70,7 +70,7 @@
       <widget class="QComboBox" name="dipoleFrequencySelect">
        <property name="minimumSize">
         <size>
-         <width>94</width>
+         <width>90</width>
          <height>0</height>
         </size>
        </property>
@@ -266,7 +266,7 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>94</width>
+         <width>90</width>
          <height>0</height>
         </size>
        </property>

--- a/plugins/feature/aprs/aprsgui.cpp
+++ b/plugins/feature/aprs/aprsgui.cpp
@@ -668,10 +668,6 @@ void APRSGUI::resizeEvent(QResizeEvent* size)
     plotWeather();
     plotTelemetry();
     plotMotion();
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 void APRSGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/feature/aprs/aprsgui.ui
+++ b/plugins/feature/aprs/aprsgui.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -20,12 +20,6 @@
    <size>
     <width>462</width>
     <height>0</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>700</width>
-    <height>16777215</height>
    </size>
   </property>
   <property name="font">
@@ -154,7 +148,7 @@
     </rect>
    </property>
    <property name="sizePolicy">
-    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
      <horstretch>0</horstretch>
      <verstretch>0</verstretch>
     </sizepolicy>
@@ -187,6 +181,12 @@
        <number>0</number>
       </property>
       <widget class="QWidget" name="stationTab">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <attribute name="title">
         <string>Stations and Objects</string>
        </attribute>
@@ -568,6 +568,12 @@
            </layout>
           </widget>
           <widget class="QWidget" name="weatherTab">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <attribute name="title">
             <string>Weather</string>
            </attribute>
@@ -840,6 +846,12 @@
            </layout>
           </widget>
           <widget class="QWidget" name="motionTab">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <attribute name="title">
             <string>Motion</string>
            </attribute>
@@ -1007,6 +1019,12 @@
            </layout>
           </widget>
           <widget class="QWidget" name="telemetryTab">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <attribute name="title">
             <string>Telemetry</string>
            </attribute>
@@ -1271,6 +1289,12 @@
            </layout>
           </widget>
           <widget class="QWidget" name="statusTab">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <attribute name="title">
             <string>Status</string>
            </attribute>
@@ -1323,6 +1347,12 @@
            </layout>
           </widget>
           <widget class="QWidget" name="packetsTab">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <attribute name="title">
             <string>Packets</string>
            </attribute>
@@ -1374,6 +1404,12 @@
        </layout>
       </widget>
       <widget class="QWidget" name="messagesTab">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <attribute name="title">
         <string>Messages</string>
        </attribute>
@@ -1454,15 +1490,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
+  </customwidget>
+  <customwidget>
    <class>RollupContents</class>
    <extends>QWidget</extends>
    <header>gui/rollupcontents.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ButtonSwitch</class>
-   <extends>QToolButton</extends>
-   <header>gui/buttonswitch.h</header>
   </customwidget>
   <customwidget>
    <class>QChartView</class>

--- a/plugins/feature/simpleptt/simplepttgui.ui
+++ b/plugins/feature/simpleptt/simplepttgui.ui
@@ -24,7 +24,7 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>360</width>
+    <width>560</width>
     <height>155</height>
    </size>
   </property>

--- a/plugins/samplesource/sdrplayv3/sdrplayv3gui.ui
+++ b/plugins/samplesource/sdrplayv3/sdrplayv3gui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>410</width>
+    <width>360</width>
     <height>234</height>
    </rect>
   </property>
@@ -18,13 +18,13 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>410</width>
+    <width>360</width>
     <height>234</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>410</width>
+    <width>360</width>
     <height>234</height>
    </size>
   </property>

--- a/plugins/samplesource/testsource/testsourcegui.ui
+++ b/plugins/samplesource/testsource/testsourcegui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>381</width>
+    <width>360</width>
     <height>331</height>
    </rect>
   </property>
@@ -18,13 +18,13 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>381</width>
+    <width>360</width>
     <height>331</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>381</width>
+    <width>360</width>
     <height>331</height>
    </size>
   </property>

--- a/sdrgui/channel/channelgui.h
+++ b/sdrgui/channel/channelgui.h
@@ -95,7 +95,7 @@ protected:
     void mouseMoveEvent(QMouseEvent* event) override;
     void resetContextMenuType() { m_contextMenuType = ContextMenuNone; }
     void updateIndexLabel();
-    int getAdditionalHeight() const { return 25 + 22; }
+    int getAdditionalHeight() const { return 22 + 22; }  // height of top and bottom bars
     void setHighlighted(bool highlighted);
 
     DeviceType m_deviceType;

--- a/sdrgui/device/devicegui.h
+++ b/sdrgui/device/devicegui.h
@@ -83,7 +83,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void resetContextMenuType() { m_contextMenuType = ContextMenuNone; }
-    int getAdditionalHeight() const { return 25 + 22; }
+    int getAdditionalHeight() const { return 26 + 22; }  // height of top and bottom bars
 
     DeviceType m_deviceType;
     int m_deviceSetIndex;

--- a/sdrgui/feature/featuregui.h
+++ b/sdrgui/feature/featuregui.h
@@ -72,7 +72,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void resetContextMenuType() { m_contextMenuType = ContextMenuNone; }
-    int getAdditionalHeight() const { return 25 + 22; }
+    int getAdditionalHeight() const { return 22 + 22; } // height of top and bottom bars
 
     int m_featureIndex;
     QString m_helpURL;

--- a/sdrgui/gui/workspace.h
+++ b/sdrgui/gui/workspace.h
@@ -31,6 +31,10 @@ class QStringList;
 class QMdiArea;
 class QMdiSubWindow;
 class QFrame;
+class ChannelGUI;
+class FeatureGUI;
+class DeviceGUI;
+class MainSpectrumGUI;
 
 class SDRGUI_API Workspace : public QDockWidget
 {
@@ -49,6 +53,10 @@ public:
     QByteArray saveMdiGeometry();
     void restoreMdiGeometry(const QByteArray& blob);
     QList<QMdiSubWindow *> getSubWindowList() const;
+    void orderByIndex(QList<ChannelGUI *> &list);
+    void orderByIndex(QList<FeatureGUI *> &list);
+    void orderByIndex(QList<DeviceGUI *> &list);
+    void orderByIndex(QList<MainSpectrumGUI *> &list);
 
 private:
     int m_index;
@@ -61,6 +69,8 @@ private:
     QFrame *m_vline2;
     QPushButton *m_cascadeSubWindows;
     QPushButton *m_tileSubWindows;
+    QPushButton *m_stackSubWindows;
+    QPushButton *m_autoStackSubWindows;
     QWidget *m_titleBar;
     QHBoxLayout *m_titleBarLayout;
     QLabel *m_titleLabel;
@@ -68,6 +78,12 @@ private:
     QPushButton *m_closeButton;
     FeatureAddDialog m_featureAddDialog;
     QMdiArea *m_mdi;
+    bool m_stacking;                // Set when stackSubWindows() is running
+    int m_userChannelMinWidth;      // Minimum width of channels column for stackSubWindows(), set by user resizing a channel window
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
 private slots:
     void addRxDeviceClicked();
@@ -77,6 +93,8 @@ private slots:
     void featurePresetsDialog();
     void cascadeSubWindows();
     void tileSubWindows();
+    void stackSubWindows();
+    void autoStackSubWindows();
     void addFeatureEmitted(int featureIndex);
     void toggleFloating();
 


### PR DESCRIPTION
Add support for auto-stack V6-like window layout as per #1209.
Correct height of bottom bar for ChannelGUI and FeatureGUI from 25 to 22, and DeviceGUI from 25 to 26.
Update size constraints on some windows so they work better with stacked layout.

There are a couple of things I've left for you marked with FIXME in sdrgui/gui/workspace.cpp :)

- Two icons need to be created.
- The state of auto-stacking checkable button should be saved in the application preferences somewhere.

 