### PR TITLE
3D Spectrogram: Use texture height rather than fft size 

### DIFF
--- a/sdrgui/gui/glshaderspectrogram.cpp
+++ b/sdrgui/gui/glshaderspectrogram.cpp
@@ -419,7 +419,7 @@ void GLShaderSpectrogram::drawSurface(SpectrumSettings::SpectrogramStyle style, 
     program->setUniformValue(m_dataTextureLoc, 0);         // set uniform to texture unit?
     program->setUniformValue(m_colorMapLoc, 1);
 
-    program->setUniformValue(m_limitLoc, 1.5f*1.0f/(float)(m_gridElements));
+    program->setUniformValue(m_limitLoc, 1.4f*1.0f/(float)(m_texture->height()));
 
     if (style == SpectrumSettings::Outline)
     {


### PR DESCRIPTION
To try to prevent interpolation of textures where it wraps.