### PR TITLE
Spectrum markers: Allow both types to be displayed at the same time

### DIFF
--- a/sdrbase/dsp/spectrummarkers.h
+++ b/sdrbase/dsp/spectrummarkers.h
@@ -161,7 +161,8 @@ struct SDRBASE_API SpectrumAnnotationMarker
     {
         Hidden,
         ShowTop,
-        ShowFull
+        ShowFull,
+        ShowText
     };
 
     qint64 m_startFrequency;

--- a/sdrbase/dsp/spectrumsettings.h
+++ b/sdrbase/dsp/spectrumsettings.h
@@ -39,11 +39,13 @@ public:
         AvgModeMax
     };
 
+    // Bitmask for which selection of markers to display
     enum MarkersDisplay
     {
-        MarkersDisplayNone,
-        MarkersDisplaySpectrum,
-		MarkersDisplayAnnotations
+        MarkersDisplayNone = 0,
+        MarkersDisplaySpectrum = 0x1,
+        MarkersDisplayAnnotations = 0x2,
+        MarkersDisplayAll = 0x3
     };
 
 	enum CalibrationInterpolationMode

--- a/sdrgui/gui/glspectrum.cpp
+++ b/sdrgui/gui/glspectrum.cpp
@@ -1379,9 +1379,10 @@ void GLSpectrum::paintGL()
         }
     }
 
-    if (m_markersDisplay == SpectrumSettings::MarkersDisplaySpectrum) {
+    if (m_markersDisplay & SpectrumSettings::MarkersDisplaySpectrum) {
         drawSpectrumMarkers();
-    } else if (m_markersDisplay == SpectrumSettings::MarkersDisplayAnnotations) {
+    }
+    if (m_markersDisplay & SpectrumSettings::MarkersDisplayAnnotations) {
         drawAnnotationMarkers();
     }
 
@@ -1908,28 +1909,27 @@ void GLSpectrum::drawAnnotationMarkers()
             m_glShaderSimple.drawSurface(m_glHistogramBoxMatrix, color, q3, 4);
         }
 
