### PR TITLE
Spectrum markers dialog: Small fixes

### DIFF
--- a/sdrgui/gui/spectrummarkersdialog.cpp
+++ b/sdrgui/gui/spectrummarkersdialog.cpp
@@ -639,6 +639,18 @@ void SpectrumMarkersDialog::on_aMarkerShowStateAll_clicked()
     }
 }
 
+// We don't get aMarkerText_editingFinished signal until after aMarkerToggleFrequency_toggled
+// when that button is pressed, so save the text immediately when edited, so it isn't lost
+// after call to displayAnnotationMarker
+void SpectrumMarkersDialog::on_aMarkerText_textEdited()
+{
+    if (m_annotationMarkers.size() == 0) {
+        return;
+    }
+
+    m_annotationMarkers[m_annotationMarkerIndex].m_text = ui->aMarkerText->text();
+}
+
 void SpectrumMarkersDialog::on_aMarkerText_editingFinished()
 {
     if (m_annotationMarkers.size() == 0) {
@@ -795,7 +807,7 @@ void SpectrumMarkersDialog::on_aMarkersExport_clicked()
                     stream << marker.m_startFrequency << ","
                         << marker.m_bandwidth << ","
                         << marker.m_text << ","
-                        << (marker.m_show ? "1" : "0") << ","
+                        << ((int)marker.m_show) << ","
                         << marker.m_markerColor.red() << ","
                         << marker.m_markerColor.green() << ","
                         << marker.m_markerColor.blue() << "\n";

--- a/sdrgui/gui/spectrummarkersdialog.h
+++ b/sdrgui/gui/spectrummarkersdialog.h
@@ -101,6 +101,7 @@ private slots:
     void on_aMarkerColor_clicked();
     void on_aMarkerShowState_currentIndexChanged(int state);
     void on_aMarkerShowStateAll_clicked();
+    void on_aMarkerText_textEdited();
     void on_aMarkerText_editingFinished();
     void on_aMarker_valueChanged(int value);
     void on_aMarkerAdd_clicked();


### PR DESCRIPTION
Fix CSV export of show field. Currently limited to 0 or 1, when 0, 1, or 2 are valid values.

Also fixes a small problem in the dialog, where currently the marker name can be lost:

- Create new annotation marker
- Enter a name for the marker - but don't press enter
- Press start button to change to centre
- Marker name is reset