### PR TITLE
fix cmake syntax warning, separate token by whitespace

### DIFF
--- a/cmake/cpack/CMakeLists.txt
+++ b/cmake/cpack/CMakeLists.txt
@@ -216,7 +216,7 @@ elseif(WIN32 OR MINGW)
   if(BUILD_GUI)
     install(CODE "
       include(BundleUtilities)
-      # BundleUtilities.cmake verify_app fails unless we ignore QtWebEngineProcess.exe, as it fails if there are any "external" prerequisites
+      # BundleUtilities.cmake verify_app fails unless we ignore QtWebEngineProcess.exe, as it fails if there are any " external " prerequisites
       # Should we ignore it? It appears to work OK if we do. Is there a better way?
       fixup_bundle(\"${SDRANGEL_BINARY_BIN_DIR}/sdrangel${CMAKE_EXECUTABLE_SUFFIX}\" \"\" \"${WINDOWS_FIXUP_BUNDLE_LIB_DIRS}\" IGNORE_ITEM \"QtWebEngineProcess.exe\")
     " COMPONENT Runtime)


### PR DESCRIPTION
Just reduce the noise during `cmake` run

Resolves `Argument not separated from preceding token by whitespace.` warning.