### PR TITLE
Spectrum: Allow frequency scrolling

### DIFF
--- a/sdrgui/gui/glspectrum.h
+++ b/sdrgui/gui/glspectrum.h
@@ -319,6 +319,9 @@ private:
     SpectrumSettings::SpectrumStyle m_spectrumStyle;
     const float *m_colorMap;
 
+    bool m_scrollFrequency;
+    qint64 m_scrollStartCenterFreq;
+
     QRgb m_histogramPalette[240];
     QImage* m_histogramBuffer;
     quint8* m_histogram; //!< Spectrum phosphor matrix of FFT width and PSD height scaled to 100. values [0..239]
@@ -391,6 +394,7 @@ private:
     void setPowerScale(int height);
     void getFrequencyZoom(int64_t& centerFrequency, int& frequencySpan);
     bool pointInWaterfallOrSpectrogram(const QPointF &point) const;
+    bool pointInHistogram(const QPointF &point) const;
 
     void enterEvent(QEvent* event);
     void leaveEvent(QEvent* event);
@@ -432,6 +436,10 @@ private slots:
     void channelMarkerDestroyed(QObject* object);
     void openGLDebug(const QOpenGLDebugMessage &debugMessage);
     bool eventFilter(QObject *object, QEvent *event);
+
+signals:
+    // Emitted when user tries to scroll to frequency currently out of range
+    void requestCenterFrequency(qint64 frequency);
 };
 
 #endif // INCLUDE_GLSPECTRUM_H

--- a/sdrgui/mainspectrum/mainspectrumgui.cpp
+++ b/sdrgui/mainspectrum/mainspectrumgui.cpp
@@ -29,6 +29,7 @@
 #include "gui/glspectrumgui.h"
 #include "gui/workspaceselectiondialog.h"
 #include "dsp/spectrumvis.h"
+#include "channel/channelwebapiutils.h"
 #include "mainspectrumgui.h"
 
 MainSpectrumGUI::MainSpectrumGUI(GLSpectrum *spectrum, GLSpectrumGUI *spectrumGUI, QWidget *parent) :
@@ -140,6 +141,8 @@ MainSpectrumGUI::MainSpectrumGUI(GLSpectrum *spectrum, GLSpectrumGUI *spectrumGU
     connect(m_shrinkButton, SIGNAL(clicked()), this, SLOT(shrinkWindow()));
     connect(this, SIGNAL(forceShrink()), this, SLOT(shrinkWindow()));
     connect(m_hideButton, SIGNAL(clicked()), this, SLOT(hide()));
+
+    connect(spectrum, &GLSpectrum::requestCenterFrequency, this, &MainSpectrumGUI::onRequestCenterFrequency);
 
     m_resizer.enableChildMouseTracking();
     shrinkWindow();
@@ -316,4 +319,11 @@ QString MainSpectrumGUI::getDeviceTypeTag()
         default:
             return "X";
     }
+}
+
+// Handle request from GLSpectrum to adjust center frequency
+void MainSpectrumGUI::onRequestCenterFrequency(qint64 frequency)
+{
+    double frequencyInHz = (double)frequency;
+    ChannelWebAPIUtils::setCenterFrequency(m_deviceSetIndex, frequencyInHz);
 }

--- a/sdrgui/mainspectrum/mainspectrumgui.h
+++ b/sdrgui/mainspectrum/mainspectrumgui.h
@@ -106,6 +106,7 @@ private slots:
     void showHelp();
     void openMoveToWorkspaceDialog();
     void shrinkWindow();
+    void onRequestCenterFrequency(qint64 frequency);
 
 signals:
     void closing();


### PR DESCRIPTION
This patch allows a user to adjust center frequency up or down in a main spectrum by:

- Holding down the middle mouse button and moving the mouse left or right
- Moving the mouse outside of the spectrum area when dragging a channel marker.

For me, this makes it much quicker and easier to move to frequencies that are just out of range. 

It works quite well on RTL SDR & USRP (for the latter, it's nearly as smooth as moving the channel marker) - but is a little slow on SDRplay.

Note, this works by GLSpectrum emitting a signal requesting a change of center frequency - The change of device frequency is handled by MainSpectrumGUI - so GLSpectrum doesn't need to know whether it is connected to a device or something else.
