### PR TITLE
SpectrumGUI: Add combo box to allow center frequency to be set to marker

### DIFF
--- a/sdrgui/gui/glspectrumgui.h
+++ b/sdrgui/gui/glspectrumgui.h
@@ -84,6 +84,8 @@ private:
 	void setFFTSizeToolitp();
 	void setMaximumOverlap();
 	bool handleMessage(const Message& message);
+    void displayGotoMarkers();
+    QString displayScaled(int64_t value, char type, int precision, bool showMult);
 
 private slots:
 	void on_fftWindow_currentIndexChanged(int index);
@@ -118,6 +120,7 @@ private slots:
 	void on_clearSpectrum_clicked(bool checked);
     void on_freeze_toggled(bool checked);
 	void on_calibration_toggled(bool checked);
+    void on_gotoMarker_currentIndexChanged(int index);
 
 	void handleInputMessages();
     void openWebsocketSpectrumSettingsDialog(const QPoint& p);
@@ -128,6 +131,10 @@ private slots:
 	void updateAnnotationMarkers();
 	void updateMarkersDisplay();
 	void updateCalibrationPoints();
+
+signals:
+    // Emitted when user selects an annotation marker
+    void requestCenterFrequency(qint64 frequency);
 };
 
 #endif // INCLUDE_GLSPECTRUMGUI_H

--- a/sdrgui/gui/glspectrumgui.ui
+++ b/sdrgui/gui/glspectrumgui.ui
@@ -1074,6 +1074,30 @@
       </widget>
      </item>
      <item>
+      <widget class="QComboBox" name="gotoMarker">
+       <property name="minimumSize">
+        <size>
+         <width>65</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>65</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Set frequency to marker</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>Go to...</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="fillLabel4">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">

--- a/sdrgui/mainspectrum/mainspectrumgui.cpp
+++ b/sdrgui/mainspectrum/mainspectrumgui.cpp
@@ -142,6 +142,7 @@ MainSpectrumGUI::MainSpectrumGUI(GLSpectrum *spectrum, GLSpectrumGUI *spectrumGU
     connect(m_hideButton, SIGNAL(clicked()), this, SLOT(hide()));
 
     connect(spectrum, &GLSpectrum::requestCenterFrequency, this, &MainSpectrumGUI::onRequestCenterFrequency);
+    connect(spectrumGUI, &GLSpectrumGUI::requestCenterFrequency, this, &MainSpectrumGUI::onRequestCenterFrequency);
 
     m_resizer.enableChildMouseTracking();
     shrinkWindow();
@@ -320,7 +321,7 @@ QString MainSpectrumGUI::getDeviceTypeTag()
     }
 }
 
-// Handle request from GLSpectrum to adjust center frequency
+// Handle request from GLSpectrum/GLSpectrumGUI to adjust center frequency
 void MainSpectrumGUI::onRequestCenterFrequency(qint64 frequency)
 {
     emit requestCenterFrequency(m_deviceSetIndex, frequency);


### PR DESCRIPTION
Last one :)

This patch adds a combo box to the Spectrum GUI that displays all of the annotation markers - and when pressed, sets the center frequency accordingly, allowing you to quickly jump between pre-defined frequencies.

Combo box is only displayed if there are annotation markers.
