### PR TITLE
Spectrum: Fix mouse wheel zoom in waterfall

### DIFF
--- a/sdrgui/gui/glspectrum.cpp
+++ b/sdrgui/gui/glspectrum.cpp
@@ -3363,7 +3363,7 @@ void GLSpectrum::wheelEvent(QWheelEvent *event)
 #else
     const QPointF& ep = event->pos();
 #endif
-    if (pointInWaterfallOrSpectrogram(ep))
+    if (m_display3DSpectrogram && pointInWaterfallOrSpectrogram(ep))
     {
         // Scale 3D spectrogram when mouse wheel moved
         // Some mice use delta in steps of 120 for 15 degrees


### PR DESCRIPTION
This patch reenables support for zooming using the mouse wheel when cursor is over the waterfall (this was accidentally disabled when adding 3D view)
