### PR TITLE
USRP: Don't call get_tx/rx methods if tx/rx channels is 0, as may result in KeyError exception

### DIFF
--- a/devices/usrp/deviceusrpparam.cpp
+++ b/devices/usrp/deviceusrpparam.cpp
@@ -37,17 +37,23 @@ bool DeviceUSRPParams::open(const QString &deviceStr, bool channelNumOnly)
 
         m_nbRxChannels = m_dev->get_rx_num_channels();
         m_nbTxChannels = m_dev->get_tx_num_channels();
+        qDebug() << "DeviceUSRPParams::open: m_nbRxChannels: " << m_nbRxChannels << " m_nbTxChannels: " << m_nbTxChannels;
 
         // Speed up program initialisation, by not getting all properties
         // If we could find out number of channles without ::make ing the device
         // that would be even better
         if (!channelNumOnly)
         {
-            m_lpfRangeRx = m_dev->get_rx_bandwidth_range();
-            m_lpfRangeTx = m_dev->get_tx_bandwidth_range();
-
-            m_loRangeRx = m_dev->get_fe_rx_freq_range();
-            m_loRangeTx = m_dev->get_fe_tx_freq_range();
+            if (m_nbRxChannels > 0)
+            {
+                m_lpfRangeRx = m_dev->get_rx_bandwidth_range();
+                m_loRangeRx = m_dev->get_fe_rx_freq_range();
+            }
+            if (m_nbTxChannels > 0)
+            {
+                m_lpfRangeTx = m_dev->get_tx_bandwidth_range();
+                m_loRangeTx = m_dev->get_fe_tx_freq_range();
+            }
 
             // For some devices (B210), rx/tx_rates vary with master_clock_rate
             // which can be set automatically by UHD. For other devices,
@@ -58,22 +64,41 @@ bool DeviceUSRPParams::open(const QString &deviceStr, bool channelNumOnly)
             uhd::property_tree::sptr properties = m_dev->get_device()->get_tree();
             if ((clockRange.start() == clockRange.stop()) || !properties->exists("/mboards/0/auto_tick_rate"))
             {
-                m_srRangeRx = m_dev->get_rx_rates();
-                m_srRangeTx = m_dev->get_tx_rates();
+                if (m_nbRxChannels > 0) {
+                    m_srRangeRx = m_dev->get_rx_rates();
+                }
+                if (m_nbTxChannels > 0) {
+                    m_srRangeTx = m_dev->get_tx_rates();
+                }
             }
             else
             {
                 // Find max and min sample rate, for max and min master clock rates
                 m_dev->set_master_clock_rate(clockRange.start());
-                uhd::meta_range_t rxLow = m_dev->get_rx_rates();
-                uhd::meta_range_t txLow = m_dev->get_tx_rates();
+                uhd::meta_range_t rxLow;
+                uhd::meta_range_t txLow;
+
+                if (m_nbRxChannels > 0) {
+                    rxLow = m_dev->get_rx_rates();
+                }
+                if (m_nbTxChannels > 0) {
+                    txLow = m_dev->get_tx_rates();
+                }
 
                 m_dev->set_master_clock_rate(clockRange.stop());
-                uhd::meta_range_t rxHigh = m_dev->get_rx_rates();
-                uhd::meta_range_t txHigh = m_dev->get_tx_rates();
+                uhd::meta_range_t rxHigh;
+                uhd::meta_range_t txHigh;
 
-                m_srRangeRx = uhd::meta_range_t(std::min(rxLow.start(), rxHigh.start()), std::max(rxLow.stop(), rxHigh.stop()));
-                m_srRangeTx = uhd::meta_range_t(std::min(txLow.start(), txHigh.start()), std::max(txLow.stop(), txHigh.stop()));
+                if (m_nbRxChannels > 0)
+                {
+                    rxHigh = m_dev->get_rx_rates();
+                    m_srRangeRx = uhd::meta_range_t(std::min(rxLow.start(), rxHigh.start()), std::max(rxLow.stop(), rxHigh.stop()));
+                }
+                if (m_nbTxChannels > 0)
+                {
+                    txHigh = m_dev->get_tx_rates();
+                    m_srRangeTx = uhd::meta_range_t(std::min(txLow.start(), txHigh.start()), std::max(txLow.stop(), txHigh.stop()));
+                }
 
                 // Need to restore automatic clock rate
                 if (properties->exists("/mboards/0/auto_tick_rate")) {
@@ -81,28 +106,38 @@ bool DeviceUSRPParams::open(const QString &deviceStr, bool channelNumOnly)
                 }
             }
 
-            m_gainRangeRx = m_dev->get_rx_gain_range();
-            m_gainRangeTx = m_dev->get_tx_gain_range();
+            if (m_nbRxChannels > 0)
+            {
+                m_gainRangeRx = m_dev->get_rx_gain_range();
 
-            std::vector<std::string> txAntennas = m_dev->get_tx_antennas();
-            m_txAntennas.reserve(txAntennas.size());
-            for(size_t i = 0, l = txAntennas.size(); i < l; ++i)
-                m_txAntennas << QString::fromStdString(txAntennas[i]);
+                std::vector<std::string> rxAntennas = m_dev->get_rx_antennas();
+                m_rxAntennas.reserve(rxAntennas.size());
+                for(size_t i = 0, l = rxAntennas.size(); i < l; ++i) {
+                    m_rxAntennas << QString::fromStdString(rxAntennas[i]);
+                }
 
-            std::vector<std::string> rxAntennas = m_dev->get_rx_antennas();
-            m_rxAntennas.reserve(rxAntennas.size());
-            for(size_t i = 0, l = rxAntennas.size(); i < l; ++i)
-                m_rxAntennas << QString::fromStdString(rxAntennas[i]);
+                std::vector<std::string> rxGainNames = m_dev->get_rx_gain_names();
+                m_rxGainNames.reserve(rxGainNames.size());
+                for(size_t i = 0, l = rxGainNames.size(); i < l; ++i) {
+                    m_rxGainNames << QString::fromStdString(rxGainNames[i]);
+                }
+            }
+            if (m_nbTxChannels > 0)
+            {
+                m_gainRangeTx = m_dev->get_tx_gain_range();
 
-            std::vector<std::string> rxGainNames = m_dev->get_rx_gain_names();
-            m_rxGainNames.reserve(rxGainNames.size());
-            for(size_t i = 0, l = rxGainNames.size(); i < l; ++i)
-                m_rxGainNames << QString::fromStdString(rxGainNames[i]);
+                std::vector<std::string> txAntennas = m_dev->get_tx_antennas();
+                m_txAntennas.reserve(txAntennas.size());
+                for(size_t i = 0, l = txAntennas.size(); i < l; ++i) {
+                    m_txAntennas << QString::fromStdString(txAntennas[i]);
+                }
+            }
 
             std::vector<std::string> clockSources = m_dev->get_clock_sources(0);
             m_clockSources.reserve(clockSources.size());
-            for(size_t i = 0, l = clockSources.size(); i < l; ++i)
+            for(size_t i = 0, l = clockSources.size(); i < l; ++i) {
                 m_clockSources << QString::fromStdString(clockSources[i]);
+            }
         }
 
         return true;


### PR DESCRIPTION
First attempt to fix #1284 