### PR TITLE
Add start/stop all devices in workspace button in toolbar. 

### DIFF
--- a/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
@@ -39,8 +39,7 @@ RTLSDRGui::RTLSDRGui(DeviceUISet *deviceUISet, QWidget* parent) :
 	m_forceSettings(true),
 	m_settings(),
     m_sampleRateMode(true),
-	m_sampleSource(0),
-	m_lastEngineState(DeviceAPI::StNotStarted)
+	m_sampleSource(0)
 {
     m_deviceUISet = deviceUISet;
     setAttribute(Qt::WA_DeleteOnClose, true);
@@ -60,8 +59,8 @@ RTLSDRGui::RTLSDRGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(openDeviceSettingsDialog(const QPoint &)));
 	connect(&m_updateTimer, SIGNAL(timeout()), this, SLOT(updateHardware()));
-	connect(&m_statusTimer, SIGNAL(timeout()), this, SLOT(updateStatus()));
-	m_statusTimer.start(500);
+	connect(deviceUISet->m_deviceAPI, &DeviceAPI::stateChanged, this, &RTLSDRGui::updateStatus);
+	updateStatus();
 
 	displaySettings();
     makeUIConnections();
@@ -426,28 +425,23 @@ void RTLSDRGui::updateStatus()
 {
     int state = m_deviceUISet->m_deviceAPI->state();
 
-    if(m_lastEngineState != state)
+    switch(state)
     {
-        switch(state)
-        {
-            case DeviceAPI::StNotStarted:
-                ui->startStop->setStyleSheet("QToolButton { background:rgb(79,79,79); }");
-                break;
-            case DeviceAPI::StIdle:
-                ui->startStop->setStyleSheet("QToolButton { background-color : blue; }");
-                break;
-            case DeviceAPI::StRunning:
-                ui->startStop->setStyleSheet("QToolButton { background-color : green; }");
-                break;
-            case DeviceAPI::StError:
-                ui->startStop->setStyleSheet("QToolButton { background-color : red; }");
-                QMessageBox::information(this, tr("Message"), m_deviceUISet->m_deviceAPI->errorMessage());
-                break;
-            default:
-                break;
-        }
-
-        m_lastEngineState = state;
+        case DeviceAPI::StNotStarted:
+            ui->startStop->setStyleSheet("QToolButton { background:rgb(79,79,79); }");
+            break;
+        case DeviceAPI::StIdle:
+            ui->startStop->setStyleSheet("QToolButton { background-color : blue; }");
+            break;
+        case DeviceAPI::StRunning:
+            ui->startStop->setStyleSheet("QToolButton { background-color : green; }");
+            break;
+        case DeviceAPI::StError:
+            ui->startStop->setStyleSheet("QToolButton { background-color : red; }");
+            QMessageBox::information(this, tr("Message"), m_deviceUISet->m_deviceAPI->errorMessage());
+            break;
+        default:
+            break;
     }
 }
 

--- a/plugins/samplesource/rtlsdr/rtlsdrgui.h
+++ b/plugins/samplesource/rtlsdr/rtlsdrgui.h
@@ -58,12 +58,10 @@ private:
 	RTLSDRSettings m_settings;
     bool m_sampleRateMode; //!< true: device, false: base band sample rate update mode
 	QTimer m_updateTimer;
-	QTimer m_statusTimer;
 	std::vector<int> m_gains;
 	RTLSDRInput* m_sampleSource;
     int m_sampleRate;
     quint64 m_deviceCenterFrequency; //!< Center frequency in device
-	int m_lastEngineState;
 	MessageQueue m_inputMessageQueue;
 
 	void displayGains();

