### PR TITLE
Stack workspace: Use full width for spectrum when no channels

### DIFF
--- a/sdrgui/gui/workspace.cpp
+++ b/sdrgui/gui/workspace.cpp
@@ -467,7 +467,7 @@ void Workspace::stackSubWindows()
     }
 
     // Calculate width & height needed for channels
-    int channelMinWidth = m_userChannelMinWidth;
+    int channelMinWidth = channels.size() > 0 ? m_userChannelMinWidth : 0;
     int channelTotalMinHeight = 0;
     int expandingChannels = 0;
     for (auto window : channels)


### PR DESCRIPTION
Small fix to use the full space for spectrum / features when all re-sized channels have been removed from the workspace