### PR TITLE
Value dial: Check for completed animation before using m_value

### DIFF
--- a/sdrgui/gui/valuedial.cpp
+++ b/sdrgui/gui/valuedial.cpp
@@ -553,13 +553,13 @@ void ValueDial::keyPressEvent(QKeyEvent *value)
 
     if (c >= QChar('0') && (c <= QChar('9')))
     {
-        int d = c.toLatin1() - '0';
-        quint64 e = findExponent(m_cursor);
-        quint64 v = (m_value / e) % 10;
-
         if (m_animationState != 0) {
             m_value = m_valueNew;
         }
+
+        int d = c.toLatin1() - '0';
+        quint64 e = findExponent(m_cursor);
+        quint64 v = (m_value / e) % 10;
 
         v = m_value - v * e;
         v += d * e;

--- a/sdrgui/gui/valuedialz.cpp
+++ b/sdrgui/gui/valuedialz.cpp
@@ -619,15 +619,15 @@ void ValueDialZ::keyPressEvent(QKeyEvent* value)
     }
     else if ((c >= QChar('0')) && (c <= QChar('9')) && (m_cursor > 0)) // digits
     {
+        if(m_animationState != 0) {
+            m_value = m_valueNew;
+        }
+
         int d = c.toLatin1() - '0';
         quint64 e = findExponent(m_cursor);
         quint64 value = abs(m_value);
         int sign = m_value < 0 ? -1 : 1;
         quint64 v = (value / e) % 10;
-
-        if(m_animationState != 0) {
-            m_value = m_valueNew;
-        }
 
         v = value - v * e;
         v += d * e;


### PR DESCRIPTION
If you go in to the Spectrum Markers dialog annotations tab, and really quickly type a value in to the start frequency value dial, if you're fast enough, some of the characters will be lost.

I think the problem is that although the key event handler looks at animation state to see if there's a new value in m_valueNew waiting to update m_value, it is doing that check and update only after it has used m_value - so it can see the old value.