--- a/sdrbase/device/deviceapi.cpp
+++ b/sdrbase/device/deviceapi.cpp
@@ -51,6 +51,15 @@ DeviceAPI::DeviceAPI(
     m_deviceSinkEngine(deviceSinkEngine),
     m_deviceMIMOEngine(deviceMIMOEngine)
 {
+    if (m_deviceSourceEngine) {
+        QObject::connect(m_deviceSourceEngine, &DSPDeviceSourceEngine::stateChanged, this, &DeviceAPI::engineStateChanged);
+    }
+    if (m_deviceSinkEngine) {
+        QObject::connect(m_deviceSinkEngine, &DSPDeviceSinkEngine::stateChanged, this, &DeviceAPI::engineStateChanged);
+    }
+    if (m_deviceMIMOEngine) {
+        QObject::connect(m_deviceMIMOEngine, &DSPDeviceMIMOEngine::stateChanged, this, &DeviceAPI::engineStateChanged);
+    }
 }
 
 DeviceAPI::~DeviceAPI()
@@ -825,4 +834,9 @@ void DeviceAPI::setDeviceSetIndex(int deviceSetIndex)
 {
     m_deviceTabIndex = deviceSetIndex;
     renumerateChannels();
+}
+
+void DeviceAPI::engineStateChanged()
+{
+    emit stateChanged(this);
 }

--- a/sdrbase/device/deviceapi.h
+++ b/sdrbase/device/deviceapi.h
@@ -212,5 +212,11 @@ protected:
 
 private:
     void renumerateChannels();
+
+private slots:
+    void engineStateChanged();
+
+signals:
+    void stateChanged(DeviceAPI *deviceAPI);
 };
 #endif // SDRBASE_DEVICE_DEVICEAPI_H_

--- a/sdrbase/dsp/dspdevicemimoengine.cpp
+++ b/sdrbase/dsp/dspdevicemimoengine.cpp
@@ -61,11 +61,29 @@ DSPDeviceMIMOEngine::~DSPDeviceMIMOEngine()
 	wait();
 }
 
+void DSPDeviceMIMOEngine::setStateRx(State state)
+{
+    if (m_stateRx != state)
+    {
+        m_stateRx = state;
+        emit stateChanged();
+    }
+}
+
+void DSPDeviceMIMOEngine::setStateTx(State state)
+{
+    if (m_stateTx != state)
+    {
+        m_stateTx = state;
+        emit stateChanged();
+    }
+}
+
 void DSPDeviceMIMOEngine::run()
 {
 	qDebug() << "DSPDeviceMIMOEngine::run";
-	m_stateRx = StIdle;
-    m_stateTx = StIdle;
+	setStateRx(StIdle);
+	setStateTx(StIdle);
 	exec();
 }
 
@@ -80,8 +98,8 @@ void DSPDeviceMIMOEngine::stop()
 	qDebug() << "DSPDeviceMIMOEngine::stop";
     gotoIdle(0); // Rx
     gotoIdle(1); // Tx
-    m_stateRx = StNotStarted;
-    m_stateTx = StNotStarted;
+    setStateRx(StNotStarted);
+    setStateTx(StNotStarted);
     QThread::exit();
 }
 
