### PR TITLE
Fix crash on exit

### DIFF
--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -245,6 +245,7 @@ MainWindow::~MainWindow()
 {
 	qDebug() << "MainWindow::~MainWindow";
 
+    m_statusTimer.stop();
     m_mainCore->m_settings.save();
     m_apiServer->stop();
     delete m_apiServer;


### PR DESCRIPTION
Debug builds on Windows are raising an exception on exit, in MainWindow::updateStatus().

This patch stops the status timer in the destructor, so updateStatus() isn't called on deleted objects, which seems to be the problem.