### PR TITLE
Darken ValueDials when disabled

### DIFF
--- a/sdrgui/gui/valuedial.cpp
+++ b/sdrgui/gui/valuedial.cpp
@@ -236,12 +236,17 @@ void ValueDial::paintEvent(QPaintEvent *)
         painter.drawRect(2 + m_hightlightedDigit * m_digitWidth, 1, m_digitWidth - 1, height() - 1);
     }
 
+    QColor secondaryForegroundColor = m_colorMapper.getSecondaryForegroundColor();
+    if (!isEnabled()) {
+        secondaryForegroundColor = secondaryForegroundColor.darker();
+    }
+
     if (m_animationState == 0)
     {
         for (int i = 0; i < m_text.length(); i++)
         {
             painter.setClipRect(1 + i * m_digitWidth, 1, m_digitWidth, m_digitHeight * 2);
-            painter.setPen(m_colorMapper.getSecondaryForegroundColor());
+            painter.setPen(secondaryForegroundColor);
             painter.drawText(QRect(1 + i * m_digitWidth, m_digitHeight * 0.6, m_digitWidth, m_digitHeight), Qt::AlignCenter, m_text.mid(i, 1));
 
             if (m_text[i] != m_groupSeparator)
@@ -257,7 +262,7 @@ void ValueDial::paintEvent(QPaintEvent *)
         if ((m_cursor >= 0) && (m_cursorState))
         {
             painter.setPen(Qt::NoPen);
-            painter.setBrush(m_colorMapper.getSecondaryForegroundColor());
+            painter.setBrush(secondaryForegroundColor);
             painter.drawRect(4 + m_cursor * m_digitWidth, 1 + m_digitHeight * 1.5, m_digitWidth - 5, m_digitHeight / 6);
         }
     }
@@ -268,7 +273,7 @@ void ValueDial::paintEvent(QPaintEvent *)
             if (m_text[i] == m_textNew[i])
             {
                 painter.setClipRect(1 + i * m_digitWidth, 1, m_digitWidth, m_digitHeight * 2);
-                painter.setPen(m_colorMapper.getSecondaryForegroundColor());
+                painter.setPen(secondaryForegroundColor);
                 painter.drawText(QRect(1 + i * m_digitWidth, m_digitHeight * 0.6, m_digitWidth, m_digitHeight), Qt::AlignCenter, m_text.mid(i, 1));
 
                 if (m_text[i] != m_groupSeparator)
@@ -282,7 +287,7 @@ void ValueDial::paintEvent(QPaintEvent *)
             {
                 int h = m_digitHeight * 0.6 + m_digitHeight * m_animationState / 2.0;
                 painter.setClipRect(1 + i * m_digitWidth, 1, m_digitWidth, m_digitHeight * 2);
-                painter.setPen(m_colorMapper.getSecondaryForegroundColor());
+                painter.setPen(secondaryForegroundColor);
                 painter.drawText(QRect(1 + i * m_digitWidth, h, m_digitWidth, m_digitHeight), Qt::AlignCenter, m_text.mid(i, 1));
 
                 if (m_text[i] != m_groupSeparator)

--- a/sdrgui/gui/valuedialz.cpp
+++ b/sdrgui/gui/valuedialz.cpp
@@ -278,12 +278,17 @@ void ValueDialZ::paintEvent(QPaintEvent*)
         painter.drawRect(2 + m_hightlightedDigit * m_digitWidth, 1, m_digitWidth - 1, height() - 1);
     }
 
+    QColor secondaryForegroundColor = m_colorMapper.getSecondaryForegroundColor();
+    if (!isEnabled()) {
+        secondaryForegroundColor = secondaryForegroundColor.darker();
+    }
+
     if (m_animationState == 0)
     {
         for (int i = 0; i < m_text.length(); i++)
         {
             painter.setClipRect(1 + i * m_digitWidth, 1, m_digitWidth, m_digitHeight * 2);
-            painter.setPen(m_colorMapper.getSecondaryForegroundColor());
+            painter.setPen(secondaryForegroundColor);
             painter.drawText(QRect(1 + i * m_digitWidth, m_digitHeight * 0.6, m_digitWidth, m_digitHeight), Qt::AlignCenter, m_text.mid(i, 1));
 
             if ((m_text[i] != m_groupSeparator) && (m_text[i] != m_decSeparator))
@@ -299,7 +304,7 @@ void ValueDialZ::paintEvent(QPaintEvent*)
         if ((m_cursor >= 0) && (m_cursorState))
         {
             painter.setPen(Qt::NoPen);
-            painter.setBrush(m_colorMapper.getSecondaryForegroundColor());
+            painter.setBrush(secondaryForegroundColor);
             painter.drawRect(4 + m_cursor * m_digitWidth, 1 + m_digitHeight * 1.5, m_digitWidth - 5, m_digitHeight / 6);
         }
     }
@@ -310,7 +315,7 @@ void ValueDialZ::paintEvent(QPaintEvent*)
             if (m_text[i] == m_textNew[i])
             {
                 painter.setClipRect(1 + i * m_digitWidth, 1, m_digitWidth, m_digitHeight * 2);
-                painter.setPen(m_colorMapper.getSecondaryForegroundColor());
+                painter.setPen(secondaryForegroundColor);
                 painter.drawText(QRect(1 + i * m_digitWidth, m_digitHeight * 0.6, m_digitWidth, m_digitHeight), Qt::AlignCenter, m_text.mid(i, 1));
 
                 if ((m_text[i] != m_groupSeparator) && (m_text[i] != m_decSeparator))
@@ -324,7 +329,7 @@ void ValueDialZ::paintEvent(QPaintEvent*)
             {
                 int h = m_digitHeight * 0.6 + m_digitHeight * m_animationState / 2.0;
                 painter.setClipRect(1 + i * m_digitWidth, 1, m_digitWidth, m_digitHeight * 2);
-                painter.setPen(m_colorMapper.getSecondaryForegroundColor());
+                painter.setPen(secondaryForegroundColor);
                 painter.drawText(QRect(1 + i * m_digitWidth, h, m_digitWidth, m_digitHeight), Qt::AlignCenter, m_text.mid(i, 1));
 
                 if ((m_text[i] != m_groupSeparator) && (m_text[i] != m_decSeparator))


### PR DESCRIPTION
This patch darkens ValueDials when disabled, to make it obvious to the user that they are disabled (i.e. when QWidget::setEnabled(false) is called).

![image](https://user-images.githubusercontent.com/57259258/178071228-487060d2-3670-45af-800d-7c6fe568fef6.png)