@@ -763,12 +781,12 @@ DSPDeviceMIMOEngine::State DSPDeviceMIMOEngine::gotoError(int subsystemIndex, co
     if (subsystemIndex == 0)
     {
     	m_errorMessageRx = errorMessage;
-	    m_stateRx = StError;
+	    setStateRx(StError);
     }
     else if (subsystemIndex == 1)
     {
     	m_errorMessageTx = errorMessage;
-	    m_stateTx = StError;
+	    setStateTx(StError);
     }
 
     return StError;
@@ -881,10 +899,10 @@ void DSPDeviceMIMOEngine::handleSynchronousMessages()
 
 	if (DSPAcquisitionInit::match(*message))
 	{
-		m_stateRx = gotoIdle(0);
+		setStateRx(gotoIdle(0));
 
 		if (m_stateRx == StIdle) {
-			m_stateRx = gotoInit(0); // State goes ready if init is performed
+			setStateRx(gotoInit(0)); // State goes ready if init is performed
 		}
 
         returnState = m_stateRx;
@@ -892,22 +910,22 @@ void DSPDeviceMIMOEngine::handleSynchronousMessages()
 	else if (DSPAcquisitionStart::match(*message))
 	{
 		if (m_stateRx == StReady) {
-			m_stateRx = gotoRunning(0);
+			setStateRx(gotoRunning(0));
 		}
 
         returnState = m_stateRx;
 	}
 	else if (DSPAcquisitionStop::match(*message))
 	{
-		m_stateRx = gotoIdle(0);
+		setStateRx(gotoIdle(0));
         returnState = m_stateRx;
 	}
     else if (DSPGenerationInit::match(*message))
 	{
-		m_stateTx = gotoIdle(1);
+		setStateTx(gotoIdle(1));
 
 		if (m_stateTx == StIdle) {
-			m_stateTx = gotoInit(1); // State goes ready if init is performed
+			setStateTx(gotoInit(1)); // State goes ready if init is performed
 		}
 
         returnState = m_stateTx;
@@ -915,14 +933,14 @@ void DSPDeviceMIMOEngine::handleSynchronousMessages()
 	else if (DSPGenerationStart::match(*message))
 	{
 		if (m_stateTx == StReady) {
-			m_stateTx = gotoRunning(1);
+			setStateTx(gotoRunning(1));
 		}
 
         returnState = m_stateTx;
 	}
 	else if (DSPGenerationStop::match(*message))
 	{
-		m_stateTx = gotoIdle(1);
+		setStateTx(gotoIdle(1));
         returnState = m_stateTx;
 	}
 	else if (GetMIMODeviceDescription::match(*message))

--- a/sdrbase/dsp/dspdevicemimoengine.h
+++ b/sdrbase/dsp/dspdevicemimoengine.h
@@ -350,6 +350,8 @@ private:
 	State gotoInit(int subsystemIndex);     //!< Go to the acquisition init state from idle
 	State gotoRunning(int subsystemIndex);  //!< Go to the running state from ready state
 	State gotoError(int subsystemIndex, const QString& errorMsg); //!< Go to an error state
+	void setStateRx(State state);
+	void setStateTx(State state);
 
     void handleSetMIMO(DeviceSampleMIMO* mimo); //!< Manage MIMO device setting
    	void iqCorrections(SampleVector::iterator begin, SampleVector::iterator end, int isource, bool imbalanceCorrection);
@@ -361,6 +363,9 @@ private slots:
 	void handleDataTxAsync(int streamIndex); //!< Handle data when Tx samples have to be processed asynchronously
 	void handleSynchronousMessages();  //!< Handle synchronous messages with the thread
 	void handleInputMessages();        //!< Handle input message queue
+
+signals:
+	void stateChanged();
 };
 
 #endif // SDRBASE_DSP_DSPDEVICEMIMOENGINE_H_

--- a/sdrbase/dsp/dspdevicesinkengine.cpp
+++ b/sdrbase/dsp/dspdevicesinkengine.cpp
@@ -50,10 +50,19 @@ DSPDeviceSinkEngine::~DSPDeviceSinkEngine()
 	wait();
 }
 
+void DSPDeviceSinkEngine::setState(State state)
+{
+    if (m_state != state)
+    {
+        m_state = state;
+        emit stateChanged();
+    }
+}
+
 void DSPDeviceSinkEngine::run()
 {
 	qDebug() << "DSPDeviceSinkEngine::run";
-	m_state = StIdle;
+	setState(StIdle);
 	exec();
 }
 
@@ -67,7 +76,7 @@ void DSPDeviceSinkEngine::stop()
 {
 	qDebug() << "DSPDeviceSinkEngine::stop";
     gotoIdle();
-    m_state = StNotStarted;
+    setState(StNotStarted);
     QThread::exit();
 //	DSPExit cmd;
 //	m_syncMessenger.sendWait(cmd);
@@ -388,7 +397,7 @@ DSPDeviceSinkEngine::State DSPDeviceSinkEngine::gotoError(const QString& errorMe
 
 	m_errorMessage = errorMessage;
 	m_deviceDescription.clear();
-	m_state = StError;
+	setState(StError);
 	return StError;
 }
 
@@ -426,21 +435,21 @@ void DSPDeviceSinkEngine::handleSynchronousMessages()
 
 	if (DSPGenerationInit::match(*message))
 	{
-		m_state = gotoIdle();
+		setState(gotoIdle());
 
 		if(m_state == StIdle) {
-			m_state = gotoInit(); // State goes ready if init is performed
+			setState(gotoInit()); // State goes ready if init is performed
 		}
 	}
 	else if (DSPGenerationStart::match(*message))
 	{
 		if(m_state == StReady) {
-			m_state = gotoRunning();
+			setState(gotoRunning());
 		}
 	}
 	else if (DSPGenerationStop::match(*message))
 	{
-		m_state = gotoIdle();
+		setState(gotoIdle());
 	}
 	else if (DSPGetSinkDeviceDescription::match(*message))
 	{

--- a/sdrbase/dsp/dspdevicesinkengine.h
+++ b/sdrbase/dsp/dspdevicesinkengine.h
@@ -113,6 +113,7 @@ private:
 	State gotoInit();     //!< Go to the acquisition init state from idle
 	State gotoRunning();  //!< Go to the running state from ready state
 	State gotoError(const QString& errorMsg); //!< Go to an error state
+	void setState(State state);
 
 	void handleSetSink(DeviceSampleSink* sink); //!< Manage sink setting
 
@@ -120,6 +121,9 @@ private slots:
 	void handleData(); //!< Handle data when samples have to be written to the sample FIFO
 	void handleInputMessages(); //!< Handle input message queue
 	void handleSynchronousMessages(); //!< Handle synchronous messages with the thread
+
+signals:
+	void stateChanged();
 };
 
 

--- a/sdrbase/dsp/dspdevicesourceengine.cpp
+++ b/sdrbase/dsp/dspdevicesourceengine.cpp
@@ -55,10 +55,19 @@ DSPDeviceSourceEngine::~DSPDeviceSourceEngine()
     wait();
 }
 
+void DSPDeviceSourceEngine::setState(State state)
+{
+    if (m_state != state)
+    {
+        m_state = state;
+        emit stateChanged();
+    }
+}
+
 void DSPDeviceSourceEngine::run()
 {
 	qDebug() << "DSPDeviceSourceEngine::run";
-	m_state = StIdle;
+	setState(StIdle);
     exec();
 }
 
@@ -72,7 +81,7 @@ void DSPDeviceSourceEngine::stop()
 {
 	qDebug() << "DSPDeviceSourceEngine::stop";
     gotoIdle();
-    m_state = StNotStarted;
+    setState(StNotStarted);
 	QThread::exit();
 //	DSPExit cmd;
 //	m_syncMessenger.sendWait(cmd);
@@ -508,7 +517,7 @@ DSPDeviceSourceEngine::State DSPDeviceSourceEngine::gotoError(const QString& err
 
 	m_errorMessage = errorMessage;
 	m_deviceDescription.clear();
-	m_state = StError;
+	setState(StError);
 	return StError;
 }
 
@@ -549,21 +558,21 @@ void DSPDeviceSourceEngine::handleSynchronousMessages()
 
 	if (DSPAcquisitionInit::match(*message))
 	{
-		m_state = gotoIdle();
+		setState(gotoIdle());
 
 		if(m_state == StIdle) {
-			m_state = gotoInit(); // State goes ready if init is performed
+			setState(gotoInit()); // State goes ready if init is performed
 		}
 	}
 	else if (DSPAcquisitionStart::match(*message))
 	{
 		if(m_state == StReady) {
-			m_state = gotoRunning();
+			setState(gotoRunning());
 		}
 	}
 	else if (DSPAcquisitionStop::match(*message))
 	{
-		m_state = gotoIdle();
+		setState(gotoIdle());
 	}
 	else if (DSPGetSourceDeviceDescription::match(*message))
 	{

--- a/sdrbase/dsp/dspdevicesourceengine.h
+++ b/sdrbase/dsp/dspdevicesourceengine.h
@@ -134,6 +134,7 @@ private:
 	State gotoInit();     //!< Go to the acquisition init state from idle
 	State gotoRunning();  //!< Go to the running state from ready state
 	State gotoError(const QString& errorMsg); //!< Go to an error state
+	void setState(State state);
 
 	void handleSetSource(DeviceSampleSource* source); //!< Manage source setting
 
@@ -141,6 +142,9 @@ private slots:
 	void handleData(); //!< Handle data when samples from source FIFO are ready to be processed
 	void handleInputMessages(); //!< Handle input message queue
 	void handleSynchronousMessages(); //!< Handle synchronous messages with the thread
+
+signals:
+	void stateChanged();
 };
 
 #endif // INCLUDE_DSPDEVICEENGINE_H

--- a/sdrbase/maincore.h
+++ b/sdrbase/maincore.h
@@ -886,6 +886,7 @@ public:
 signals:
     void deviceSetAdded(int index, DeviceAPI *device);
     void deviceChanged(int index);
+    void deviceStateChanged(int index, DeviceAPI *device);
     void deviceSetRemoved(int index);
     void channelAdded(int deviceSetIndex, ChannelAPI *channel);
     void channelRemoved(int deviceSetIndex, ChannelAPI *oldChannel);

--- a/sdrgui/gui/workspace.h
+++ b/sdrgui/gui/workspace.h
@@ -23,6 +23,7 @@
 
 #include "export.h"
 #include "featureadddialog.h"
+#include "device/deviceapi.h"
 
 class QHBoxLayout;
 class QLabel;
@@ -61,12 +62,14 @@ public:
     void orderByIndex(QList<DeviceGUI *> &list);
     void orderByIndex(QList<MainSpectrumGUI *> &list);
     void adjustSubWindowsAfterRestore();
+    void updateStartStopButton(bool checked);
 
 private:
     int m_index;
     QPushButton *m_addRxDeviceButton;
     QPushButton *m_addTxDeviceButton;
     QPushButton *m_addMIMODeviceButton;
+    ButtonSwitch *m_startStopButton;
     QFrame *m_vline1;
     QPushButton *m_addFeatureButton;
     QPushButton *m_featurePresetsButton;
@@ -99,8 +102,10 @@ private slots:
     void tileSubWindows();
     void stackSubWindows();
     void autoStackSubWindows();
+    void startStopClicked(bool checked = false);
     void addFeatureEmitted(int featureIndex);
     void toggleFloating();
+    void deviceStateChanged(int index, DeviceAPI *deviceAPI);
 
 signals:
     void addRxDevice(Workspace *inWorkspace, int deviceIndex);
@@ -108,6 +113,8 @@ signals:
     void addMIMODevice(Workspace *inWorkspace, int deviceIndex);
     void addFeature(Workspace*, int);
     void featurePresetsDialogRequested(QPoint, Workspace*);
+    void startAllDevices(Workspace *inWorkspace);
+    void stopAllDevices(Workspace *inWorkspace);
 };
 
 

--- a/sdrgui/mainwindow.h
+++ b/sdrgui/mainwindow.h
@@ -203,7 +203,10 @@ private slots:
     void channelAddClicked(Workspace *workspace, int deviceSetIndex, int channelPluginIndex);
     void featureAddClicked(Workspace *workspace, int featureIndex);
     void featureMove(FeatureGUI *gui, int wsIndexDestnation);
+    void deviceStateChanged(DeviceAPI *deviceAPI);
     void openFeaturePresetsDialog(QPoint p, Workspace *workspace);
+    void startAllDevices(Workspace *workspace);
+    void stopAllDevices(Workspace *workspace);
     void deviceMove(DeviceGUI *gui, int wsIndexDestnation);
     void mainSpectrumMove(MainSpectrumGUI *gui, int wsIndexDestnation);
     void mainSpectrumShow(int deviceSetIndex);


### PR DESCRIPTION
This PR is to primarily add a "start/stop all devices in workspace" button, to the workspace toolbar. 

![image](https://user-images.githubusercontent.com/57259258/187032141-a17c1002-981b-42d9-9866-51a5c7308662.png)


I find this useful in a couple of cases:

- When recording/playing back data from multiple devices, it helps to sync them in time. (Not perfect, but better than by clicking start individually)
- For some modes, device settings don't need to be adjusted, so the device GUI can be hidden after setup - but start/stop button is still needed. Having it on the toolbar allows device GUI space to be used for something else.
- As with the latency example on the mailing list the other day, it can be useful to stop all devices at the same time to compare spectra.

In order to keep the state / colour of the toolbar button consistent with the state of the devices, I have added a signal in the device API (stateChanged) that is emitted whenever the device state changes.

This signal can also be used to eliminate the state polling that currently uses a timer in the device GUIs. Just as an example, I've updated the RTL SDR GUI to use this. If you think this patch is OK, then I can update some of the others to work the same.

