### PR TITLE
Lime - Partially implement #1389

### DIFF
--- a/plugins/samplesink/limesdroutput/limesdroutput.cpp
+++ b/plugins/samplesink/limesdroutput/limesdroutput.cpp
@@ -1066,11 +1066,12 @@ bool LimeSDROutput::applySettings(const LimeSDROutputSettings& settings, bool fo
 
         if (doCalibration)
         {
+            double bw = std::min((double)m_settings.m_devSampleRate, 2500000.0); // Min supported calibration bandwidth is 2.5MHz
             if (LMS_Calibrate(m_deviceShared.m_deviceParams->getDevice(),
                     LMS_CH_TX,
                     m_deviceShared.m_channel,
-                    m_settings.m_devSampleRate,
-                    0) < 0)
+                    bw,
+                    0) != 0)
             {
                 qCritical("LimeSDROutput::applySettings: calibration failed on Tx channel %d", m_deviceShared.m_channel);
             }

--- a/plugins/samplesink/limesdroutput/limesdroutputgui.cpp
+++ b/plugins/samplesink/limesdroutput/limesdroutputgui.cpp
@@ -151,8 +151,10 @@ void LimeSDROutputGUI::updateFrequencyLimits()
     m_limeSDROutput->getLORange(minF, maxF);
     qint64 minLimit = minF/1000 + deltaFrequency;
     qint64 maxLimit = maxF/1000 + deltaFrequency;
+    // Min freq is 30MHz - NCO must be used to go below this
+    qint64 minFreq = m_settings.m_ncoEnable ? 30000 + m_settings.m_ncoFrequency/1000 : 30000;
 
-    minLimit = minLimit < 0 ? 0 : minLimit > 9999999 ? 9999999 : minLimit;
+    minLimit = minLimit < minFreq ? minFreq : minLimit > 9999999 ? 9999999 : minLimit;
     maxLimit = maxLimit < 0 ? 0 : maxLimit > 9999999 ? 9999999 : maxLimit;
 
     qDebug("LimeSDROutputGUI::updateFrequencyLimits: delta: %lld min: %lld max: %lld", deltaFrequency, minLimit, maxLimit);
@@ -515,6 +517,7 @@ void LimeSDROutputGUI::on_centerFrequency_changed(quint64 value)
 void LimeSDROutputGUI::on_ncoFrequency_changed(qint64 value)
 {
     m_settings.m_ncoFrequency = value;
+    updateFrequencyLimits();
     setCenterFrequencyDisplay();
     sendSettings();
 }
@@ -522,6 +525,7 @@ void LimeSDROutputGUI::on_ncoFrequency_changed(qint64 value)
 void LimeSDROutputGUI::on_ncoEnable_toggled(bool checked)
 {
     m_settings.m_ncoEnable = checked;
+    updateFrequencyLimits();
     setCenterFrequencyDisplay();
     sendSettings();
 }

--- a/plugins/samplesink/limesdroutput/readme.md
+++ b/plugins/samplesink/limesdroutput/readme.md
@@ -64,6 +64,8 @@ Transmission latency depends essentially in the delay in the sample FIFO. The si
 
 This is the center frequency of transmission in kHz.
 
+The NCO must be enabled with a negative value in order to set this below 30MHz.
+
 <h3>3A: Center frequency units</h3>
 
 This is the center frequency units thus kHz (fixed)
@@ -170,6 +172,8 @@ The LMS7002M uses the same clock for both the ADCs and DACs therefore this sampl
 <h3>11: Tx hardware filter bandwidth</h3>
 
 This is the Tx hardware filter bandwidth in kHz in the LMS7002M device for the given channel. Boundaries are updated automatically but generally are from 5 to 130 MHz in 1 kHz steps. Use the wheels to adjust the value. Pressing shift simultaneously moves digit by 5 and pressing control moves it by 2.
+
+The filter is centered at the LO frequency, so if using the NCO to achieve frequencies below 30MHz, the filter bandwidth needs to be set wide enough for not only your desired signal but the offset from the 30MHz LO as well.
 
 <h3>12: TSP FIR filter toggle</h3>
 