-        if (marker->m_show == SpectrumAnnotationMarker::ShowFull)
+        // Always draw a line in the top area, so we can see where bands start/stop when contiguous
+        // When show is ShowFull, we draw at full height of spectrum
+        bool full = marker->m_show == SpectrumAnnotationMarker::ShowFull;
+
+        GLfloat d1[] {
+            marker->m_startPos, full ? 0 : htop,
+            marker->m_startPos, full ? 1 : h,
+        };
+        m_glShaderSimple.drawSegments(m_glHistogramBoxMatrix, color, d1, 2);
+
+        if (marker->m_bandwidth != 0)
         {
-            QVector4D color(
-                marker->m_markerColor.redF(),
-                marker->m_markerColor.greenF(),
-                marker->m_markerColor.blueF(), 0.5f
-            );
-            GLfloat d1[] {
-                marker->m_startPos, 0,
-                marker->m_startPos, 1,
+            GLfloat d2[] {
+                marker->m_stopPos, full ? 0 : htop,
+                marker->m_stopPos, full ? 1 : h,
             };
-            m_glShaderSimple.drawSegments(m_glHistogramBoxMatrix, color, d1, 2);
+            m_glShaderSimple.drawSegments(m_glHistogramBoxMatrix, color, d2, 2);
+        }
 
-            if (marker->m_bandwidth != 0)
-            {
-                GLfloat d2[] {
-                    marker->m_stopPos, 0,
-                    marker->m_stopPos, 1,
-                };
-                m_glShaderSimple.drawSegments(m_glHistogramBoxMatrix, color, d2, 2);
-            }
-
+        if ((marker->m_show == SpectrumAnnotationMarker::ShowFull) || (marker->m_show == SpectrumAnnotationMarker::ShowText))
+        {
             float txtpos = marker->m_startPos < 0.5f ?
                 marker->m_startPos :
                 marker->m_stopPos;
@@ -2822,7 +2822,7 @@ void GLSpectrum::updateWaterfallMarkers()
 
 void GLSpectrum::updateAnnotationMarkers()
 {
-    if (m_markersDisplay != SpectrumSettings::MarkersDisplayAnnotations) {
+    if (!(m_markersDisplay & SpectrumSettings::MarkersDisplayAnnotations)) {
         return;
     }
 
@@ -2838,7 +2838,7 @@ void GLSpectrum::updateAnnotationMarkers()
 
 void GLSpectrum::updateSortedAnnotationMarkers()
 {
-    if (m_markersDisplay != SpectrumSettings::MarkersDisplayAnnotations) {
+    if (!(m_markersDisplay & SpectrumSettings::MarkersDisplayAnnotations)) {
         return;
     }
 
@@ -2862,7 +2862,7 @@ void GLSpectrum::updateSortedAnnotationMarkers()
 
 void GLSpectrum::updateMarkersDisplay()
 {
-    if (m_markersDisplay == SpectrumSettings::MarkersDisplayAnnotations) {
+    if (m_markersDisplay & SpectrumSettings::MarkersDisplayAnnotations) {
         updateAnnotationMarkers();
     }
 }
@@ -3275,7 +3275,7 @@ void GLSpectrum::mousePressEvent(QMouseEvent* event)
             }
         }
 
-        if ((m_markersDisplay == SpectrumSettings::MarkersDisplayAnnotations) &&
+        if ((m_markersDisplay & SpectrumSettings::MarkersDisplayAnnotations) &&
             (ep.y() <= m_histogramRect.top()*height() + m_annotationMarkerHeight + 2.0f))
         {
             QPointF pHis;
@@ -3294,8 +3294,18 @@ void GLSpectrum::mousePressEvent(QMouseEvent* event)
 
                 if (((*iMarker)->m_startFrequency < selectedFrequency) && (selectedFrequency <= stopFrequency) && !selected)
                 {
-                    (*iMarker)->m_show = (*iMarker)->m_show == SpectrumAnnotationMarker::ShowFull ?
-						SpectrumAnnotationMarker::ShowTop : SpectrumAnnotationMarker::ShowFull;
+                    switch ((*iMarker)->m_show)
+                    {
+                    case SpectrumAnnotationMarker::ShowTop:
+                        (*iMarker)->m_show = SpectrumAnnotationMarker::ShowText;
+                        break;
+                    case SpectrumAnnotationMarker::ShowText:
+                        (*iMarker)->m_show = SpectrumAnnotationMarker::ShowFull;
+                        break;
+                    case SpectrumAnnotationMarker::ShowFull:
+                        (*iMarker)->m_show = SpectrumAnnotationMarker::ShowTop;
+                        break;
+                    }
                     selected = true;
                 }
             }

--- a/sdrgui/gui/spectrummarkersdialog.ui
+++ b/sdrgui/gui/spectrummarkersdialog.ui
@@ -1673,6 +1673,11 @@ Max - Marker will move according to the maximum power at the marker frequency</s
               <string>Full</string>
              </property>
             </item>
+            <item>
+             <property name="text">
+              <string>Text</string>
+             </property>
+            </item>
            </widget>
           </item>
           <item>
@@ -1730,7 +1735,8 @@ Max - Marker will move according to the maximum power at the marker frequency</s
 
 None - Hide all markers
 Spec - Show histogram and waterfall markers
-Anno - Show annotation markers</string>
+Anno - Show annotation markers
+All  - Show all markers</string>
        </property>
        <item>
         <property name="text">
@@ -1745,6 +1751,11 @@ Anno - Show annotation markers</string>
        <item>
         <property name="text">
          <string>Anno</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>All</string>
         </property>
        </item>
       </widget>


### PR DESCRIPTION
This PR makes two two small changes to spectrum markers.

Firstly, it adds an option of All, to allow both Spectrum markers and Annotations to be displayed at the same time. (MarkersDisplay enum changed to a bitmask in case we want more permutations of additional marker types in the future).

Secondly, it adds an additional option of Text for the Annotation markers, so that the Annotation text is displayed in the header, without the full height bandwidth markers being drawn (just my personal preference!)

Also, I made a small change, so that the bandwidth lines are always drawn when annotations are visible - however, unless the setting is full, the lines are drawn only in the header area, so that you can see where bands start and finish if they are contiguous. If you don't like this, I'm happy to change it back / tweak it further.
