### PR TITLE
Use grey text for disabled widgets

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -73,6 +73,10 @@ static int runQtApplication(int argc, char* argv[], qtwebapp::LoggerWithFile *lo
 	palette.setColor(QPalette::LinkVisited, QColor(0,0xa0,0xa0).lighter());
 	palette.setColor(QPalette::Highlight, QColor(0xff, 0x8c, 0x00));
 	palette.setColor(QPalette::HighlightedText, Qt::black);
+
+	palette.setColor(QPalette::Disabled, QPalette::WindowText, Qt::gray);
+	palette.setColor(QPalette::Disabled, QPalette::Text, Qt::gray);
+	palette.setColor(QPalette::Disabled, QPalette::ButtonText, Qt::gray);
 	qApp->setPalette(palette);
 
 #if 0


### PR DESCRIPTION
This PR uses grey text for disabled widgets, which I think makes it a bit clearer that they are disabled.

Example:

![image](https://user-images.githubusercontent.com/57259258/188614278-7a46e679-bf47-44ff-b59e-99968de3e0e8.png)
