### PR TITLE
SDRPlayInput: separate HW flavour from mirisdr_open

### DIFF
--- a/plugins/samplesource/sdrplay/sdrplayinput.cpp
+++ b/plugins/samplesource/sdrplay/sdrplayinput.cpp
@@ -103,9 +103,15 @@ bool SDRPlayInput::openDevice()
         return false;
     }
 
-    if ((res = mirisdr_open(&m_dev, MIRISDR_HW_SDRPLAY, m_devNumber)) < 0)
+    if ((res = mirisdr_open(&m_dev, m_devNumber)) < 0)
     {
         qCritical("SDRPlayInput::openDevice: could not open SDRPlay #%d: %s", m_devNumber, strerror(errno));
+        return false;
+    }
+    
+    if ((res = mirisdr_set_hw_flavour(m_dev, MIRISDR_HW_SDRPLAY)) < 0)
+    {
+        qCritical("SDRPlayInput::openDevice: failed to set HW flavour: %s", strerror(errno));
         return false;
     }
 


### PR DESCRIPTION
We broke SDRangel with https://github.com/f4exb/libmirisdr-4/commit/fd0452e31264f065bb315e74313384ca4a121ef1

I wasn't expecting any app to actually use the library with that argument in `mirisdr_open`.

Fixes #1340