### PR TITLE
Fix typing errors in readme's

### DIFF
--- a/plugins/channelrx/demodais/readme.md
+++ b/plugins/channelrx/demodais/readme.md
@@ -68,7 +68,7 @@ UDP port number to forward received messages to.
 
 <h3>12: UDP format</h3>
 
-The format the messages are forwared via UDP in. This can be either binary (which is useful for SDRangel's PERTester feature) or NMEA (which is useful for 3rd party applications such as OpenCPN).
+The format the messages are forwarded via UDP in. This can be either binary (which is useful for SDRangel's PERTester feature) or NMEA (which is useful for 3rd party applications such as OpenCPN).
 
 <h3>13: Start/stop Logging Messages to .csv File</h3>
 

--- a/plugins/channelrx/demodvormc/readme.md
+++ b/plugins/channelrx/demodvormc/readme.md
@@ -42,7 +42,7 @@ Pressing this button downloads the OpenAIP.net Navaid database, which contains t
 
 <h3>5: Draw Radials Adjusted for Magnetic Declination</h3>
 
-When checked, radials on the map will drawn adjusted for magnetic declination. For example, if a VOR has a magnetic declination of 5 degrees, and the radial is calculated at 0 degrees, the radial will be drawn to magnetic North, i.e. -5 degress from true North. If not checked, the same radial would be drawn to true North (i.e 0 degrees), which may result in a less accurate position estimate.
+When checked, radials on the map will drawn adjusted for magnetic declination. For example, if a VOR has a magnetic declination of 5 degrees, and the radial is calculated at 0 degrees, the radial will be drawn to magnetic North, i.e. -5 degrees from true North. If not checked, the same radial would be drawn to true North (i.e 0 degrees), which may result in a less accurate position estimate.
 
 <h3>6: Morse ident threshold</h3>
 

--- a/plugins/feature/vorlocalizer/readme.md
+++ b/plugins/feature/vorlocalizer/readme.md
@@ -27,7 +27,7 @@ Pressing this button downloads the OpenAIP.net Navaid database, which contains t
 
 <h3>3: Draw Radials Adjusted for Magnetic Declination</h3>
 
-When checked, radials on the map will drawn adjusted for magnetic declination. For example, if a VOR has a magnetic declination of 5 degrees, and the radial is calculated at 0 degrees, the radial will be drawn to magnetic North, i.e. -5 degress from true North. If not checked, the same radial would be drawn to true North (i.e 0 degrees), which may result in a less accurate position estimate.
+When checked, radials on the map will drawn adjusted for magnetic declination. For example, if a VOR has a magnetic declination of 5 degrees, and the radial is calculated at 0 degrees, the radial will be drawn to magnetic North, i.e. -5 degrees from true North. If not checked, the same radial would be drawn to true North (i.e 0 degrees), which may result in a less accurate position estimate.
 
 <h3>4: Round robin turn time</h3>
 

--- a/plugins/samplemimo/bladerf2mimo/readme.md
+++ b/plugins/samplemimo/bladerf2mimo/readme.md
@@ -104,7 +104,7 @@ With SR as the sample rate before decimation Fc is calculated as:
 
 For Rx streams the I/Q stream from the BladeRF ADC is downsampled by a power of two before being sent to the passband.
 
-For Tx strams the baseband stream is interpolated by this value before being sent to the BladeRF device.
+For Tx streams the baseband stream is interpolated by this value before being sent to the BladeRF device.
 
 Possible values are increasing powers of two: 1 (no decimation or interpolation), 2, 4, 8, 16, 32, 64.
 

--- a/plugins/samplesource/limesdrinput/readme.md
+++ b/plugins/samplesource/limesdrinput/readme.md
@@ -161,7 +161,7 @@ Use this button to adjust the global gain of the LNA, TIA and PGA. LimeSuite sof
 
 <h4>8.3: LNA manual gain</h4>
 
-Use this button to adjust the gain of tha LNA when manual gain mode is set (8.1). Gain can be set between 1 and 30 dB in 1 dB steps. However the hardware has 3 dB steps for the lower gain values so increasing or decreasing by one step does not always produce a change. The value in dB appears at the right of the button.
+Use this button to adjust the gain of the LNA when manual gain mode is set (8.1). Gain can be set between 1 and 30 dB in 1 dB steps. However the hardware has 3 dB steps for the lower gain values so increasing or decreasing by one step does not always produce a change. The value in dB appears at the right of the button.
 
 <h4>8.4: TIA manual gain</h4>
 
@@ -169,7 +169,7 @@ Use this combo to select the TIA gain in dB when manual gain mode is set (8.1). 
 
 <h4>8.5: PGA manual gain</h4>
 
-Use this button to adjust the gain of tha PGA when manual gain mode is set (8.1). Gain can be set between 0 and 32 dB in 1 dB steps. The value in dB appears at the right of the button.
+Use this button to adjust the gain of the PGA when manual gain mode is set (8.1). Gain can be set between 0 and 32 dB in 1 dB steps. The value in dB appears at the right of the button.
 
 <h3>9: Antenna select</h3>
 

--- a/plugins/samplesource/xtrxinput/readme.md
+++ b/plugins/samplesource/xtrxinput/readme.md
@@ -179,7 +179,7 @@ Use this button to adjust the global gain of the LNA, TIA and PGA. LimeSuite sof
 
 <h4>8.3: LNA manual gain</h4>
 
-Use this button to adjust the gain of tha LNA when manual gain mode is set (9.1). Gain can be set between 1 and 30 dB in 1 dB steps. However the hardware has 3 dB steps for the lower gain values so increasing or decreasing by one step does not always produce a change. The value in dB appears at the right of the button.
+Use this button to adjust the gain of the LNA when manual gain mode is set (9.1). Gain can be set between 1 and 30 dB in 1 dB steps. However the hardware has 3 dB steps for the lower gain values so increasing or decreasing by one step does not always produce a change. The value in dB appears at the right of the button.
 
 <h4>8.4: TIA manual gain</h4>
 
@@ -187,7 +187,7 @@ Use this combo to select the TIA gain in dB when manual gain mode is set (9.1). 
 
 <h4>8.5: PGA manual gain</h4>
 
-Use this button to adjust the gain of tha PGA when manual gain mode is set (9.1). Gain can be set between 0 and 32 dB in 1 dB steps. The value in dB appears at the right of the button.
+Use this button to adjust the gain of the PGA when manual gain mode is set (9.1). Gain can be set between 0 and 32 dB in 1 dB steps. The value in dB appears at the right of the button.
 
 <h3>9: Antenna select</h3>
 

--- a/sdrgui/readme.md
+++ b/sdrgui/readme.md
@@ -53,7 +53,7 @@ The workspace has a top bar with the following controls:
 
 <h3>1.1: Workspace index</h3>
 
-Shows the index of the workspaces in the list of workspaces as a "W" followd by the index.
+Shows the index of the workspaces in the list of workspaces as a "W" followed by the index.
 
 <h3>1.2: Create new receiver</h3>
 


### PR DESCRIPTION
These are errors that codespell doesn't fix automatically because there is more than one fix.
The following command now gives an empty list of possible fixes, as expected:
find . -name '*.md' -exec codespell --ignore-words-list=cach,doas,ehr,hist,inout,lits,nd,ot,verry --write-changes --summary {} \+