### PR TITLE
Change frequency zoom so that frequency under cursor remains the same

### DIFF
--- a/sdrgui/gui/glspectrum.cpp
+++ b/sdrgui/gui/glspectrum.cpp
@@ -3399,6 +3399,21 @@ void GLSpectrum::zoom(QWheelEvent *event)
 
     if ((pwx >= 0.0f) && (pwx <= 1.0f))
     {
+        // When we zoom, we want the frequency under the cursor to remain the same
+
+        // Determine frequency at cursor position
+        float zoomFreq = m_frequencyScale.getRangeMin() + pwx*m_frequencyScale.getRange();
+        //float zoomFreq2 = ((pwx - 0.5) *  m_sampleRate/m_frequencyZoomFactor + ((m_frequencyZoomPos - 0.5)* m_sampleRate + m_centerFrequency));
+
+        // Calculate current centre frequency
+        float currentCF = (m_frequencyZoomFactor == 1) ? m_centerFrequency : ((m_frequencyZoomPos - 0.5) * m_sampleRate + m_centerFrequency);
+
+        // Calculate difference from frequency under cursor to centre frequency
+        float freqDiff = (currentCF - zoomFreq);
+
+        // Calculate what that difference would be if there was no zoom
+        float freqDiffZoom1 = freqDiff * m_frequencyZoomFactor;
+
         if (event->angleDelta().y() > 0) // zoom in
         {
             if (m_frequencyZoomFactor < m_maxFrequencyZoom) {
@@ -3416,7 +3431,17 @@ void GLSpectrum::zoom(QWheelEvent *event)
             }
         }
 
-        frequencyZoom(pwx);
+        // Calculate what frequency difference should be at new zoom
+        float zoomedFreqDiff = freqDiffZoom1 / m_frequencyZoomFactor;
+        // Then calculate what the center frequency should be
+        float zoomedCF = zoomFreq + zoomedFreqDiff;
+
+        // Calculate zoom position which will set the desired center frequency
+        float zoomPos = (zoomedCF - m_centerFrequency) / m_sampleRate + 0.5;
+        zoomPos = std::max(0.0f, zoomPos);
+        zoomPos = std::min(1.0f, zoomPos);
+
+        frequencyZoom(zoomPos);
     }
     else
     {
@@ -3445,13 +3470,9 @@ void GLSpectrum::zoom(QWheelEvent *event)
     }
 }
 
-void GLSpectrum::frequencyZoom(float pw)
+void GLSpectrum::frequencyZoom(float zoomPos)
 {
-    m_frequencyZoomPos += (pw - 0.5f) * (1.0f / m_frequencyZoomFactor);
-    float lim = 0.5f / m_frequencyZoomFactor;
-    m_frequencyZoomPos = m_frequencyZoomPos < lim ? lim : m_frequencyZoomPos > 1 - lim ? 1 - lim : m_frequencyZoomPos;
-
-    qDebug("GLSpectrum::frequencyZoom: pw: %f p: %f z: %f", pw, m_frequencyZoomPos, m_frequencyZoomFactor);
+    m_frequencyZoomPos = zoomPos;
     updateFFTLimits();
 }
 

--- a/sdrgui/gui/glspectrum.cpp
+++ b/sdrgui/gui/glspectrum.cpp
@@ -3403,7 +3403,6 @@ void GLSpectrum::zoom(QWheelEvent *event)
 
         // Determine frequency at cursor position
         float zoomFreq = m_frequencyScale.getRangeMin() + pwx*m_frequencyScale.getRange();
-        //float zoomFreq2 = ((pwx - 0.5) *  m_sampleRate/m_frequencyZoomFactor + ((m_frequencyZoomPos - 0.5)* m_sampleRate + m_centerFrequency));
 
         // Calculate current centre frequency
         float currentCF = (m_frequencyZoomFactor == 1) ? m_centerFrequency : ((m_frequencyZoomPos - 0.5) * m_sampleRate + m_centerFrequency);


### PR DESCRIPTION
This patch changes the spectrum frequency zoom so that the frequency under the cursor remains the same after the zoom. This makes it easier to zoom in to a particular peak.

Currently, if you zoom using the scroll wheel with the cursor over the peak highlighted in green (i.e. one that isn't at the centre of the spectrum):

![image](https://user-images.githubusercontent.com/57259258/175102046-b8ffe0a4-8092-42fb-a843-cb565daefbc4.png)

the peak will have moved to the right of the cursor after the first zoom increment. If you then zoom again several times without moving the mouse back over the peak, the peak may disappear of the right off the screen.

With this patch, it should stay where it is, relative to the cursor, so you can zoom all the way in to it, without moving the mouse.

