### PR TITLE
Lime: Implement #1389

### DIFF
--- a/plugins/samplesink/limesdroutput/limesdroutput.h
+++ b/plugins/samplesink/limesdroutput/limesdroutput.h
@@ -79,6 +79,25 @@ public:
         { }
     };
 
+    class MsgCalibrationResult : public Message {
+        MESSAGE_CLASS_DECLARATION
+
+    public:
+        bool getSuccess() const { return m_success; }
+
+        static MsgCalibrationResult* create(bool success) {
+            return new MsgCalibrationResult(success);
+        }
+
+    protected:
+        bool m_success;
+
+        MsgCalibrationResult(bool success) :
+            Message(),
+            m_success(success)
+        { }
+    };
+
     class MsgGetStreamInfo : public Message {
         MESSAGE_CLASS_DECLARATION
 

--- a/plugins/samplesink/limesdroutput/limesdroutputgui.h
+++ b/plugins/samplesink/limesdroutput/limesdroutputgui.h
@@ -73,6 +73,7 @@ private:
     void setCenterFrequencySetting(uint64_t kHzValue);
     void sendSettings();
     void updateSampleRateAndFrequency();
+    void checkLPF();
     void updateDACRate();
     void updateFrequencyLimits();
     void blockApplySettings(bool block);

--- a/plugins/samplesink/limesdroutput/limesdroutputgui.ui
+++ b/plugins/samplesink/limesdroutput/limesdroutputgui.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>360</width>
-    <height>209</height>
+    <height>230</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="minimumSize">
    <size>
     <width>360</width>
-    <height>209</height>
+    <height>230</height>
    </size>
   </property>
   <property name="maximumSize">
@@ -832,6 +832,19 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="calibrationLabel">
+       <property name="toolTip">
+        <string>Red if calibration failed (check log for error)</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background:rgb(79,79,79);</string>
+       </property>
+       <property name="text">
+        <string>C</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="streamLinkRateText">
        <property name="minimumSize">
         <size>
@@ -935,12 +948,6 @@ QToolTip{background-color: white; color: black;}</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ValueDial</class>
-   <extends>QWidget</extends>
-   <header>gui/valuedial.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>ButtonSwitch</class>
    <extends>QToolButton</extends>
    <header>gui/buttonswitch.h</header>
@@ -949,6 +956,12 @@ QToolTip{background-color: white; color: black;}</string>
    <class>ValueDialZ</class>
    <extends>QWidget</extends>
    <header>gui/valuedialz.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ValueDial</class>
+   <extends>QWidget</extends>
+   <header>gui/valuedial.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/plugins/samplesink/limesdroutput/readme.md
+++ b/plugins/samplesink/limesdroutput/readme.md
@@ -202,6 +202,7 @@ This label turns green when status can be obtained from the current stream. Usua
   - **U**: turns red if stream experiences underruns
   - **O**: turns red if stream experiences overruns
   - **P**: turns red if stream experiences packet drop outs
+  - **C**: turns red if calibration fails
 
 <h3>18: Stream global (all Tx) throughput in MB/s</h3>
 

--- a/plugins/samplesource/fileinput/fileinputgui.h
+++ b/plugins/samplesource/fileinput/fileinputgui.h
@@ -77,6 +77,7 @@ private:
 	void displayTime();
 	void sendSettings();
     void updateSampleRateAndFrequency();
+    void checkLPF();
 	void configureFileName();
 	void updateWithAcquisition();
 	void updateWithStreamData();

--- a/plugins/samplesource/limesdrinput/limesdrinput.h
+++ b/plugins/samplesource/limesdrinput/limesdrinput.h
@@ -184,6 +184,25 @@ public:
         { }
     };
 
+    class MsgCalibrationResult : public Message {
+        MESSAGE_CLASS_DECLARATION
+
+    public:
+        bool getSuccess() const { return m_success; }
+
+        static MsgCalibrationResult* create(bool success) {
+            return new MsgCalibrationResult(success);
+        }
+
+    protected:
+        bool m_success;
+
+        MsgCalibrationResult(bool success) :
+            Message(),
+            m_success(success)
+        { }
+    };
+
     LimeSDRInput(DeviceAPI *deviceAPI);
     virtual ~LimeSDRInput();
     virtual void destroy();

--- a/plugins/samplesource/limesdrinput/limesdrinputgui.h
+++ b/plugins/samplesource/limesdrinput/limesdrinputgui.h
@@ -72,6 +72,7 @@ private:
     void setCenterFrequencySetting(uint64_t kHzValue);
     void sendSettings();
     void updateSampleRateAndFrequency();
+    void checkLPF();
     void updateADCRate();
     void updateFrequencyLimits();
     void blockApplySettings(bool block);

--- a/plugins/samplesource/limesdrinput/limesdrinputgui.ui
+++ b/plugins/samplesource/limesdrinput/limesdrinputgui.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>370</width>
-    <height>209</height>
+    <width>360</width>
+    <height>230</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -18,13 +18,13 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>370</width>
-    <height>209</height>
+    <width>360</width>
+    <height>230</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>390</width>
+    <width>380</width>
     <height>266</height>
    </size>
   </property>
@@ -135,7 +135,6 @@
         <font>
          <family>Liberation Mono</family>
          <pointsize>16</pointsize>
-         <weight>50</weight>
          <bold>false</bold>
         </font>
        </property>
@@ -248,7 +247,6 @@
         <font>
          <family>Liberation Mono</family>
          <pointsize>12</pointsize>
-         <weight>50</weight>
          <bold>false</bold>
         </font>
        </property>
@@ -374,7 +372,6 @@
         <font>
          <family>Liberation Mono</family>
          <pointsize>12</pointsize>
-         <weight>50</weight>
          <bold>false</bold>
         </font>
        </property>
@@ -565,7 +562,6 @@
         <font>
          <family>Liberation Mono</family>
          <pointsize>12</pointsize>
-         <weight>50</weight>
          <bold>false</bold>
         </font>
        </property>
@@ -1058,6 +1054,19 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="calibrationLabel">
+       <property name="toolTip">
+        <string>Red if calibration failed (check log for error)</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background:rgb(79,79,79);</string>
+       </property>
+       <property name="text">
+        <string>C</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="streamLinkRateText">
        <property name="minimumSize">
         <size>
@@ -1164,12 +1173,6 @@ QToolTip{background-color: white; color: black;}</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ValueDial</class>
-   <extends>QWidget</extends>
-   <header>gui/valuedial.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>ButtonSwitch</class>
    <extends>QToolButton</extends>
    <header>gui/buttonswitch.h</header>
@@ -1178,6 +1181,12 @@ QToolTip{background-color: white; color: black;}</string>
    <class>ValueDialZ</class>
    <extends>QWidget</extends>
    <header>gui/valuedialz.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ValueDial</class>
+   <extends>QWidget</extends>
+   <header>gui/valuedial.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/plugins/samplesource/limesdrinput/readme.md
+++ b/plugins/samplesource/limesdrinput/readme.md
@@ -195,6 +195,7 @@ This label turns green when status can be obtained from the current stream. Usua
   - **U**: turns red if stream experiences underruns
   - **O**: turns red if stream experiences overruns
   - **P**: turns red if stream experiences packet drop outs
+  - **C**: turns red if calibration fails
 
 <h3>12: Stream global (all Rx) throughput in MB/s</h3>
 


### PR DESCRIPTION
Implements #1389

Indicates calibration errors in GUI via 'C' label. 
Makes LPF BW label background red if setting is not reasonable for up/downconversion using NCO.
Size of device windows tweaked slightly so that the start/stop button isn't squashed.
