### PR TITLE
Support open GL ES

### DIFF
--- a/sdrgui/gui/glshadercolormap.cpp
+++ b/sdrgui/gui/glshadercolormap.cpp
@@ -156,7 +156,11 @@ void GLShaderColorMap::drawSurfaceStrip(const QMatrix4x4& transformMatrix, GLflo
     QOpenGLFunctions *f = QOpenGLContext::currentContext()->functions();
     m_program->bind();
     m_program->setUniformValue(m_matrixLoc, transformMatrix);
-    m_colorMapTexture->bind();
+    if (m_useImmutableStorage) {
+        m_colorMapTexture->bind();
+    } else {
+        glBindTexture(GL_TEXTURE_2D, m_colorMapTextureId);
+    }
     m_program->setUniformValue(m_colorMapLoc, 0); // Texture unit 0 for color map
     m_program->setUniformValue(m_scaleLoc, scale);
     m_program->setUniformValue(m_alphaLoc, alpha);
@@ -242,7 +246,7 @@ bool GLShaderColorMap::useImmutableStorage()
 const QString GLShaderColorMap::m_vertexShaderSourceColorMap2 = QString(
         "uniform highp mat4 uMatrix;\n"
         "attribute highp vec4 vertex;\n"
-        "varying float y;\n"
+        "varying highp float y;\n"
         "void main() {\n"
         "    gl_Position = uMatrix * vertex;\n"
         "    y = vertex.y;\n"
@@ -261,10 +265,10 @@ const QString GLShaderColorMap::m_vertexShaderSourceColorMap = QString(
         );
 
 const QString GLShaderColorMap::m_fragmentShaderSourceColorMap2 = QString(
-        "uniform float alpha;\n"
-        "uniform float scale;\n"
+        "uniform highp float alpha;\n"
+        "uniform highp float scale;\n"
         "uniform highp sampler2D colorMap;\n"
-        "varying float y;\n"
+        "varying highp float y;\n"
         "void main() {\n"
         "    gl_FragColor = vec4(texture2D(colorMap, vec2(1.0-(y/scale), 0)).rgb, alpha);\n"
         "}\n"

--- a/sdrgui/gui/glshaderspectrogram.cpp
+++ b/sdrgui/gui/glshaderspectrogram.cpp
@@ -288,6 +288,7 @@ void GLShaderSpectrogram::initTexture(const QImage& image)
         initTextureMutable(image);
     }
     initGrid(image.width());
+    m_limit = 1.4f*1.0f/(float)image.height();
 }
 
 void GLShaderSpectrogram::initTextureImmutable(const QImage& image)
@@ -419,7 +420,7 @@ void GLShaderSpectrogram::drawSurface(SpectrumSettings::SpectrogramStyle style, 
     program->setUniformValue(m_dataTextureLoc, 0);         // set uniform to texture unit?
     program->setUniformValue(m_colorMapLoc, 1);
 
-    program->setUniformValue(m_limitLoc, 1.4f*1.0f/(float)(m_texture->height()));
+    program->setUniformValue(m_limitLoc, m_limit);
 
     if (style == SpectrumSettings::Outline)
     {
@@ -721,11 +722,11 @@ void GLShaderSpectrogram::applyPerspective(QMatrix4x4 &matrix)
 const QString GLShaderSpectrogram::m_vertexShader2 = QString(
     "attribute vec2 coord2d;\n"
     "varying vec4 coord;\n"
-    "varying float lightDistance;\n"
+    "varying highp float lightDistance;\n"
     "uniform mat4 textureTransform;\n"
     "uniform mat4 vertexTransform;\n"
     "uniform sampler2D dataTexture;\n"
-    "uniform float limit;\n"
+    "uniform highp float limit;\n"
     "uniform vec3 lightPos;\n"
     "void main(void) {\n"
     "   coord = textureTransform * vec4(clamp(coord2d, limit, 1.0-limit), 0, 1);\n"
@@ -810,11 +811,11 @@ const QString GLShaderSpectrogram::m_fragmentShaderShaded = QString(
     );
 
 const QString GLShaderSpectrogram::m_fragmentShaderSimple2 = QString(
-    "varying vec4 coord;\n"
-    "uniform float brightness;\n"
+    "varying highp vec4 coord;\n"
+    "uniform highp float brightness;\n"
     "uniform sampler2D colorMap;\n"
     "void main(void) {\n"
-    "    float factor;\n"
+    "    highp float factor;\n"
     "    if (gl_FrontFacing)\n"
     "        factor = 1.0;\n"
     "    else\n"

--- a/sdrgui/gui/glshaderspectrogram.h
+++ b/sdrgui/gui/glshaderspectrogram.h
@@ -81,6 +81,7 @@ private:
     unsigned int m_textureId;
     QOpenGLTexture *m_colorMapTexture;
     unsigned int m_colorMapTextureId;
+    float m_limit;
 
     QOpenGLShaderProgram *m_programForLocs;     // Which program the locations are for
     int m_coord2dLoc;


### PR DESCRIPTION
Use 2D textures with height 1, instead of 1D textures that aren't available in Open GL ES.

Specify float precision in shaders which seems to be required by ES.

Fix a crash when mutable textures are used.

Should help with #1359