### PR TITLE
Disable NAN and INF optimisations on Linux

### DIFF
--- a/cmake/Modules/CompilerOptions.cmake
+++ b/cmake/Modules/CompilerOptions.cmake
@@ -19,7 +19,7 @@ if(WIN32)
 endif()
 
 if(NOT MSVC)
-  add_compile_options(-Wall -Wextra -Wvla -Woverloaded-virtual -ffast-math -ftree-vectorize)
+  add_compile_options(-Wall -Wextra -Wvla -Woverloaded-virtual -ffast-math -fno-finite-math-only -ftree-vectorize)
 endif()
 
 if (SANITIZE_ADDRESS)


### PR DESCRIPTION
This PR disables the NAN and INF optimisations that are enabled by -ffinite-math-only (which is implied by -ffast-math)

This is needed as there are a few bits of code that use NANs (E.g. some code uses NANs to indicate uninitialized variables and then checks with isnan() - however, isnan() doesn't work with -ffinite-math-only) and a few uses of INFINITY too.

I wouldn't expect -ffinite-math-only to make much of a performance difference to the DSP code - but if it does, the option can perhaps be applied more selectively.