### PR TITLE
Don't use pkg-config on MacOS when building rtlsdr libraries

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1067,10 +1067,10 @@ if (WIN32 OR APPLE)
         if (WIN32)
             set(LIBRTLSDR_LIBRARIES "${SDRANGEL_BINARY_LIB_DIR}/rtlsdr.lib" CACHE INTERNAL "")
             set(RTLSDR_LIBUSB_INCLUDE "${LIBUSB_INCLUDE_DIR}/libusb-1.0")
-            # Disable pkg-config to allow LIBUSB_INCLUDE_DIRS to be used
-            set(DISABLE_PKGCONFIG "-DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON")
         endif ()
-        # needs pkgconfig and libusb
+        # Disable pkg-config to allow LIBUSB_INCLUDE_DIRS to be used
+        set(DISABLE_PKGCONFIG "-DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON")
+        # needs libusb
         ExternalProject_Add(rtlsdr
                 GIT_REPOSITORY https://github.com/osmocom/rtl-sdr.git
                 GIT_TAG ${RTLSDR_TAG}


### PR DESCRIPTION
Should fix broken Mac build.