--- a/plugins/samplesource/limesdrinput/limesdrinput.cpp
+++ b/plugins/samplesource/limesdrinput/limesdrinput.cpp
@@ -1227,11 +1227,12 @@ bool LimeSDRInput::applySettings(const LimeSDRInputSettings& settings, bool forc
 
         if (doCalibration)
         {
+            double bw = std::min((double)m_settings.m_devSampleRate, 2500000.0); // Min supported calibration bandwidth is 2.5MHz
             if (LMS_Calibrate(m_deviceShared.m_deviceParams->getDevice(),
                     LMS_CH_RX,
                     m_deviceShared.m_channel,
-                    m_settings.m_devSampleRate,
-                    0) < 0)
+                    bw,
+                    0) != 0)
             {
                 qCritical("LimeSDRInput::applySettings: calibration failed on Rx channel %d", m_deviceShared.m_channel);
             }

--- a/plugins/samplesource/limesdrinput/limesdrinputgui.cpp
+++ b/plugins/samplesource/limesdrinput/limesdrinputgui.cpp
@@ -262,8 +262,10 @@ void LimeSDRInputGUI::updateFrequencyLimits()
     m_limeSDRInput->getLORange(minF, maxF);
     qint64 minLimit = minF/1000 + deltaFrequency;
     qint64 maxLimit = maxF/1000 + deltaFrequency;
+    // Min freq is 30MHz - NCO must be used to go below this
+    qint64 minFreq = m_settings.m_ncoEnable ? 30000 + m_settings.m_ncoFrequency/1000 : 30000;
 
-    minLimit = minLimit < 0 ? 0 : minLimit > 9999999 ? 9999999 : minLimit;
+    minLimit = minLimit < minFreq ? minFreq : minLimit > 9999999 ? 9999999 : minLimit;
     maxLimit = maxLimit < 0 ? 0 : maxLimit > 9999999 ? 9999999 : maxLimit;
 
     qDebug("LimeSDRInputGUI::updateFrequencyLimits: delta: %lld min: %lld max: %lld", deltaFrequency, minLimit, maxLimit);
@@ -548,6 +550,7 @@ void LimeSDRInputGUI::on_centerFrequency_changed(quint64 value)
 void LimeSDRInputGUI::on_ncoFrequency_changed(qint64 value)
 {
     m_settings.m_ncoFrequency = value;
+    updateFrequencyLimits();
     setCenterFrequencyDisplay();
     sendSettings();
 }
@@ -555,6 +558,7 @@ void LimeSDRInputGUI::on_ncoFrequency_changed(qint64 value)
 void LimeSDRInputGUI::on_ncoEnable_toggled(bool checked)
 {
     m_settings.m_ncoEnable = checked;
+    updateFrequencyLimits();
     setCenterFrequencyDisplay();
     sendSettings();
 }

--- a/plugins/samplesource/limesdrinput/readme.md
+++ b/plugins/samplesource/limesdrinput/readme.md
@@ -24,6 +24,8 @@ The top and bottom bars of the device window are described [here](../../../sdrgu
 
 This is the center frequency of reception in kHz.
 
+The NCO must be enabled with a negative value in order to set this below 30MHz.
+
 <h4>1.2: Start/Stop</h4>
 
 Device start / stop button.
@@ -132,6 +134,8 @@ The LMS7002M uses the same clock for both the ADCs and DACs therefore this sampl
 <h4>7.1: Rx hardware filter bandwidth</h4>
 
 This is the Rx hardware filter bandwidth in kHz in the LMS7002M device for the given channel. Boundaries are updated automatically but generally are from 1.4 to 130 MHz in 1 kHz steps. Use the wheels to adjust the value. Pressing shift simultaneously moves digit by 5 and pressing control moves it by 2.
+
+The filter is centered at the LO frequency, so if using the NCO to achieve frequencies below 30MHz, the filter bandwidth needs to be set wide enough for not only your desired signal but the offset from the 30MHz LO as well.
 
 <h4>7.2: TSP FIR filter toggle</h4>
 


### PR DESCRIPTION
Handle LMS_Calibrate returning positive error values.
Set Lime minimum frequency in GUI to 30MHz+NCO freq.
Set minimum calibration bandwidth to 2.5MHz.