### PR TITLE
DATV Demod: Add support for LDPC on Windows

### DIFF
--- a/plugins/channelrx/demoddatv/CMakeLists.txt
+++ b/plugins/channelrx/demoddatv/CMakeLists.txt
@@ -25,6 +25,7 @@ set(datv_SOURCES
 
 set(ldpc_SOURCES
     ldpctool/tables_handler.cpp
+    ldpctool/ldpcworker.cpp
 )
 
 set(datv_HEADERS
@@ -55,6 +56,7 @@ set(ldpc_HEADERS
     ldpctool/dvb_s2_tables.h
     ldpctool/dvb_s2x_tables.h
     ldpctool/dvb_t2_tables.h
+    ldpctool/ldpcworker.h
 )
 
 include_directories(
@@ -69,16 +71,10 @@ include_directories(
 set(TARGET_NAME demoddatv)
 set(INSTALL_FOLDER ${INSTALL_PLUGINS_DIR})
 
-if (LINUX)
-    add_library(${TARGET_NAME} SHARED
-        ${datv_SOURCES}
-        ${ldpc_SOURCES}
-    )
-else()
-    add_library(${TARGET_NAME} SHARED
-        ${datv_SOURCES}
-    )
-endif()
+add_library(${TARGET_NAME} SHARED
+    ${datv_SOURCES}
+    ${ldpc_SOURCES}
+)
 
 target_link_libraries(${TARGET_NAME}
     Qt5::Core
@@ -94,13 +90,11 @@ target_link_libraries(${TARGET_NAME}
     ${SWRESAMPLE_LIBRARIES}
 )
 
-if (LINUX)
-    add_executable(ldpctool
-        ldpctool/ldpc_tool.cpp
-        ldpctool/tables_handler.cpp
-    )
-    install(TARGETS ldpctool DESTINATION ${INSTALL_BIN_DIR})
-endif()
+add_executable(ldpctool
+    ldpctool/ldpc_tool.cpp
+    ldpctool/tables_handler.cpp
+)
+install(TARGETS ldpctool DESTINATION ${INSTALL_BIN_DIR})
 
 if(FFMPEG_EXTERNAL)
     add_dependencies(${TARGET_NAME} ffmpeg)

--- a/plugins/channelrx/demoddatv/datvdemodgui.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodgui.cpp
@@ -300,13 +300,8 @@ DATVDemodGUI::DATVDemodGUI(PluginAPI* objPluginAPI, DeviceUISet *deviceUISet, Ba
 	CRightClickEnabler *audioMuteRightClickEnabler = new CRightClickEnabler(ui->audioMute);
 	connect(audioMuteRightClickEnabler, SIGNAL(rightClick(const QPoint &)), this, SLOT(audioSelect()));
 
-#ifdef LINUX
     CRightClickEnabler *ldpcToolRightClickEnabler = new CRightClickEnabler(ui->softLDPC);
     connect(ldpcToolRightClickEnabler, SIGNAL(rightClick(const QPoint &)), this, SLOT(ldpcToolSelect()));
-#else
-    ui->softLDPC->setEnabled(false);
-    ui->softLDPC->setStyleSheet("QCheckBox { color: gray }");
-#endif
 
     ui->playerIndicator->setStyleSheet("QLabel { background-color: gray; border-radius: 8px; }");
     ui->udpIndicator->setStyleSheet("QLabel { background-color: gray; border-radius: 8px; }");
@@ -377,7 +372,6 @@ void DATVDemodGUI::displaySettings()
         ui->maxBitflipsLabel->setStyleSheet("QLabel { color: white }");
     }
 
-#ifdef LINUX
     if (m_settings.m_standard == DATVDemodSettings::dvb_version::DVB_S)
     {
         ui->softLDPC->setEnabled(false);
@@ -388,7 +382,6 @@ void DATVDemodGUI::displaySettings()
         ui->softLDPC->setEnabled(true);
         ui->softLDPC->setStyleSheet("QCheckBox { color: white }");
     }
-#endif
 
     if (m_settings.m_standard == DATVDemodSettings::dvb_version::DVB_S)
     {
@@ -658,7 +651,6 @@ void DATVDemodGUI::on_cmbStandard_currentIndexChanged(int index)
         ui->maxBitflipsLabel->setStyleSheet("QLabel { color: white }");
     }
 
-#ifdef LINUX
     if (m_settings.m_standard == DATVDemodSettings::dvb_version::DVB_S)
     {
         ui->softLDPC->setEnabled(false);
@@ -669,7 +661,6 @@ void DATVDemodGUI::on_cmbStandard_currentIndexChanged(int index)
         ui->softLDPC->setEnabled(true);
         ui->softLDPC->setStyleSheet("QCheckBox { color: white }");
     }
-#endif
 
     if (m_settings.m_standard == DATVDemodSettings::dvb_version::DVB_S)
     {
@@ -710,18 +701,14 @@ void DATVDemodGUI::on_cmbFEC_currentIndexChanged(int arg1)
 
 void DATVDemodGUI::on_softLDPC_clicked()
 {
-#ifdef LINUX
     m_settings.m_softLDPC = ui->softLDPC->isChecked();
     applySettings();
-#endif
 }
 
 void DATVDemodGUI::on_maxBitflips_valueChanged(int value)
 {
-#ifdef LINUX
     m_settings.m_maxBitflips = value;
     applySettings();
-#endif
 }
 
 void DATVDemodGUI::on_chkViterbi_clicked()

--- a/plugins/channelrx/demoddatv/datvdemodsettings.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodsettings.cpp
@@ -27,6 +27,12 @@
 
 #include "datvdemodsettings.h"
 
+#ifdef _MSC_VER
+#define DEFAULT_LDPCTOOLPATH "C:/Program Files/SDRangel/ldpctool.exe"
+#else
+#define DEFAULT_LDPCTOOLPATH "/opt/install/sdrangel/bin/ldpctool"
+#endif
+
 DATVDemodSettings::DATVDemodSettings() :
     m_channelMarker(nullptr),
     m_rollupState(nullptr)
@@ -44,7 +50,7 @@ void DATVDemodSettings::resetToDefaults()
     m_modulation = BPSK;
     m_fec = FEC12;
     m_softLDPC = false;
-    m_softLDPCToolPath = "/opt/install/sdrangel/bin/ldpctool";
+    m_softLDPCToolPath = DEFAULT_LDPCTOOLPATH;
     m_softLDPCMaxTrials = 8;
     m_maxBitflips = 0;
     m_symbolRate = 250000;
@@ -208,7 +214,7 @@ bool DATVDemodSettings::deserialize(const QByteArray& data)
 
         d.readBool(32, &m_softLDPC, false);
         d.readS32(33, &m_maxBitflips, 0);
-        d.readString(34, &m_softLDPCToolPath, "/opt/install/sdrangel/bin/ldpctool");
+        d.readString(34, &m_softLDPCToolPath, DEFAULT_LDPCTOOLPATH);
         d.readS32(35, &tmp, 8);
         m_softLDPCMaxTrials = tmp < 1 ? 1 : tmp > m_softLDPCMaxMaxTrials ? m_softLDPCMaxMaxTrials : tmp;
         d.readBool(36, &m_playerEnable, true);

--- a/plugins/channelrx/demoddatv/datvdvbs2ldpcdialog.cpp
+++ b/plugins/channelrx/demoddatv/datvdvbs2ldpcdialog.cpp
@@ -58,7 +58,11 @@ void DatvDvbS2LdpcDialog::on_showFileDialog_clicked(bool checked)
 
     QFileDialog fileDialog(this, "Select LDPC tool");
     fileDialog.setOption(QFileDialog::DontUseNativeDialog, true);
+#ifdef _MSC_VER
+    fileDialog.setNameFilter("*.exe");
+#else
     fileDialog.setFilter(QDir::Executable | QDir::Files);
+#endif
     fileDialog.selectFile(m_fileName);
 
     if (fileDialog.exec() == QDialog::Accepted)

--- a/plugins/channelrx/demoddatv/ldpctool/ldpc_tool.cpp
+++ b/plugins/channelrx/demoddatv/ldpctool/ldpc_tool.cpp
@@ -201,9 +201,6 @@ int main(int argc, char **argv)
 					code[(j + n) * CODE_LEN + i] = reinterpret_cast<ldpctool::code_type *>(simd + i)[n];
 		}
 
-		for (int i = 0; i < BLOCKS * CODE_LEN; ++i)
-			assert(!std::isnan(code[i]));
-
 		for (ssize_t pos = 0; pos < iosize;)
 		{
 			ssize_t nw = write(1, code + pos, iosize - pos);

--- a/plugins/channelrx/demoddatv/ldpctool/ldpc_tool.cpp
+++ b/plugins/channelrx/demoddatv/ldpctool/ldpc_tool.cpp
@@ -7,7 +7,14 @@ Copyright 2019 <pabr@pabr.org>
 */
 
 #include <stdlib.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#else
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#include <io.h>
+#include <malloc.h>
+#endif
 #include <iostream>
 #include <iomanip>
 #include <random>
@@ -20,6 +27,7 @@ Copyright 2019 <pabr@pabr.org>
 #include "testbench.h"
 #include "algorithms.h"
 #include "ldpc.h"
+
 
 #if 0
 #include "flooding_decoder.h"
@@ -129,7 +137,7 @@ int main(int argc, char **argv)
 
 	int BLOCKS = batch_size;
 	ldpctool::code_type *code = new ldpctool::code_type[BLOCKS * CODE_LEN];
-	void *aligned_buffer = aligned_alloc(sizeof(ldpctool::simd_type), sizeof(ldpctool::simd_type) * CODE_LEN);
+	void *aligned_buffer = ldpctool::LDPCUtil::aligned_malloc(sizeof(ldpctool::simd_type), sizeof(ldpctool::simd_type) * CODE_LEN);
 	ldpctool::simd_type *simd = reinterpret_cast<ldpctool::simd_type *>(aligned_buffer);
 
 	// Expect LLR values in int8_t format.
@@ -212,7 +220,7 @@ int main(int argc, char **argv)
 
 	delete ldpc;
 
-	free(aligned_buffer);
+	ldpctool::LDPCUtil::aligned_free(aligned_buffer);
 	delete[] code;
 
 	return 0;

--- a/plugins/channelrx/demoddatv/ldpctool/ldpcworker.cpp
+++ b/plugins/channelrx/demoddatv/ldpctool/ldpcworker.cpp
@@ -140,9 +140,6 @@ void LDPCWorker::process(QByteArray data)
                     m_code[(j + n) * m_codeLen + i] = reinterpret_cast<ldpctool::code_type *>(m_simd + i)[n];
         }
 
-        for (int i = 0; i < BLOCKS * m_codeLen; ++i)
-            assert(!std::isnan(m_code[i]));
-
         m_mutexOut.lock();
         for (int j = 0; j < BLOCKS; j++)
         {

--- a/plugins/channelrx/demoddatv/ldpctool/ldpcworker.cpp
+++ b/plugins/channelrx/demoddatv/ldpctool/ldpcworker.cpp
@@ -1,0 +1,159 @@
+/*
+LDPC testbench
+Copyright 2018 Ahmet Inan <xdsopl@gmail.com>
+
+Transformed into external decoder for third-party applications
+Copyright 2019 <pabr@pabr.org>
+
+Transformed again in to a Qt worker.
+*/
+
+#include <QDebug>
+
+#include <stdlib.h>
+#ifdef _MSC_VER
+#include <malloc.h>
+#endif
+#include <iostream>
+#include <iomanip>
+#include <random>
+#include <cmath>
+#include <cassert>
+#include <chrono>
+#include <cstring>
+#include <algorithm>
+#include <functional>
+#include "ldpcworker.h"
+
+LDPCWorker::LDPCWorker(int modcod, int maxTrials, int batchSize, bool shortFrames) :
+    m_maxTrials(maxTrials),
+    m_aligned_buffer(nullptr),
+    m_ldpc(nullptr),
+    m_code(nullptr),
+    m_simd(nullptr)
+{
+    // DVB-S2 MODCOD definitions
+    static const char *mc_tabnames[2][32] = { // [shortframes][modcod]
+                                             {// Normal frames
+                                              0, "B1", "B2", "B3", "B4", "B5", "B6", "B7",
+                                              "B8", "B9", "B10", "B11", "B5", "B6", "B7", "B9",
+                                              "B10", "B11", "B6", "B7", "B8", "B9", "B10", "B11",
+                                              "B7", "B8", "B8", "B10", "B11", 0, 0, 0},
+                                             {// Short frames
+                                              0, "C1", "C2", "C3", "C4", "C5", "C6", "C7",
+                                              "C8", "C9", "C10", 0, "C5", "C6", "C7", "C9",
+                                              "C10", 0, "C6", "C7", "C8", "C9", "C10", 0,
+                                              "C7", "C8", "C8", "C10", 0, 0, 0, 0}};
+
+    const char *tabname = mc_tabnames[shortFrames][modcod];
+    if (!tabname)
+    {
+        qCritical() << "LDPCWorker::LDPCWorker: unsupported modcod";
+        return;
+    }
+
+    m_ldpc = ldpctool::create_ldpc((char *)"S2", tabname[0], atoi(tabname + 1));
+
+    if (!m_ldpc)
+    {
+        qCritical() << "LDPCWorker::LDPCWorker: no such table!";
+        return;
+    }
+
+    m_codeLen = m_ldpc->code_len();
+    m_dataLen = m_ldpc->data_len();
+
+    m_decode.init(m_ldpc);
+
+    BLOCKS = batchSize;
+    m_code = new ldpctool::code_type[BLOCKS * m_codeLen];
+    m_aligned_buffer = ldpctool::LDPCUtil::aligned_malloc(sizeof(ldpctool::simd_type), sizeof(ldpctool::simd_type) * m_codeLen);
+    m_simd = reinterpret_cast<ldpctool::simd_type *>(m_aligned_buffer);
+
+    // Expect LLR values in int8_t format.
+    if (sizeof(ldpctool::code_type) != 1) {
+        qCritical() << "LDPCWorker::LDPCWorker: Unsupported code_type";
+    }
+}
+
+LDPCWorker::~LDPCWorker()
+{
+    m_condOut.wakeAll();
+    delete m_ldpc;
+
+    ldpctool::LDPCUtil::aligned_free(m_aligned_buffer);
+    delete[] m_code;
+}
+
+void LDPCWorker::process(QByteArray data)
+{
+    int trials_count = 0;
+    int max_count = 0;
+    int num_decodes = 0;
+
+    int iosize = m_codeLen * sizeof(*m_code);
+
+    m_mutexIn.lock();
+    m_dataIn.append(data);
+
+    if (m_dataIn.size() >= BLOCKS)
+    {
+        for (int j = 0; j < BLOCKS; j++)
+        {
+            QByteArray inputData = m_dataIn.takeAt(0);
+            memcpy(m_code + j * m_codeLen, inputData.data(), inputData.size());
+        }
+        m_mutexIn.unlock();
+
+        for (int j = 0; j < BLOCKS; j += ldpctool::SIMD_WIDTH)
+        {
+            int blocks = j + ldpctool::SIMD_WIDTH > BLOCKS ? BLOCKS - j : ldpctool::SIMD_WIDTH;
+
+            for (int n = 0; n < blocks; ++n)
+                for (int i = 0; i < m_codeLen; ++i)
+                    reinterpret_cast<ldpctool::code_type *>(m_simd + i)[n] = m_code[(j + n) * m_codeLen + i];
+
+            int count = m_decode(m_simd, m_simd + m_dataLen, m_maxTrials, blocks);
+            num_decodes++;
+
+            if (count < 0)
+            {
+                trials_count += m_maxTrials;
+                max_count++;
+            }
+            else
+            {
+                trials_count += m_maxTrials - count;
+            }
+
+            if (num_decodes == 20)
+            {
+                qDebug() << "ldpc_tool: trials: " << ((trials_count*100)/(num_decodes*m_maxTrials)) << "% max: "
+                        << ((max_count*100)/num_decodes) << "% at converging to a code word (max trials: " << m_maxTrials << ")";
+                trials_count = 0;
+                max_count = 0;
+                num_decodes = 0;
+            }
+
+            for (int n = 0; n < blocks; ++n)
+                for (int i = 0; i < m_codeLen; ++i)
+                    m_code[(j + n) * m_codeLen + i] = reinterpret_cast<ldpctool::code_type *>(m_simd + i)[n];
+        }
+
+        for (int i = 0; i < BLOCKS * m_codeLen; ++i)
+            assert(!std::isnan(m_code[i]));
+
+        m_mutexOut.lock();
+        for (int j = 0; j < BLOCKS; j++)
+        {
+            QByteArray outputData((const char *)m_code + j * m_codeLen, iosize);
+            m_dataOut.append(outputData);
+        }
+        m_condOut.wakeAll();
+        m_mutexOut.unlock();
+    }
+    else
+    {
+        m_mutexIn.unlock();
+    }
+}

--- a/plugins/channelrx/demoddatv/ldpctool/ldpcworker.h
+++ b/plugins/channelrx/demoddatv/ldpctool/ldpcworker.h
@@ -1,0 +1,94 @@
+///////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2022 Jon Beniston, M7RCE                                        //
+//                                                                               //
+// This program is free software; you can redistribute it and/or modify          //
+// it under the terms of the GNU General Public License as published by          //
+// the Free Software Foundation as version 3 of the License, or                  //
+// (at your option) any later version.                                           //
+//                                                                               //
+// This program is distributed in the hope that it will be useful,               //
+// but WITHOUT ANY WARRANTY; without even the implied warranty of                //
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                  //
+// GNU General Public License V3 for more details.                               //
+//                                                                               //
+// You should have received a copy of the GNU General Public License             //
+// along with this program. If not, see <http://www.gnu.org/licenses/>.          //
+///////////////////////////////////////////////////////////////////////////////////
+
+#include <QObject>
+#include <QByteArray>
+#include <QMutex>
+#include <QWaitCondition>
+
+#include "testbench.h"
+#include "algorithms.h"
+#include "ldpc.h"
+#include "layered_decoder.h"
+
+class LDPCWorker : public QObject {
+    Q_OBJECT
+
+public:
+    LDPCWorker(int modcod, int maxTrials, int batchSize, bool shortFrames);
+    ~LDPCWorker();
+
+    // Are we busy
+    bool busy()
+    {
+        QMutexLocker locker(&m_mutexIn);
+        return m_dataIn.size() >= BLOCKS;
+    }
+
+    // Is processed data available?
+    bool dataAvailable()
+    {
+        QMutexLocker locker(&m_mutexOut);
+        return !m_dataOut.isEmpty();
+    }
+
+    // Get processed data
+    QByteArray data()
+    {
+        m_mutexOut.lock();
+        if (m_dataOut.isEmpty()) {
+            m_condOut.wait(&m_mutexOut);
+        }
+        QByteArray data = m_dataOut.takeAt(0);
+        m_mutexOut.unlock();
+        return data;
+    }
+
+public slots:
+    void process(QByteArray data);
+
+signals:
+    void finished();
+
+private:
+    QMutex m_mutexIn;
+    QMutex m_mutexOut;
+    QWaitCondition m_condOut;
+    QList<QByteArray> m_dataIn;
+    QList<QByteArray> m_dataOut;
+    int m_maxTrials;
+    int BLOCKS;
+    int m_codeLen;
+    int m_dataLen;
+    void *m_aligned_buffer;
+
+    ldpctool::LDPCInterface *m_ldpc;
+    ldpctool::code_type *m_code;
+    ldpctool::simd_type *m_simd;
+
+    typedef ldpctool::NormalUpdate<ldpctool::simd_type> update_type;
+    //typedef SelfCorrectedUpdate<simd_type> update_type;
+
+    //typedef MinSumAlgorithm<simd_type, update_type> algorithm_type;
+    //typedef OffsetMinSumAlgorithm<simd_type, update_type, FACTOR> algorithm_type;
+    typedef ldpctool::MinSumCAlgorithm<ldpctool::simd_type, update_type, ldpctool::FACTOR> algorithm_type;
+    //typedef LogDomainSPA<simd_type, update_type> algorithm_type;
+    //typedef LambdaMinAlgorithm<simd_type, update_type, 3> algorithm_type;
+    //typedef SumProductAlgorithm<simd_type, update_type> algorithm_type;
+
+    ldpctool::LDPCDecoder<ldpctool::simd_type, algorithm_type> m_decode;
+};

--- a/plugins/channelrx/demoddatv/ldpctool/testbench.h
+++ b/plugins/channelrx/demoddatv/ldpctool/testbench.h
@@ -4,6 +4,8 @@ LDPC testbench
 Copyright 2018 Ahmet Inan <xdsopl@gmail.com>
 */
 
+#pragma once
+
 #include <cstdint>
 #include <complex>
 #include "simd.h"

--- a/plugins/channelrx/demoddatv/readme.md
+++ b/plugins/channelrx/demoddatv/readme.md
@@ -183,13 +183,11 @@ The controls specific to DVB-S are disabled and greyed out. These are: Fast Lock
 
 <h5>B.2b.6: DVB-S2 specific - Soft LDPC decoder</h5>
 
-This is for experimenters only working in Linux. It can be used to decode signals lower that ~10 db MER which is the limit of LDPC hard decoding as explained next (B.2b.7). Video degrades progressively down to about 7.5 dB MER and drops below this limit.
-
-Runs the `ldpctool` program for soft LDPC decoding. Frames are sent on its standard input and decoded frames retrieved from its standard output. Two processes executing `ldpctool` are spawned but so far it seems that only one is effectively used.
+It can be used to decode signals lower that ~10 db MER which is the limit of LDPC hard decoding as explained next (B.2b.7). Video degrades progressively down to about 7.5 dB MER and drops below this limit.
 
 Right clicking on this control opens a dialog where you can choose:
 
-  - The `ldpctool` executable. You have to use the `ldpctool` binary produced by the build of SDRangel.
+  - The `ldpctool` executable. Obsolete.
   - The maximum of retries in LDPC decoding from 1 to 8.
 
 <h5>B.2b.7: DVB-S2 specific - LDPC maximum number of bit flips allowed</h5>


### PR DESCRIPTION
This PR adds support for LDPC on Windows as per #1341. It does this by implementing ldpctool as a Qt worker thread instead of an external process. This can be used on Linux as well, avoiding the need for the ldpctool binary.

However, I've left the lpdctool path in the GUI & settings in case you wanted to make it optional which to use - but it could be removed, if you think this is the way to go. 

I don't really use this plugin, so have only done some basic testing on Linux and Windows. I think there's a DATV demod problem on Windows that can occasionally cause a crash, that isn't related to this change. Needs more investigation though.