### PR TITLE
Replace deprecated QMutex(Recursive) with QRecursiveMutex

### DIFF
--- a/logging/logger.cpp
+++ b/logging/logger.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <QMutex>
+#include <QRecursiveMutex>
 #include <QDateTime>
 #include <QThread>
 #include <QObject>
@@ -19,7 +20,7 @@ Logger* Logger::defaultLogger=0;
 QThreadStorage<QHash<QString,QString>*> Logger::logVars;
 
 
-QMutex Logger::mutex;
+QRecursiveMutex Logger::mutex;
 
 
 Logger::Logger(QObject* parent)
@@ -43,8 +44,8 @@ Logger::Logger(const QString msgFormat, const QString timestampFormat, const QtM
 
 void Logger::msgHandler(const QtMsgType type, const QString &message, const QString &file, const QString &function, const int line)
 {
-    static QMutex recursiveMutex(QMutex::Recursive);
-    static QMutex nonRecursiveMutex(QMutex::NonRecursive);
+    static QRecursiveMutex recursiveMutex;
+    static QMutex nonRecursiveMutex;
 
     // Prevent multiple threads from calling this method simultaneoulsy.
     // But allow recursive calls, which is required to prevent a deadlock

--- a/logging/logger.h
+++ b/logging/logger.h
@@ -10,7 +10,7 @@
 #include <QThreadStorage>
 #include <QHash>
 #include <QStringList>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QObject>
 #include "logglobal.h"
 #include "logmessage.h"
@@ -139,7 +139,7 @@ protected:
     int bufferSize;
 
     /** Used to synchronize access of concurrent threads */
-    static QMutex mutex;
+    static QRecursiveMutex mutex;
 
     /**
       Decorate and write a log message to stderr. Override this method

--- a/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodbaseband.cpp
+++ b/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodbaseband.cpp
@@ -27,8 +27,7 @@
 MESSAGE_CLASS_DEFINITION(BeamSteeringCWModBaseband::MsgConfigureBeamSteeringCWModBaseband, Message)
 MESSAGE_CLASS_DEFINITION(BeamSteeringCWModBaseband::MsgSignalNotification, Message)
 
-BeamSteeringCWModBaseband::BeamSteeringCWModBaseband() :
-    m_mutex(QMutex::Recursive)
+BeamSteeringCWModBaseband::BeamSteeringCWModBaseband()
 {
     m_sampleMOFifo.init(2, SampleMOFifo::getSizePolicy(48000));
     m_vbegin.resize(2);

--- a/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodbaseband.h
+++ b/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_BEAMSTEERINGCWMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplemofifo.h"
 #include "util/message.h"
@@ -93,7 +93,7 @@ private:
     UpChannelizer *m_channelizers[2];
     BeamSteeringCWModStreamSource m_streamSources[2];
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     unsigned int m_lastStream;
 
 private slots:

--- a/plugins/channelmimo/doa2/doa2baseband.cpp
+++ b/plugins/channelmimo/doa2/doa2baseband.cpp
@@ -42,8 +42,7 @@ DOA2Baseband::DOA2Baseband(int fftSize) :
     m_magThreshold(0.0f),
     m_fftAvg(1),
     m_fftAvgCount(0),
-    m_scopeSink(nullptr),
-    m_mutex(QMutex::Recursive)
+    m_scopeSink(nullptr)
 {
     m_sampleMIFifo.init(2, 96000 * 8);
     m_vbegin.resize(2);

--- a/plugins/channelmimo/doa2/doa2baseband.h
+++ b/plugins/channelmimo/doa2/doa2baseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_DOA2BASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplemififo.h"
 #include "util/messagequeue.h"
@@ -137,7 +137,7 @@ private:
     DownChannelizer *m_channelizers[2];
     ScopeVis *m_scopeSink;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     unsigned int m_lastStream;
 
 private slots:

--- a/plugins/channelmimo/interferometer/interferometerbaseband.cpp
+++ b/plugins/channelmimo/interferometer/interferometerbaseband.cpp
@@ -33,8 +33,7 @@ MESSAGE_CLASS_DEFINITION(InterferometerBaseband::MsgConfigureCorrelation, Messag
 InterferometerBaseband::InterferometerBaseband(int fftSize) :
     m_correlator(fftSize),
     m_spectrumSink(nullptr),
-    m_scopeSink(nullptr),
-    m_mutex(QMutex::Recursive)
+    m_scopeSink(nullptr)
 {
     m_sampleMIFifo.init(2, 96000 * 8);
     m_vbegin.resize(2);

--- a/plugins/channelmimo/interferometer/interferometerbaseband.h
+++ b/plugins/channelmimo/interferometer/interferometerbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_INTERFEROMETERBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplemififo.h"
 #include "util/messagequeue.h"
@@ -126,7 +126,7 @@ private:
     BasebandSampleSink *m_spectrumSink;
     ScopeVis *m_scopeSink;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     unsigned int m_lastStream;
 
 private slots:

--- a/plugins/channelrx/chanalyzer/chanalyzerbaseband.cpp
+++ b/plugins/channelrx/chanalyzer/chanalyzerbaseband.cpp
@@ -26,8 +26,7 @@
 MESSAGE_CLASS_DEFINITION(ChannelAnalyzerBaseband::MsgConfigureChannelAnalyzerBaseband, Message)
 
 ChannelAnalyzerBaseband::ChannelAnalyzerBaseband() :
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("ChannelAnalyzerBaseband::ChannelAnalyzerBaseband");
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));

--- a/plugins/channelrx/chanalyzer/chanalyzerbaseband.h
+++ b/plugins/channelrx/chanalyzer/chanalyzerbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_CHANNELANALYZERBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -81,7 +81,7 @@ private:
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     ChannelAnalyzerSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const ChannelAnalyzerSettings& settings, bool force = false);

--- a/plugins/channelrx/demodadsb/adsbdemodbaseband.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodbaseband.cpp
@@ -27,8 +27,7 @@
 
 MESSAGE_CLASS_DEFINITION(ADSBDemodBaseband::MsgConfigureADSBDemodBaseband, Message)
 
-ADSBDemodBaseband::ADSBDemodBaseband() :
-    m_mutex(QMutex::Recursive)
+ADSBDemodBaseband::ADSBDemodBaseband()
 {
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(8000000));
     m_channelizer = new DownChannelizer(&m_sink);

--- a/plugins/channelrx/demodadsb/adsbdemodbaseband.h
+++ b/plugins/channelrx/demodadsb/adsbdemodbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_ADSBDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -77,7 +77,7 @@ private:
     ADSBDemodSink m_sink;
     MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     ADSBDemodSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const ADSBDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/demodadsb/adsbdemodworker.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodworker.cpp
@@ -80,8 +80,7 @@ void ADSBBeastServer::discardClient()
 }
 
 ADSBDemodWorker::ADSBDemodWorker() :
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     connect(&m_heartbeatTimer, SIGNAL(timeout()), this, SLOT(heartbeat()));
     connect(&m_socket, SIGNAL(readyRead()),this, SLOT(recv()));

--- a/plugins/channelrx/demodadsb/adsbdemodworker.h
+++ b/plugins/channelrx/demodadsb/adsbdemodworker.h
@@ -92,7 +92,7 @@ private:
     MessageQueue m_inputMessageQueue;
     ADSBDemodSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     QTimer m_heartbeatTimer;
     QTcpSocket m_socket;
     QFile m_logFile;

--- a/plugins/channelrx/demodais/aisdemodbaseband.cpp
+++ b/plugins/channelrx/demodais/aisdemodbaseband.cpp
@@ -28,8 +28,7 @@ MESSAGE_CLASS_DEFINITION(AISDemodBaseband::MsgConfigureAISDemodBaseband, Message
 
 AISDemodBaseband::AISDemodBaseband(AISDemod *aisDemod) :
     m_sink(aisDemod),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("AISDemodBaseband::AISDemodBaseband");
 

--- a/plugins/channelrx/demodais/aisdemodbaseband.h
+++ b/plugins/channelrx/demodais/aisdemodbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_AISDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/scopevis.h"
@@ -87,7 +87,7 @@ private:
     AISDemodSettings m_settings;
     ScopeVis m_scopeSink;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void calculateOffset(AISDemodSink *sink);

--- a/plugins/channelrx/demodam/amdemodbaseband.cpp
+++ b/plugins/channelrx/demodam/amdemodbaseband.cpp
@@ -26,8 +26,7 @@
 MESSAGE_CLASS_DEFINITION(AMDemodBaseband::MsgConfigureAMDemodBaseband, Message)
 
 AMDemodBaseband::AMDemodBaseband() :
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("AMDemodBaseband::AMDemodBaseband");
 

--- a/plugins/channelrx/demodam/amdemodbaseband.h
+++ b/plugins/channelrx/demodam/amdemodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_AMDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -85,7 +85,7 @@ private:
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     AMDemodSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const AMDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/demodapt/aptdemodbaseband.cpp
+++ b/plugins/channelrx/demodapt/aptdemodbaseband.cpp
@@ -29,8 +29,7 @@ MESSAGE_CLASS_DEFINITION(APTDemodBaseband::MsgConfigureAPTDemodBaseband, Message
 
 APTDemodBaseband::APTDemodBaseband(APTDemod *packetDemod) :
     m_sink(packetDemod),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("APTDemodBaseband::APTDemodBaseband");
 

--- a/plugins/channelrx/demodapt/aptdemodbaseband.h
+++ b/plugins/channelrx/demodapt/aptdemodbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_APTDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -81,7 +81,7 @@ private:
     MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     APTDemodSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void calculateOffset(APTDemodSink *sink);

--- a/plugins/channelrx/demodapt/aptdemodimageworker.cpp
+++ b/plugins/channelrx/demodapt/aptdemodimageworker.cpp
@@ -38,8 +38,7 @@ APTDemodImageWorker::APTDemodImageWorker(APTDemod *aptDemod) :
     m_messageQueueToGUI(nullptr),
     m_aptDemod(aptDemod),
     m_sgp4(nullptr),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     for (int y = 0; y < APT_MAX_HEIGHT; y++)
     {

--- a/plugins/channelrx/demodapt/aptdemodimageworker.h
+++ b/plugins/channelrx/demodapt/aptdemodimageworker.h
@@ -20,7 +20,7 @@
 #define INCLUDE_APTDEMODIMAGEWORKER_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QImage>
 
 #include <apt.h>
@@ -137,7 +137,7 @@ private:
     QList<QImage> m_palettes;
 
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const APTDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/demodatv/atvdemodbaseband.cpp
+++ b/plugins/channelrx/demodatv/atvdemodbaseband.cpp
@@ -26,8 +26,7 @@
 MESSAGE_CLASS_DEFINITION(ATVDemodBaseband::MsgConfigureATVDemodBaseband, Message)
 
 ATVDemodBaseband::ATVDemodBaseband() :
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("ATVDemodBaseband::ATVDemodBaseband");
     m_sink.setScopeSink(&m_scopeSink);

--- a/plugins/channelrx/demodatv/atvdemodbaseband.h
+++ b/plugins/channelrx/demodatv/atvdemodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_ATVDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/scopevis.h"
@@ -82,7 +82,7 @@ private:
     ATVDemodSettings m_settings;
     ScopeVis m_scopeSink;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const ATVDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/demodbfm/bfmdemodbaseband.cpp
+++ b/plugins/channelrx/demodbfm/bfmdemodbaseband.cpp
@@ -28,7 +28,6 @@
 MESSAGE_CLASS_DEFINITION(BFMDemodBaseband::MsgConfigureBFMDemodBaseband, Message)
 
 BFMDemodBaseband::BFMDemodBaseband() :
-    m_mutex(QMutex::Recursive),
     m_messageQueueToGUI(nullptr),
     m_spectrumVis(nullptr)
 {

--- a/plugins/channelrx/demodbfm/bfmdemodbaseband.h
+++ b/plugins/channelrx/demodbfm/bfmdemodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_BFMDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -90,7 +90,7 @@ private:
     BFMDemodSink m_sink;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     BFMDemodSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     MessageQueue *m_messageQueueToGUI;
     SpectrumVis *m_spectrumVis;
 

--- a/plugins/channelrx/demodchirpchat/chirpchatdemodbaseband.cpp
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemodbaseband.cpp
@@ -25,8 +25,7 @@
 
 MESSAGE_CLASS_DEFINITION(ChirpChatDemodBaseband::MsgConfigureChirpChatDemodBaseband, Message)
 
-ChirpChatDemodBaseband::ChirpChatDemodBaseband() :
-    m_mutex(QMutex::Recursive)
+ChirpChatDemodBaseband::ChirpChatDemodBaseband()
 {
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));
     m_channelizer = new DownChannelizer(&m_sink);

--- a/plugins/channelrx/demodchirpchat/chirpchatdemodbaseband.h
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_CHIRPCHATDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -76,7 +76,7 @@ private:
     ChirpChatDemodSink m_sink;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     ChirpChatDemodSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const ChirpChatDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/demoddab/dabdemodbaseband.cpp
+++ b/plugins/channelrx/demoddab/dabdemodbaseband.cpp
@@ -29,8 +29,7 @@ MESSAGE_CLASS_DEFINITION(DABDemodBaseband::MsgConfigureDABDemodBaseband, Message
 
 DABDemodBaseband::DABDemodBaseband(DABDemod *packetDemod) :
     m_sink(packetDemod),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("DABDemodBaseband::DABDemodBaseband");
 

--- a/plugins/channelrx/demoddab/dabdemodbaseband.h
+++ b/plugins/channelrx/demoddab/dabdemodbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_DABDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -85,7 +85,7 @@ private:
     MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     DABDemodSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const DABDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/demoddatv/datvdemodbaseband.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodbaseband.cpp
@@ -26,8 +26,7 @@
 MESSAGE_CLASS_DEFINITION(DATVDemodBaseband::MsgConfigureDATVDemodBaseband, Message)
 
 DATVDemodBaseband::DATVDemodBaseband() :
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("DATVDemodBaseband::DATVDemodBaseband");
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));

--- a/plugins/channelrx/demoddatv/datvdemodbaseband.h
+++ b/plugins/channelrx/demoddatv/datvdemodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_DATVDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -101,7 +101,7 @@ private:
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     DATVDemodSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const DATVDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/demoddatv/datvdemodsink.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodsink.cpp
@@ -46,8 +46,7 @@ DATVDemodSink::DATVDemodSink() :
     m_modcodCodeRate(-1),
     m_enmModulation(DATVDemodSettings::BPSK /*DATV_FM1*/),
     m_channelSampleRate(1024000),
-    m_messageQueueToGUI(nullptr),
-    m_mutex(QMutex::Recursive)
+    m_messageQueueToGUI(nullptr)
 {
     //*************** DATV PARAMETERS  ***************
     m_blnInitialized=false;

--- a/plugins/channelrx/demoddatv/datvdemodsink.h
+++ b/plugins/channelrx/demoddatv/datvdemodsink.h
@@ -18,7 +18,7 @@
 #ifndef INCLUDE_DATVDEMODSINK_H
 #define INCLUDE_DATVDEMODSINK_H
 
-#include <QMutex>
+#include <QRecursiveMutex>
 
 //LeanSDR
 #include "leansdr/framework.h"
@@ -345,7 +345,7 @@ private:
     MovingAverageUtil<double, double, 32> m_objMagSqAverage;
 
     MessageQueue *m_messageQueueToGUI;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     static const unsigned int m_rfFilterFftLength;
 };

--- a/plugins/channelrx/demoddatv/datvideostream.cpp
+++ b/plugins/channelrx/demoddatv/datvideostream.cpp
@@ -19,8 +19,7 @@
 #include "datvideostream.h"
 #include <stdio.h>
 
-DATVideostream::DATVideostream():
-    m_mutex(QMutex::NonRecursive)
+DATVideostream::DATVideostream()
 {
     cleanUp();
     m_totalReceived = 0;

--- a/plugins/channelrx/demoddsd/dsddemod.cpp
+++ b/plugins/channelrx/demoddsd/dsddemod.cpp
@@ -58,7 +58,6 @@ const int DSDDemod::m_udpBlockSize = 512;
 DSDDemod::DSDDemod(DeviceAPI *deviceAPI) :
         ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSink),
         m_deviceAPI(deviceAPI),
-        m_mutex(QMutex::Recursive),
         m_running(false),
         m_basebandSampleRate(0)
 {

--- a/plugins/channelrx/demoddsd/dsddemod.h
+++ b/plugins/channelrx/demoddsd/dsddemod.h
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include <QNetworkRequest>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/basebandsamplesink.h"
 #include "channel/channelapi.h"
@@ -171,7 +171,7 @@ private:
 	DeviceAPI *m_deviceAPI;
     QThread *m_thread;
     DSDDemodBaseband *m_basebandSink;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     bool m_running;
 	DSDDemodSettings m_settings;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink

--- a/plugins/channelrx/demoddsd/dsddemodbaseband.cpp
+++ b/plugins/channelrx/demoddsd/dsddemodbaseband.cpp
@@ -25,8 +25,7 @@
 MESSAGE_CLASS_DEFINITION(DSDDemodBaseband::MsgConfigureDSDDemodBaseband, Message)
 
 DSDDemodBaseband::DSDDemodBaseband() :
-    m_channelizer(&m_sink),
-    m_mutex(QMutex::Recursive)
+    m_channelizer(&m_sink)
 {
     qDebug("DSDDemodBaseband::DSDDemodBaseband");
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));

--- a/plugins/channelrx/demoddsd/dsddemodbaseband.h
+++ b/plugins/channelrx/demoddsd/dsddemodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_DSDDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/downchannelizer.h"
@@ -85,7 +85,7 @@ private:
     DSDDemodSink m_sink;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     DSDDemodSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const DSDDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/demodfreedv/freedvdemodbaseband.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemodbaseband.cpp
@@ -27,7 +27,6 @@ MESSAGE_CLASS_DEFINITION(FreeDVDemodBaseband::MsgConfigureFreeDVDemodBaseband, M
 MESSAGE_CLASS_DEFINITION(FreeDVDemodBaseband::MsgResyncFreeDVDemod, Message)
 
 FreeDVDemodBaseband::FreeDVDemodBaseband() :
-    m_mutex(QMutex::Recursive),
     m_messageQueueToGUI(nullptr)
 {
     qDebug("FreeDVDemodBaseband::FreeDVDemodBaseband");

--- a/plugins/channelrx/demodfreedv/freedvdemodbaseband.h
+++ b/plugins/channelrx/demodfreedv/freedvdemodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_FREEDVDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -107,7 +107,7 @@ private:
     FreeDVDemodSink m_sink;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     FreeDVDemodSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     MessageQueue *m_messageQueueToGUI;
 
     MessageQueue *getMessageQueueToGUI() { return m_messageQueueToGUI; }

--- a/plugins/channelrx/demodfreedv/freedvdemodsink.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemodsink.cpp
@@ -150,8 +150,7 @@ FreeDVDemodSink::FreeDVDemodSink() :
         m_iModem(0),
         m_speechOut(nullptr),
         m_modIn(nullptr),
-        m_levelInNbSamples(480), // 10ms @ 48 kS/s
-        m_mutex(QMutex::Recursive)
+        m_levelInNbSamples(480) // 10ms @ 48 kS/s
 {
 	m_audioBuffer.resize(1<<14);
 	m_audioBufferFill = 0;

--- a/plugins/channelrx/demodfreedv/freedvdemodsink.h
+++ b/plugins/channelrx/demodfreedv/freedvdemodsink.h
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include <QTimer>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/channelsamplesink.h"
 #include "dsp/ncof.h"
@@ -200,7 +200,7 @@ private:
 	int m_levelInNbSamples;
     Real m_rmsLevel;
     Real m_peakLevel;
-	QMutex m_mutex;
+	QRecursiveMutex m_mutex;
 
     static const unsigned int m_ssbFftLen;
     static const float m_agcTarget;

--- a/plugins/channelrx/demodm17/m17demodbaseband.cpp
+++ b/plugins/channelrx/demodm17/m17demodbaseband.cpp
@@ -25,8 +25,7 @@
 
 MESSAGE_CLASS_DEFINITION(M17DemodBaseband::MsgConfigureM17DemodBaseband, Message)
 
-M17DemodBaseband::M17DemodBaseband() :
-    m_mutex(QMutex::Recursive)
+M17DemodBaseband::M17DemodBaseband()
 {
     qDebug("M17DemodBaseband::M17DemodBaseband");
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));

--- a/plugins/channelrx/demodm17/m17demodbaseband.h
+++ b/plugins/channelrx/demodm17/m17demodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_M17DEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -129,7 +129,7 @@ private:
     M17DemodSink m_sink;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     M17DemodSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const M17DemodSettings& settings, const QList<QString>& settingsKeys, bool force = false);

--- a/plugins/channelrx/demodnfm/dcsdetector.cpp
+++ b/plugins/channelrx/demodnfm/dcsdetector.cpp
@@ -28,8 +28,7 @@ DCSDetector::DCSDetector() :
     m_low(0.0f),
     m_mid(0.0f),
     m_prevSample(0.0f),
-    m_dcsWord(0),
-    m_mutex(QMutex::Recursive)
+    m_dcsWord(0)
 {
     setBitrate(134.3);
     setEqWindow(23);

--- a/plugins/channelrx/demodnfm/dcsdetector.h
+++ b/plugins/channelrx/demodnfm/dcsdetector.h
@@ -18,7 +18,7 @@
 #ifndef INCLUDE_DSP_DCSDETECTOR_H_
 #define INCLUDE_DSP_DCSDETECTOR_H_
 
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/dsptypes.h"
 #include "util/golay2312.h"
@@ -49,7 +49,7 @@ private:
     float m_prevSample;
     unsigned int m_dcsWord; //!< 23 bit DCS code word
     Golay2312 m_golay2312;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 };
 
 #endif // INCLUDE_DSP_DCSDETECTOR_H_

--- a/plugins/channelrx/demodnfm/nfmdemodbaseband.cpp
+++ b/plugins/channelrx/demodnfm/nfmdemodbaseband.cpp
@@ -25,8 +25,7 @@
 MESSAGE_CLASS_DEFINITION(NFMDemodBaseband::MsgConfigureNFMDemodBaseband, Message)
 
 NFMDemodBaseband::NFMDemodBaseband() :
-    m_channelizer(&m_sink),
-    m_mutex(QMutex::Recursive)
+    m_channelizer(&m_sink)
 {
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));
 

--- a/plugins/channelrx/demodnfm/nfmdemodbaseband.h
+++ b/plugins/channelrx/demodnfm/nfmdemodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_NFMDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/downchannelizer.h"
@@ -80,7 +80,7 @@ private:
     NFMDemodSink m_sink;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     NFMDemodSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const NFMDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/demodpacket/packetdemodbaseband.cpp
+++ b/plugins/channelrx/demodpacket/packetdemodbaseband.cpp
@@ -28,8 +28,7 @@ MESSAGE_CLASS_DEFINITION(PacketDemodBaseband::MsgConfigurePacketDemodBaseband, M
 
 PacketDemodBaseband::PacketDemodBaseband(PacketDemod *packetDemod) :
     m_sink(packetDemod),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("PacketDemodBaseband::PacketDemodBaseband");
 

--- a/plugins/channelrx/demodpacket/packetdemodbaseband.h
+++ b/plugins/channelrx/demodpacket/packetdemodbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_PACKETDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -84,7 +84,7 @@ private:
     MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     PacketDemodSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void calculateOffset(PacketDemodSink *sink);

--- a/plugins/channelrx/demodpager/pagerdemodbaseband.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodbaseband.cpp
@@ -28,8 +28,7 @@ MESSAGE_CLASS_DEFINITION(PagerDemodBaseband::MsgConfigurePagerDemodBaseband, Mes
 
 PagerDemodBaseband::PagerDemodBaseband(PagerDemod *pagerDemod) :
     m_sink(pagerDemod),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("PagerDemodBaseband::PagerDemodBaseband");
 

--- a/plugins/channelrx/demodpager/pagerdemodbaseband.h
+++ b/plugins/channelrx/demodpager/pagerdemodbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_PAGERDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/scopevis.h"
@@ -88,7 +88,7 @@ private:
     PagerDemodSettings m_settings;
     ScopeVis m_scopeSink;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void calculateOffset(PagerDemodSink *sink);

--- a/plugins/channelrx/demodradiosonde/radiosondedemodbaseband.cpp
+++ b/plugins/channelrx/demodradiosonde/radiosondedemodbaseband.cpp
@@ -28,8 +28,7 @@ MESSAGE_CLASS_DEFINITION(RadiosondeDemodBaseband::MsgConfigureRadiosondeDemodBas
 
 RadiosondeDemodBaseband::RadiosondeDemodBaseband(RadiosondeDemod *radiosondeDemod) :
     m_sink(radiosondeDemod),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("RadiosondeDemodBaseband::RadiosondeDemodBaseband");
 

--- a/plugins/channelrx/demodradiosonde/radiosondedemodbaseband.h
+++ b/plugins/channelrx/demodradiosonde/radiosondedemodbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_RADIOSONDEDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/scopevis.h"
@@ -87,7 +87,7 @@ private:
     RadiosondeDemodSettings m_settings;
     ScopeVis m_scopeSink;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void calculateOffset(RadiosondeDemodSink *sink);

--- a/plugins/channelrx/demodssb/ssbdemod.cpp
+++ b/plugins/channelrx/demodssb/ssbdemod.cpp
@@ -52,7 +52,6 @@ const char* const SSBDemod::m_channelId = "SSBDemod";
 SSBDemod::SSBDemod(DeviceAPI *deviceAPI) :
         ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSink),
         m_deviceAPI(deviceAPI),
-        m_mutex(QMutex::Recursive),
         m_running(false),
         m_spectrumVis(SDR_RX_SCALEF),
         m_basebandSampleRate(0)

--- a/plugins/channelrx/demodssb/ssbdemod.h
+++ b/plugins/channelrx/demodssb/ssbdemod.h
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesink.h"
@@ -143,7 +143,7 @@ private:
 	DeviceAPI *m_deviceAPI;
     QThread *m_thread;
     SSBDemodBaseband* m_basebandSink;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     bool m_running;
     SSBDemodSettings m_settings;
     SpectrumVis m_spectrumVis;

--- a/plugins/channelrx/demodssb/ssbdemodbaseband.cpp
+++ b/plugins/channelrx/demodssb/ssbdemodbaseband.cpp
@@ -28,8 +28,7 @@ MESSAGE_CLASS_DEFINITION(SSBDemodBaseband::MsgConfigureSSBDemodBaseband, Message
 SSBDemodBaseband::SSBDemodBaseband() :
     m_channelizer(&m_sink),
     m_messageQueueToGUI(nullptr),
-    m_spectrumVis(nullptr),
-    m_mutex(QMutex::Recursive)
+    m_spectrumVis(nullptr)
 {
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));
 

--- a/plugins/channelrx/demodssb/ssbdemodbaseband.h
+++ b/plugins/channelrx/demodssb/ssbdemodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_SSBDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/downchannelizer.h"
@@ -85,7 +85,7 @@ private:
     int m_channelSampleRate;
     MessageQueue *m_messageQueueToGUI;
     SpectrumVis *m_spectrumVis;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const SSBDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/demodvor/vordemodbaseband.cpp
+++ b/plugins/channelrx/demodvor/vordemodbaseband.cpp
@@ -29,8 +29,7 @@ MESSAGE_CLASS_DEFINITION(VORDemodBaseband::MsgConfigureVORDemodBaseband, Message
 
 VORDemodBaseband::VORDemodBaseband() :
     m_messageQueueToGUI(nullptr),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("VORDemodBaseband::VORDemodBaseband");
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));

--- a/plugins/channelrx/demodvor/vordemodbaseband.h
+++ b/plugins/channelrx/demodvor/vordemodbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_VORDEMODSCBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -82,7 +82,7 @@ private:
     VORDemodSettings m_settings;
     MessageQueue *m_messageQueueToGUI;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const VORDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/demodvormc/vordemodmcbaseband.cpp
+++ b/plugins/channelrx/demodvormc/vordemodmcbaseband.cpp
@@ -29,7 +29,6 @@ MESSAGE_CLASS_DEFINITION(VORDemodMCBaseband::MsgConfigureVORDemodBaseband, Messa
 
 VORDemodMCBaseband::VORDemodMCBaseband() :
     m_running(false),
-    m_mutex(QMutex::Recursive),
     m_messageQueueToGUI(nullptr),
     m_basebandSampleRate(0)
 {

--- a/plugins/channelrx/demodvormc/vordemodmcbaseband.h
+++ b/plugins/channelrx/demodvormc/vordemodmcbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_VORDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -120,7 +120,7 @@ private:
     MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     VORDemodMCSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     MessageQueue *m_messageQueueToGUI;
     int m_basebandSampleRate;
     int m_centerFrequency;

--- a/plugins/channelrx/demodwfm/wfmdemodbaseband.cpp
+++ b/plugins/channelrx/demodwfm/wfmdemodbaseband.cpp
@@ -25,8 +25,7 @@
 
 MESSAGE_CLASS_DEFINITION(WFMDemodBaseband::MsgConfigureWFMDemodBaseband, Message)
 
-WFMDemodBaseband::WFMDemodBaseband() :
-    m_mutex(QMutex::Recursive)
+WFMDemodBaseband::WFMDemodBaseband()
 {
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));
     m_channelizer = new DownChannelizer(&m_sink);

--- a/plugins/channelrx/demodwfm/wfmdemodbaseband.h
+++ b/plugins/channelrx/demodwfm/wfmdemodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_WFMDEMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -81,7 +81,7 @@ private:
     WFMDemodSink m_sink;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     WFMDemodSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const WFMDemodSettings& settings, bool force = false);

--- a/plugins/channelrx/filesink/filesink.cpp
+++ b/plugins/channelrx/filesink/filesink.cpp
@@ -54,7 +54,6 @@ const char* const FileSink::m_channelId = "FileSink";
 FileSink::FileSink(DeviceAPI *deviceAPI) :
         ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSink),
         m_deviceAPI(deviceAPI),
-        m_mutex(QMutex::Recursive),
         m_running(false),
         m_spectrumVis(SDR_RX_SCALEF),
         m_centerFrequency(0),

--- a/plugins/channelrx/filesink/filesink.h
+++ b/plugins/channelrx/filesink/filesink.h
@@ -19,7 +19,7 @@
 #define INCLUDE_FILESINK_H_
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesink.h"
@@ -161,7 +161,7 @@ private:
     DeviceAPI *m_deviceAPI;
     QThread *m_thread;
     FileSinkBaseband *m_basebandSink;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     bool m_running;
     FileSinkSettings m_settings;
     SpectrumVis m_spectrumVis;

--- a/plugins/channelrx/filesink/filesinkbaseband.cpp
+++ b/plugins/channelrx/filesink/filesinkbaseband.cpp
@@ -33,8 +33,7 @@ FileSinkBaseband::FileSinkBaseband() :
     m_channelizer(&m_sink),
     m_specMax(0),
     m_squelchLevel(0),
-    m_squelchOpen(false),
-    m_mutex(QMutex::Recursive)
+    m_squelchOpen(false)
 {
     qDebug("FileSinkBaseband::FileSinkBaseband");
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));

--- a/plugins/channelrx/filesink/filesinkbaseband.h
+++ b/plugins/channelrx/filesink/filesinkbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_FILESINKBASEBAND_H_
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/downchannelizer.h"
@@ -113,7 +113,7 @@ private:
     float m_squelchLevel;
     bool m_squelchOpen;
     int64_t m_centerFrequency;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     QTimer *m_timer;
 
     void stopWork();

--- a/plugins/channelrx/freqtracker/freqtrackerbaseband.cpp
+++ b/plugins/channelrx/freqtracker/freqtrackerbaseband.cpp
@@ -26,8 +26,7 @@
 
 MESSAGE_CLASS_DEFINITION(FreqTrackerBaseband::MsgConfigureFreqTrackerBaseband, Message)
 
-FreqTrackerBaseband::FreqTrackerBaseband() :
-    m_mutex(QMutex::Recursive)
+FreqTrackerBaseband::FreqTrackerBaseband()
 {
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));
     m_channelizer = new DownChannelizer(&m_sink);

--- a/plugins/channelrx/freqtracker/freqtrackerbaseband.h
+++ b/plugins/channelrx/freqtracker/freqtrackerbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_FREQTRACKERBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -84,7 +84,7 @@ private:
     FreqTrackerSettings m_settings;
     unsigned int m_basebandSampleRate;
     SpectrumVis *m_spectrumVis;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const FreqTrackerSettings& settings, bool force = false);

--- a/plugins/channelrx/localsink/localsinkbaseband.cpp
+++ b/plugins/channelrx/localsink/localsinkbaseband.cpp
@@ -28,8 +28,7 @@ MESSAGE_CLASS_DEFINITION(LocalSinkBaseband::MsgConfigureLocalSinkWork, Message)
 MESSAGE_CLASS_DEFINITION(LocalSinkBaseband::MsgConfigureLocalDeviceSampleSource, Message)
 
 LocalSinkBaseband::LocalSinkBaseband() :
-    m_localSampleSource(nullptr),
-    m_mutex(QMutex::Recursive)
+    m_localSampleSource(nullptr)
 {
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));
     m_channelizer = new DownChannelizer(&m_sink);

--- a/plugins/channelrx/localsink/localsinkbaseband.h
+++ b/plugins/channelrx/localsink/localsinkbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_LOCALSINKBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -114,7 +114,7 @@ private:
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     LocalSinkSettings m_settings;
     DeviceSampleSource *m_localSampleSource;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const LocalSinkSettings& settings, bool force = false);

--- a/plugins/channelrx/noisefigure/noisefigurebaseband.cpp
+++ b/plugins/channelrx/noisefigure/noisefigurebaseband.cpp
@@ -28,8 +28,7 @@ MESSAGE_CLASS_DEFINITION(NoiseFigureBaseband::MsgConfigureNoiseFigureBaseband, M
 
 NoiseFigureBaseband::NoiseFigureBaseband(NoiseFigure *aisDemod) :
     m_sink(aisDemod),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("NoiseFigureBaseband::NoiseFigureBaseband");
 

--- a/plugins/channelrx/noisefigure/noisefigurebaseband.h
+++ b/plugins/channelrx/noisefigure/noisefigurebaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_NOISEFIGUREBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/scopevis.h"
@@ -85,7 +85,7 @@ private:
     MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     NoiseFigureSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void calculateOffset(NoiseFigureSink *sink);

--- a/plugins/channelrx/radioastronomy/radioastronomybaseband.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomybaseband.cpp
@@ -29,8 +29,7 @@ MESSAGE_CLASS_DEFINITION(RadioAstronomyBaseband::MsgConfigureRadioAstronomyBaseb
 
 RadioAstronomyBaseband::RadioAstronomyBaseband(RadioAstronomy *aisDemod) :
     m_sink(aisDemod),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("RadioAstronomyBaseband::RadioAstronomyBaseband");
 

--- a/plugins/channelrx/radioastronomy/radioastronomybaseband.h
+++ b/plugins/channelrx/radioastronomy/radioastronomybaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_RADIOASTRONOMYBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/scopevis.h"
@@ -84,7 +84,7 @@ private:
     MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     RadioAstronomySettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void calculateOffset(RadioAstronomySink *sink);

--- a/plugins/channelrx/radioastronomy/radioastronomyworker.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomyworker.cpp
@@ -30,7 +30,6 @@ RadioAstronomyWorker::RadioAstronomyWorker(RadioAstronomy* radioAstronomy) :
     m_msgQueueToChannel(nullptr),
     m_msgQueueToGUI(nullptr),
     m_running(false),
-    m_mutex(QMutex::Recursive),
     m_sensorTimer(this)
 {
     connect(&m_sensorTimer, SIGNAL(timeout()), this, SLOT(measureSensors()));

--- a/plugins/channelrx/radioastronomy/radioastronomyworker.h
+++ b/plugins/channelrx/radioastronomy/radioastronomyworker.h
@@ -75,7 +75,7 @@ private:
     MessageQueue *m_msgQueueToGUI;
     RadioAstronomySettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     VISA m_visa;
     ViSession m_session[RADIOASTRONOMY_SENSORS];

--- a/plugins/channelrx/radioclock/radioclockbaseband.cpp
+++ b/plugins/channelrx/radioclock/radioclockbaseband.cpp
@@ -29,8 +29,7 @@ MESSAGE_CLASS_DEFINITION(RadioClockBaseband::MsgConfigureRadioClockBaseband, Mes
 
 RadioClockBaseband::RadioClockBaseband(RadioClock *radioClock) :
     m_sink(radioClock),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("RadioClockBaseband::RadioClockBaseband");
 

--- a/plugins/channelrx/radioclock/radioclockbaseband.h
+++ b/plugins/channelrx/radioclock/radioclockbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_RADIOCLOCKBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/scopevis.h"
@@ -87,7 +87,7 @@ private:
     RadioClockSettings m_settings;
     ScopeVis m_scopeSink;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const RadioClockSettings& settings, bool force = false);

--- a/plugins/channelrx/remotesink/remotesinkbaseband.cpp
+++ b/plugins/channelrx/remotesink/remotesinkbaseband.cpp
@@ -25,8 +25,7 @@
 
 MESSAGE_CLASS_DEFINITION(RemoteSinkBaseband::MsgConfigureRemoteSinkBaseband, Message)
 
-RemoteSinkBaseband::RemoteSinkBaseband() :
-    m_mutex(QMutex::Recursive)
+RemoteSinkBaseband::RemoteSinkBaseband()
 {
     qDebug("RemoteSinkBaseband::RemoteSinkBaseband");
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));

--- a/plugins/channelrx/remotesink/remotesinkbaseband.h
+++ b/plugins/channelrx/remotesink/remotesinkbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_REMOTESINKBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -82,7 +82,7 @@ private:
     RemoteSinkSink m_sink;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     RemoteSinkSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const RemoteSinkSettings& settings, bool force = false);

--- a/plugins/channelrx/remotetcpsink/remotetcpsinkbaseband.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinkbaseband.cpp
@@ -25,8 +25,7 @@
 #include "remotetcpsinkbaseband.h"
 #include "remotetcpsink.h"
 
-RemoteTCPSinkBaseband::RemoteTCPSinkBaseband() :
-    m_mutex(QMutex::Recursive)
+RemoteTCPSinkBaseband::RemoteTCPSinkBaseband()
 {
     qDebug("RemoteTCPSinkBaseband::RemoteTCPSinkBaseband");
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));

--- a/plugins/channelrx/remotetcpsink/remotetcpsinkbaseband.h
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinkbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_REMOTETCPSINKBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -60,7 +60,7 @@ private:
     RemoteTCPSinkSink m_sink;
     MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     RemoteTCPSinkSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const RemoteTCPSinkSettings& settings, bool force = false, bool remoteChange = false);

--- a/plugins/channelrx/remotetcpsink/remotetcpsinksink.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinksink.cpp
@@ -36,7 +36,6 @@ RemoteTCPSinkSink::RemoteTCPSinkSink() :
         m_channelFrequencyOffset(0),
         m_channelSampleRate(48000),
         m_linearGain(1.0f),
-        m_mutex(QMutex::Recursive),
         m_server(nullptr)
 {
     qDebug("RemoteTCPSinkSink::RemoteTCPSinkSink");

--- a/plugins/channelrx/remotetcpsink/remotetcpsinksink.h
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinksink.h
@@ -75,7 +75,7 @@ private:
     uint32_t m_channelIndex;
     float m_linearGain;
 
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     QTcpServer *m_server;
     QList<QTcpSocket *> m_clients;
 

--- a/plugins/channelrx/sigmffilesink/sigmffilesink.cpp
+++ b/plugins/channelrx/sigmffilesink/sigmffilesink.cpp
@@ -54,7 +54,6 @@ const char* const SigMFFileSink::m_channelId = "SigMFFileSink";
 SigMFFileSink::SigMFFileSink(DeviceAPI *deviceAPI) :
         ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSink),
         m_deviceAPI(deviceAPI),
-        m_mutex(QMutex::Recursive),
         m_running(false),
         m_spectrumVis(SDR_RX_SCALEF),
         m_centerFrequency(0),

--- a/plugins/channelrx/sigmffilesink/sigmffilesink.h
+++ b/plugins/channelrx/sigmffilesink/sigmffilesink.h
@@ -19,7 +19,7 @@
 #define INCLUDE_SIGMFFILESINK_H_
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesink.h"
@@ -161,7 +161,7 @@ private:
     DeviceAPI *m_deviceAPI;
     QThread *m_thread;
     SigMFFileSinkBaseband *m_basebandSink;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     bool m_running;
     SigMFFileSinkSettings m_settings;
     SpectrumVis m_spectrumVis;

--- a/plugins/channelrx/sigmffilesink/sigmffilesinkbaseband.cpp
+++ b/plugins/channelrx/sigmffilesink/sigmffilesinkbaseband.cpp
@@ -33,8 +33,7 @@ SigMFFileSinkBaseband::SigMFFileSinkBaseband() :
     m_channelizer(&m_sink),
     m_specMax(0),
     m_squelchLevel(0),
-    m_squelchOpen(false),
-    m_mutex(QMutex::Recursive)
+    m_squelchOpen(false)
 {
     qDebug("SigMFFileSinkBaseband::SigMFFileSinkBaseband");
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));

--- a/plugins/channelrx/sigmffilesink/sigmffilesinkbaseband.h
+++ b/plugins/channelrx/sigmffilesink/sigmffilesinkbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_SIFMFFILESINKBASEBAND_H_
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "dsp/downchannelizer.h"
@@ -113,7 +113,7 @@ private:
     float m_squelchLevel;
     bool m_squelchOpen;
     int64_t m_centerFrequency;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     QTimer *m_timer;
 
     void stopWork();

--- a/plugins/channelrx/udpsink/udpsinkbaseband.cpp
+++ b/plugins/channelrx/udpsink/udpsinkbaseband.cpp
@@ -26,8 +26,7 @@
 MESSAGE_CLASS_DEFINITION(UDPSinkBaseband::MsgConfigureUDPSinkBaseband, Message)
 MESSAGE_CLASS_DEFINITION(UDPSinkBaseband::MsgEnableSpectrum, Message)
 
-UDPSinkBaseband::UDPSinkBaseband() :
-    m_mutex(QMutex::Recursive)
+UDPSinkBaseband::UDPSinkBaseband()
 {
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));
     m_channelizer = new DownChannelizer(&m_sink);

--- a/plugins/channelrx/udpsink/udpsinkbaseband.h
+++ b/plugins/channelrx/udpsink/udpsinkbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_UDPSINKBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -97,7 +97,7 @@ private:
     UDPSinkSink m_sink;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     UDPSinkSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const UDPSinkSettings& settings, bool force = false);

--- a/plugins/channeltx/filesource/filesource.cpp
+++ b/plugins/channeltx/filesource/filesource.cpp
@@ -53,7 +53,6 @@ const char* const FileSource::m_channelId ="FileSource";
 FileSource::FileSource(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
     m_deviceAPI(deviceAPI),
-	m_settingsMutex(QMutex::Recursive),
 	m_frequencyOffset(0),
 	m_basebandSampleRate(0),
     m_linearGain(0.0)

--- a/plugins/channeltx/filesource/filesource.h
+++ b/plugins/channeltx/filesource/filesource.h
@@ -228,7 +228,7 @@ private:
     FileSourceSettings m_settings;
 
     SampleVector m_sampleBuffer;
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
     uint64_t m_frequencyOffset;
     uint32_t m_basebandSampleRate;
     double m_linearGain;

--- a/plugins/channeltx/filesource/filesourcebaseband.cpp
+++ b/plugins/channeltx/filesource/filesourcebaseband.cpp
@@ -31,8 +31,7 @@ MESSAGE_CLASS_DEFINITION(FileSourceBaseband::MsgConfigureFileSourceSeek, Message
 FileSourceBaseband::FileSourceBaseband() :
     m_avg(0.0),
     m_peak(0.0),
-    m_nbSamples(1),
-    m_mutex(QMutex::Recursive)
+    m_nbSamples(1)
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/filesource/filesourcebaseband.h
+++ b/plugins/channeltx/filesource/filesourcebaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_FILESOURCEBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -147,7 +147,7 @@ private:
     double m_avg;
     double m_peak;
     int m_nbSamples;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/localsource/localsourcebaseband.cpp
+++ b/plugins/channeltx/localsource/localsourcebaseband.cpp
@@ -28,8 +28,7 @@ MESSAGE_CLASS_DEFINITION(LocalSourceBaseband::MsgConfigureLocalSourceWork, Messa
 MESSAGE_CLASS_DEFINITION(LocalSourceBaseband::MsgConfigureLocalDeviceSampleSink, Message)
 
 LocalSourceBaseband::LocalSourceBaseband() :
-    m_localSampleSink(nullptr),
-    m_mutex(QMutex::Recursive)
+    m_localSampleSink(nullptr)
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/localsource/localsourcebaseband.h
+++ b/plugins/channeltx/localsource/localsourcebaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_LOCALSOURCEBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -113,7 +113,7 @@ private:
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     LocalSourceSettings m_settings;
     DeviceSampleSink *m_localSampleSink;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_mod.cpp
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_mod.cpp
@@ -57,8 +57,7 @@ const char* const IEEE_802_15_4_Mod::m_channelId = "IEEE_802_15_4_Mod";
 IEEE_802_15_4_Mod::IEEE_802_15_4_Mod(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
     m_deviceAPI(deviceAPI),
-    m_spectrumVis(SDR_TX_SCALEF),
-    m_settingsMutex(QMutex::Recursive)
+    m_spectrumVis(SDR_TX_SCALEF)
 {
     setObjectName(m_channelId);
 

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_mod.h
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_mod.h
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <fstream>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesource.h"
@@ -169,7 +169,7 @@ private:
     SpectrumVis m_spectrumVis;
 
     SampleVector m_sampleBuffer;
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
 
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_modbaseband.cpp
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_modbaseband.cpp
@@ -27,8 +27,7 @@
 
 MESSAGE_CLASS_DEFINITION(IEEE_802_15_4_ModBaseband::MsgConfigureIEEE_802_15_4_ModBaseband, Message)
 
-IEEE_802_15_4_ModBaseband::IEEE_802_15_4_ModBaseband() :
-    m_mutex(QMutex::Recursive)
+IEEE_802_15_4_ModBaseband::IEEE_802_15_4_ModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_modbaseband.h
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_modbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_IEEE_802_15_4_MODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "dsp/scopevis.h"
@@ -86,7 +86,7 @@ private:
     MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     IEEE_802_15_4_ModSettings m_settings;
     ScopeVis m_scopeSink;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/modais/aismod.cpp
+++ b/plugins/channeltx/modais/aismod.cpp
@@ -59,7 +59,6 @@ AISMod::AISMod(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
     m_deviceAPI(deviceAPI),
     m_spectrumVis(SDR_TX_SCALEF),
-    m_settingsMutex(QMutex::Recursive),
     m_udpSocket(nullptr)
 {
     setObjectName(m_channelId);

--- a/plugins/channeltx/modais/aismod.h
+++ b/plugins/channeltx/modais/aismod.h
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesource.h"
@@ -230,7 +230,7 @@ private:
     AISModSettings m_settings;
     SpectrumVis m_spectrumVis;
 
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
 
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channeltx/modais/aismodbaseband.cpp
+++ b/plugins/channeltx/modais/aismodbaseband.cpp
@@ -27,8 +27,7 @@
 
 MESSAGE_CLASS_DEFINITION(AISModBaseband::MsgConfigureAISModBaseband, Message)
 
-AISModBaseband::AISModBaseband() :
-    m_mutex(QMutex::Recursive)
+AISModBaseband::AISModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/modais/aismodbaseband.h
+++ b/plugins/channeltx/modais/aismodbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_AISMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "dsp/scopevis.h"
@@ -87,7 +87,7 @@ private:
     MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     AISModSettings m_settings;
     ScopeVis m_scopeSink;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/modam/ammod.cpp
+++ b/plugins/channeltx/modam/ammod.cpp
@@ -56,7 +56,6 @@ const char* const AMMod::m_channelId ="AMMod";
 AMMod::AMMod(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
     m_deviceAPI(deviceAPI),
-	m_settingsMutex(QMutex::Recursive),
 	m_fileSize(0),
 	m_recordLength(0),
 	m_sampleRate(48000)

--- a/plugins/channeltx/modam/ammod.h
+++ b/plugins/channeltx/modam/ammod.h
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <fstream>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesource.h"
@@ -251,7 +251,7 @@ private:
     AMModSettings m_settings;
 
     SampleVector m_sampleBuffer;
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
 
     std::ifstream m_ifstream;
     QString m_fileName;

--- a/plugins/channeltx/modam/ammodbaseband.cpp
+++ b/plugins/channeltx/modam/ammodbaseband.cpp
@@ -25,8 +25,7 @@
 
 MESSAGE_CLASS_DEFINITION(AMModBaseband::MsgConfigureAMModBaseband, Message)
 
-AMModBaseband::AMModBaseband() :
-    m_mutex(QMutex::Recursive)
+AMModBaseband::AMModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/modam/ammodbaseband.h
+++ b/plugins/channeltx/modam/ammodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_AMMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -87,7 +87,7 @@ private:
     AMModSource m_source;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     AMModSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/modam/ammodsource.cpp
+++ b/plugins/channeltx/modam/ammodsource.cpp
@@ -34,8 +34,7 @@ AMModSource::AMModSource() :
 	m_levelCalcCount(0),
 	m_peakLevel(0.0f),
 	m_levelSum(0.0f),
-    m_ifstream(nullptr),
-    m_mutex(QMutex::Recursive)
+    m_ifstream(nullptr)
 {
     m_audioFifo.setLabel("AMModSource.m_audioFifo");
     m_feedbackAudioFifo.setLabel("AMModSource.m_feedbackAudioFifo");

--- a/plugins/channeltx/modam/ammodsource.h
+++ b/plugins/channeltx/modam/ammodsource.h
@@ -19,7 +19,7 @@
 #define INCLUDE_AMMODSOURCE_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QVector>
 
 #include <iostream>
@@ -113,7 +113,7 @@ private:
     std::ifstream *m_ifstream;
     CWKeyer m_cwKeyer;
 
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     static const int m_levelNbSamples;
 

--- a/plugins/channeltx/modatv/atvmodbaseband.cpp
+++ b/plugins/channeltx/modatv/atvmodbaseband.cpp
@@ -32,8 +32,7 @@ MESSAGE_CLASS_DEFINITION(ATVModBaseband::MsgConfigureVideoFileSourceStreamTiming
 MESSAGE_CLASS_DEFINITION(ATVModBaseband::MsgConfigureCameraIndex, Message)
 MESSAGE_CLASS_DEFINITION(ATVModBaseband::MsgConfigureCameraData, Message)
 
-ATVModBaseband::ATVModBaseband() :
-    m_mutex(QMutex::Recursive)
+ATVModBaseband::ATVModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/modatv/atvmodbaseband.h
+++ b/plugins/channeltx/modatv/atvmodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_ATVMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -237,7 +237,7 @@ private:
     ATVModSource m_source;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     ATVModSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/modchirpchat/chirpchatmod.cpp
+++ b/plugins/channeltx/modchirpchat/chirpchatmod.cpp
@@ -55,7 +55,6 @@ ChirpChatMod::ChirpChatMod(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
 	m_deviceAPI(deviceAPI),
     m_currentPayloadTime(0.0),
-	m_settingsMutex(QMutex::Recursive),
 	m_sampleRate(48000),
         m_udpSocket(nullptr)
 {

--- a/plugins/channeltx/modchirpchat/chirpchatmod.h
+++ b/plugins/channeltx/modchirpchat/chirpchatmod.h
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <fstream>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesource.h"
@@ -162,7 +162,7 @@ private:
     float m_currentPayloadTime;
 
     SampleVector m_sampleBuffer;
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
 
     int m_sampleRate;
 

--- a/plugins/channeltx/modchirpchat/chirpchatmodbaseband.cpp
+++ b/plugins/channeltx/modchirpchat/chirpchatmodbaseband.cpp
@@ -26,8 +26,7 @@
 MESSAGE_CLASS_DEFINITION(ChirpChatModBaseband::MsgConfigureChirpChatModBaseband, Message)
 MESSAGE_CLASS_DEFINITION(ChirpChatModBaseband::MsgConfigureChirpChatModPayload, Message)
 
-ChirpChatModBaseband::ChirpChatModBaseband() :
-    m_mutex(QMutex::Recursive)
+ChirpChatModBaseband::ChirpChatModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/modchirpchat/chirpchatmodbaseband.h
+++ b/plugins/channeltx/modchirpchat/chirpchatmodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_CHIRPCHATMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -104,7 +104,7 @@ private:
     ChirpChatModSource m_source;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     ChirpChatModSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/moddatv/datvmodbaseband.cpp
+++ b/plugins/channeltx/moddatv/datvmodbaseband.cpp
@@ -25,8 +25,7 @@
 #include "datvmodbaseband.h"
 #include "datvmod.h"
 
-DATVModBaseband::DATVModBaseband() :
-    m_mutex(QMutex::Recursive)
+DATVModBaseband::DATVModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/moddatv/datvmodbaseband.h
+++ b/plugins/channeltx/moddatv/datvmodbaseband.h
@@ -23,7 +23,7 @@
 #include <boost/chrono/chrono.hpp>
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -66,7 +66,7 @@ private:
     DATVModSource m_source;
     MessageQueue m_inputMessageQueue;
     DATVModSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/modfreedv/freedvmod.cpp
+++ b/plugins/channeltx/modfreedv/freedvmod.cpp
@@ -56,7 +56,6 @@ FreeDVMod::FreeDVMod(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
     m_deviceAPI(deviceAPI),
     m_spectrumVis(SDR_TX_SCALEF),
-	m_settingsMutex(QMutex::Recursive),
 	m_fileSize(0),
 	m_recordLength(0),
 	m_fileSampleRate(8000) // all modes take 8000 S/s input

--- a/plugins/channeltx/modfreedv/freedvmod.h
+++ b/plugins/channeltx/modfreedv/freedvmod.h
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <fstream>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesource.h"
@@ -259,7 +259,7 @@ private:
     SpectrumVis m_spectrumVis;
 
 	SampleVector m_sampleBuffer;
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
 
     std::ifstream m_ifstream;
     QString m_fileName;

--- a/plugins/channeltx/modfreedv/freedvmodbaseband.cpp
+++ b/plugins/channeltx/modfreedv/freedvmodbaseband.cpp
@@ -25,8 +25,7 @@
 
 MESSAGE_CLASS_DEFINITION(FreeDVModBaseband::MsgConfigureFreeDVModBaseband, Message)
 
-FreeDVModBaseband::FreeDVModBaseband() :
-    m_mutex(QMutex::Recursive)
+FreeDVModBaseband::FreeDVModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/modfreedv/freedvmodbaseband.h
+++ b/plugins/channeltx/modfreedv/freedvmodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_FREEDVMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -87,7 +87,7 @@ private:
     FreeDVModSource m_source;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     FreeDVModSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/modfreedv/freedvmodsource.cpp
+++ b/plugins/channeltx/modfreedv/freedvmodsource.cpp
@@ -46,8 +46,7 @@ FreeDVModSource::FreeDVModSource() :
 	m_iModem(0),
 	m_speechIn(nullptr),
 	m_modOut(nullptr),
-	m_scaleFactor(SDR_TX_SCALEF),
-    m_mutex(QMutex::Recursive)
+	m_scaleFactor(SDR_TX_SCALEF)
 {
     m_audioFifo.setLabel("FreeDVModSource.m_audioFifo");
     m_SSBFilter = new fftfilt(m_lowCutoff / m_audioSampleRate, m_hiCutoff / m_audioSampleRate, m_ssbFftLen);

--- a/plugins/channeltx/modfreedv/freedvmodsource.h
+++ b/plugins/channeltx/modfreedv/freedvmodsource.h
@@ -19,7 +19,7 @@
 #define INCLUDE_FREEDVMODSOURCE_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include <iostream>
 #include <fstream>
@@ -128,7 +128,7 @@ private:
     float m_scaleFactor; //!< divide by this amount to scale from int16 to float in [-1.0, 1.0] interval
     AudioResampler m_audioResampler;
 
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     static const int m_levelNbSamples;
 

--- a/plugins/channeltx/modm17/m17mod.cpp
+++ b/plugins/channeltx/modm17/m17mod.cpp
@@ -55,7 +55,6 @@ const char* const M17Mod::m_channelId = "M17Mod";
 M17Mod::M17Mod(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
 	m_deviceAPI(deviceAPI),
-	m_settingsMutex(QMutex::Recursive),
 	m_fileSize(0),
 	m_recordLength(0),
 	m_sampleRate(48000)

--- a/plugins/channeltx/modm17/m17mod.h
+++ b/plugins/channeltx/modm17/m17mod.h
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <fstream>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 #include <QTimer>
 
@@ -255,7 +255,7 @@ private:
     M17ModSettings m_settings;
 
     SampleVector m_sampleBuffer;
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
 
     std::ifstream m_ifstream;
     QString m_fileName;

--- a/plugins/channeltx/modm17/m17modbaseband.cpp
+++ b/plugins/channeltx/modm17/m17modbaseband.cpp
@@ -25,8 +25,7 @@
 
 MESSAGE_CLASS_DEFINITION(M17ModBaseband::MsgConfigureM17ModBaseband, Message)
 
-M17ModBaseband::M17ModBaseband() :
-    m_mutex(QMutex::Recursive)
+M17ModBaseband::M17ModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/modm17/m17modbaseband.h
+++ b/plugins/channeltx/modm17/m17modbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_M17MODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -89,7 +89,7 @@ private:
     M17ModSource m_source;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     M17ModSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/modm17/m17modsource.cpp
+++ b/plugins/channeltx/modm17/m17modsource.cpp
@@ -39,8 +39,7 @@ M17ModSource::M17ModSource() :
 	m_peakLevel(0.0f),
 	m_levelSum(0.0f),
     m_ifstream(nullptr),
-    m_preemphasisFilter(m_preemphasis*48000),
-    m_mutex(QMutex::Recursive)
+    m_preemphasisFilter(m_preemphasis*48000)
 {
     m_audioFifo.setLabel("M17ModSource.m_audioFifo");
     m_feedbackAudioFifo.setLabel("M17ModSource.m_feedbackAudioFifo");

--- a/plugins/channeltx/modm17/m17modsource.h
+++ b/plugins/channeltx/modm17/m17modsource.h
@@ -19,7 +19,7 @@
 #define INCLUDE_M17MODSOURCE_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QVector>
 #include <QThread>
 
@@ -128,7 +128,7 @@ private:
     QThread m_processorThread;
     HighPassFilterRC m_preemphasisFilter;
 
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     static const int m_levelNbSamples;
     static const float m_preemphasis;

--- a/plugins/channeltx/modnfm/nfmmod.cpp
+++ b/plugins/channeltx/modnfm/nfmmod.cpp
@@ -57,7 +57,6 @@ const char* const NFMMod::m_channelId = "NFMMod";
 NFMMod::NFMMod(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
 	m_deviceAPI(deviceAPI),
-	m_settingsMutex(QMutex::Recursive),
 	m_fileSize(0),
 	m_recordLength(0),
 	m_sampleRate(48000)

--- a/plugins/channeltx/modnfm/nfmmod.h
+++ b/plugins/channeltx/modnfm/nfmmod.h
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <fstream>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesource.h"
@@ -251,7 +251,7 @@ private:
     NFMModSettings m_settings;
 
     SampleVector m_sampleBuffer;
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
 
     std::ifstream m_ifstream;
     QString m_fileName;

--- a/plugins/channeltx/modnfm/nfmmodbaseband.cpp
+++ b/plugins/channeltx/modnfm/nfmmodbaseband.cpp
@@ -25,8 +25,7 @@
 
 MESSAGE_CLASS_DEFINITION(NFMModBaseband::MsgConfigureNFMModBaseband, Message)
 
-NFMModBaseband::NFMModBaseband() :
-    m_mutex(QMutex::Recursive)
+NFMModBaseband::NFMModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/modnfm/nfmmodbaseband.h
+++ b/plugins/channeltx/modnfm/nfmmodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_NFMMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -87,7 +87,7 @@ private:
     NFMModSource m_source;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     NFMModSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/modnfm/nfmmodsource.cpp
+++ b/plugins/channeltx/modnfm/nfmmodsource.cpp
@@ -37,8 +37,7 @@ NFMModSource::NFMModSource() :
 	m_levelCalcCount(0),
 	m_peakLevel(0.0f),
 	m_levelSum(0.0f),
-    m_ifstream(nullptr),
-    m_mutex(QMutex::Recursive)
+    m_ifstream(nullptr)
 {
     m_audioFifo.setLabel("NFMModSource.m_audioFifo");
     m_feedbackAudioFifo.setLabel("NFMModSource.m_feedbackAudioFifo");

--- a/plugins/channeltx/modnfm/nfmmodsource.h
+++ b/plugins/channeltx/modnfm/nfmmodsource.h
@@ -19,7 +19,7 @@
 #define INCLUDE_NFMMODSOURCE_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QVector>
 
 #include <iostream>
@@ -127,7 +127,7 @@ private:
 
     AudioCompressorSnd m_audioCompressor;
 
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     static const int m_levelNbSamples;
     static const float m_preemphasis;

--- a/plugins/channeltx/modpacket/packetmod.cpp
+++ b/plugins/channeltx/modpacket/packetmod.cpp
@@ -61,7 +61,6 @@ PacketMod::PacketMod(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
     m_deviceAPI(deviceAPI),
     m_spectrumVis(SDR_TX_SCALEF),
-    m_settingsMutex(QMutex::Recursive),
     m_sampleRate(48000),
     m_udpSocket(nullptr)
 {

--- a/plugins/channeltx/modpacket/packetmod.h
+++ b/plugins/channeltx/modpacket/packetmod.h
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <fstream>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesource.h"
@@ -224,7 +224,7 @@ private:
     SpectrumVis m_spectrumVis;
 
     SampleVector m_sampleBuffer;
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
 
     int m_sampleRate;
 

--- a/plugins/channeltx/modpacket/packetmodbaseband.cpp
+++ b/plugins/channeltx/modpacket/packetmodbaseband.cpp
@@ -27,8 +27,7 @@
 
 MESSAGE_CLASS_DEFINITION(PacketModBaseband::MsgConfigurePacketModBaseband, Message)
 
-PacketModBaseband::PacketModBaseband() :
-    m_mutex(QMutex::Recursive)
+PacketModBaseband::PacketModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/modpacket/packetmodbaseband.h
+++ b/plugins/channeltx/modpacket/packetmodbaseband.h
@@ -20,7 +20,7 @@
 #define INCLUDE_PACKETMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -84,7 +84,7 @@ private:
     PacketModSource m_source;
     MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     PacketModSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/modssb/ssbmod.cpp
+++ b/plugins/channeltx/modssb/ssbmod.cpp
@@ -57,7 +57,6 @@ SSBMod::SSBMod(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
     m_deviceAPI(deviceAPI),
     m_spectrumVis(SDR_TX_SCALEF),
-	m_settingsMutex(QMutex::Recursive),
 	m_fileSize(0),
 	m_recordLength(0),
 	m_sampleRate(48000)

--- a/plugins/channeltx/modssb/ssbmod.h
+++ b/plugins/channeltx/modssb/ssbmod.h
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <fstream>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesource.h"
@@ -255,7 +255,7 @@ private:
     SpectrumVis m_spectrumVis;
 
 	SampleVector m_sampleBuffer;
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
 
     std::ifstream m_ifstream;
     QString m_fileName;

--- a/plugins/channeltx/modssb/ssbmodbaseband.cpp
+++ b/plugins/channeltx/modssb/ssbmodbaseband.cpp
@@ -26,8 +26,7 @@
 
 MESSAGE_CLASS_DEFINITION(SSBModBaseband::MsgConfigureSSBModBaseband, Message)
 
-SSBModBaseband::SSBModBaseband() :
-    m_mutex(QMutex::Recursive)
+SSBModBaseband::SSBModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/modssb/ssbmodbaseband.h
+++ b/plugins/channeltx/modssb/ssbmodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_SSBMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -91,7 +91,7 @@ private:
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     SSBModSettings m_settings;
     SpectrumVis *m_spectrumVis;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/modssb/ssbmodsource.cpp
+++ b/plugins/channeltx/modssb/ssbmodsource.cpp
@@ -38,8 +38,7 @@ SSBModSource::SSBModSource() :
 	m_levelCalcCount(0),
 	m_peakLevel(0.0f),
 	m_levelSum(0.0f),
-    m_ifstream(nullptr),
-    m_mutex(QMutex::Recursive)
+    m_ifstream(nullptr)
 {
     m_audioFifo.setLabel("SSBModSource.m_audioFifo");
     m_feedbackAudioFifo.setLabel("SSBModSource.m_feedbackAudioFifo");

--- a/plugins/channeltx/modssb/ssbmodsource.h
+++ b/plugins/channeltx/modssb/ssbmodsource.h
@@ -19,7 +19,7 @@
 #define INCLUDE_SSBMODSOURCE_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QVector>
 
 #include <iostream>
@@ -135,7 +135,7 @@ private:
     AudioCompressorSnd m_audioCompressor;
     int m_agcStepLength;
 
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     static const int m_levelNbSamples;
 

--- a/plugins/channeltx/modwfm/wfmmod.cpp
+++ b/plugins/channeltx/modwfm/wfmmod.cpp
@@ -55,7 +55,6 @@ const char* const WFMMod::m_channelId = "WFMMod";
 WFMMod::WFMMod(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
     m_deviceAPI(deviceAPI),
-	m_settingsMutex(QMutex::Recursive),
     m_fileSize(0),
 	m_recordLength(0),
 	m_sampleRate(48000)

--- a/plugins/channeltx/modwfm/wfmmod.h
+++ b/plugins/channeltx/modwfm/wfmmod.h
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <fstream>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesource.h"
@@ -261,7 +261,7 @@ private:
     WFMModSettings m_settings;
 
     SampleVector m_sampleBuffer;
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
 
     std::ifstream m_ifstream;
     QString m_fileName;

--- a/plugins/channeltx/modwfm/wfmmodbaseband.cpp
+++ b/plugins/channeltx/modwfm/wfmmodbaseband.cpp
@@ -25,8 +25,7 @@
 
 MESSAGE_CLASS_DEFINITION(WFMModBaseband::MsgConfigureWFMModBaseband, Message)
 
-WFMModBaseband::WFMModBaseband() :
-    m_mutex(QMutex::Recursive)
+WFMModBaseband::WFMModBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/modwfm/wfmmodbaseband.h
+++ b/plugins/channeltx/modwfm/wfmmodbaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_WFMMODBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -86,7 +86,7 @@ private:
     WFMModSource m_source;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     WFMModSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/modwfm/wfmmodsource.cpp
+++ b/plugins/channeltx/modwfm/wfmmodsource.cpp
@@ -36,8 +36,7 @@ WFMModSource::WFMModSource() :
 	m_levelCalcCount(0),
 	m_peakLevel(0.0f),
 	m_levelSum(0.0f),
-    m_ifstream(nullptr),
-    m_mutex(QMutex::Recursive)
+    m_ifstream(nullptr)
 {
     m_audioFifo.setLabel("WFMModSource.m_audioFifo");
     m_feedbackAudioFifo.setLabel("WFMModSource.m_feedbackAudioFifo");

--- a/plugins/channeltx/modwfm/wfmmodsource.h
+++ b/plugins/channeltx/modwfm/wfmmodsource.h
@@ -19,7 +19,7 @@
 #define INCLUDE_WFMMODSOURCE_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QVector>
 
 #include <iostream>
@@ -122,7 +122,7 @@ private:
     std::ifstream *m_ifstream;
     CWKeyer m_cwKeyer;
 
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     static const int m_levelNbSamples;
 

--- a/plugins/channeltx/remotesource/remotesourcebaseband.cpp
+++ b/plugins/channeltx/remotesource/remotesourcebaseband.cpp
@@ -26,8 +26,7 @@
 MESSAGE_CLASS_DEFINITION(RemoteSourceBaseband::MsgConfigureRemoteSourceBaseband, Message)
 MESSAGE_CLASS_DEFINITION(RemoteSourceBaseband::MsgConfigureRemoteSourceWork, Message)
 
-RemoteSourceBaseband::RemoteSourceBaseband() :
-    m_mutex(QMutex::Recursive)
+RemoteSourceBaseband::RemoteSourceBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/remotesource/remotesourcebaseband.h
+++ b/plugins/channeltx/remotesource/remotesourcebaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_REMOTESOURCEBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -94,7 +94,7 @@ private:
     RemoteSourceSource m_source;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     RemoteSourceSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/channeltx/remotesource/remotesourceworker.cpp
+++ b/plugins/channeltx/remotesource/remotesourceworker.cpp
@@ -32,7 +32,6 @@ RemoteSourceWorker::RemoteSourceWorker(RemoteDataQueue *dataQueue, QObject* pare
     m_dataQueue(dataQueue),
     m_address(QHostAddress::LocalHost),
     m_socket(this),
-    m_mutex(QMutex::Recursive),
     m_sampleRate(0),
     m_udpReadBytes(0)
 {

--- a/plugins/channeltx/remotesource/remotesourceworker.h
+++ b/plugins/channeltx/remotesource/remotesourceworker.h
@@ -69,7 +69,7 @@ private:
 
     QHostAddress m_address;
     QUdpSocket m_socket;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     static const uint32_t m_nbDataFrames = 4;       //!< number of data frames in the ring buffer
     RemoteDataFrame *m_dataFrames[m_nbDataFrames];  //!< ring buffer of data frames indexed by frame affinity

--- a/plugins/channeltx/udpsource/udpsource.cpp
+++ b/plugins/channeltx/udpsource/udpsource.cpp
@@ -44,8 +44,7 @@ const char* const UDPSource::m_channelId = "UDPSource";
 UDPSource::UDPSource(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSource),
     m_deviceAPI(deviceAPI),
-    m_spectrumVis(SDR_TX_SCALEF),
-    m_settingsMutex(QMutex::Recursive)
+    m_spectrumVis(SDR_TX_SCALEF)
 {
     setObjectName(m_channelId);
 

--- a/plugins/channeltx/udpsource/udpsource.h
+++ b/plugins/channeltx/udpsource/udpsource.h
@@ -174,7 +174,7 @@ private:
     SpectrumVis m_spectrumVis;
 
     SampleVector m_sampleBuffer;
-    QMutex m_settingsMutex;
+    QRecursiveMutex m_settingsMutex;
 
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channeltx/udpsource/udpsourcebaseband.cpp
+++ b/plugins/channeltx/udpsource/udpsourcebaseband.cpp
@@ -29,8 +29,7 @@ MESSAGE_CLASS_DEFINITION(UDPSourceBaseband::MsgConfigureChannelizer, Message)
 MESSAGE_CLASS_DEFINITION(UDPSourceBaseband::MsgUDPSourceSpectrum, Message)
 MESSAGE_CLASS_DEFINITION(UDPSourceBaseband::MsgResetReadIndex, Message)
 
-UDPSourceBaseband::UDPSourceBaseband() :
-    m_mutex(QMutex::Recursive)
+UDPSourceBaseband::UDPSourceBaseband()
 {
     m_sampleFifo.resize(SampleSourceFifo::getSizePolicy(48000));
     m_channelizer = new UpChannelizer(&m_source);

--- a/plugins/channeltx/udpsource/udpsourcebaseband.h
+++ b/plugins/channeltx/udpsource/udpsourcebaseband.h
@@ -19,7 +19,7 @@
 #define INCLUDE_UDPSOURCEBASEBAND_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/samplesourcefifo.h"
 #include "util/message.h"
@@ -144,7 +144,7 @@ private:
     UDPSourceSource m_source;
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     UDPSourceSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void processFifo(SampleVector& data, unsigned int iBegin, unsigned int iEnd);
     bool handleMessage(const Message& cmd);

--- a/plugins/feature/afc/afcworker.cpp
+++ b/plugins/feature/afc/afcworker.cpp
@@ -46,8 +46,7 @@ AFCWorker::AFCWorker(WebAPIAdapterInterface *webAPIAdapterInterface) :
     m_freqTracker(nullptr),
     m_trackerDeviceFrequency(0),
     m_trackerChannelOffset(0),
-    m_updateTimer(this),
-    m_mutex(QMutex::Recursive)
+    m_updateTimer(this)
 {
     qDebug("AFCWorker::AFCWorker");
 	connect(&m_updateTimer, SIGNAL(timeout()), this, SLOT(updateTarget()));

--- a/plugins/feature/afc/afcworker.h
+++ b/plugins/feature/afc/afcworker.h
@@ -153,7 +153,7 @@ private:
     int m_trackerChannelOffset;
     QMap<ChannelAPI*, ChannelTracking> m_channelsMap;
 	QTimer m_updateTimer;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const AFCSettings& settings, bool force = false);

--- a/plugins/feature/aprs/aprsworker.cpp
+++ b/plugins/feature/aprs/aprsworker.cpp
@@ -38,7 +38,6 @@ APRSWorker::APRSWorker(APRS *aprs, WebAPIAdapterInterface *webAPIAdapterInterfac
     m_msgQueueToFeature(nullptr),
     m_msgQueueToGUI(nullptr),
     m_running(false),
-    m_mutex(QMutex::Recursive),
     m_socket(this)
 {
     connect(&m_socket, SIGNAL(readyRead()),this, SLOT(recv()));

--- a/plugins/feature/aprs/aprsworker.h
+++ b/plugins/feature/aprs/aprsworker.h
@@ -76,7 +76,7 @@ private:
     MessageQueue *m_msgQueueToGUI;
     APRSSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     QTcpSocket m_socket;
     bool m_loggedIn;
 

--- a/plugins/feature/demodanalyzer/demodanalyzerworker.cpp
+++ b/plugins/feature/demodanalyzer/demodanalyzerworker.cpp
@@ -29,8 +29,7 @@ DemodAnalyzerWorker::DemodAnalyzerWorker() :
     m_dataFifo(nullptr),
     m_msgQueueToFeature(nullptr),
     m_sampleBufferSize(0),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("DemodAnalyzerWorker::DemodAnalyzerWorker");
 }

--- a/plugins/feature/demodanalyzer/demodanalyzerworker.h
+++ b/plugins/feature/demodanalyzer/demodanalyzerworker.h
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QByteArray>
 
 #include "dsp/dsptypes.h"
@@ -123,7 +123,7 @@ private:
 	MovingAverageUtil<double, double, 480> m_channelPowerAvg;
     ScopeVis* m_scopeVis;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void decimate(int countSamples);

--- a/plugins/feature/gs232controller/gs232controllerworker.cpp
+++ b/plugins/feature/gs232controller/gs232controllerworker.cpp
@@ -33,7 +33,6 @@ MESSAGE_CLASS_DEFINITION(GS232ControllerReport::MsgReportAzAl, Message)
 GS232ControllerWorker::GS232ControllerWorker() :
     m_msgQueueToFeature(nullptr),
     m_running(false),
-    m_mutex(QMutex::Recursive),
     m_device(nullptr),
     m_serialPort(this),
     m_socket(this),

--- a/plugins/feature/gs232controller/gs232controllerworker.h
+++ b/plugins/feature/gs232controller/gs232controllerworker.h
@@ -71,7 +71,7 @@ private:
     MessageQueue *m_msgQueueToFeature; //!< Queue to report channel change to main feature object
     GS232ControllerSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     QIODevice *m_device;
     QSerialPort m_serialPort;
     QTcpSocket m_socket;

--- a/plugins/feature/map/map.cpp
+++ b/plugins/feature/map/map.cpp
@@ -46,8 +46,7 @@ const char* const Map::m_featureId = "Map";
 
 Map::Map(WebAPIAdapterInterface *webAPIAdapterInterface) :
     Feature(m_featureIdURI, webAPIAdapterInterface),
-    m_multiplier(0.0),
-    m_dateTimeMutex(QMutex::Recursive)
+    m_multiplier(0.0)
 {
     qDebug("Map::Map: webAPIAdapterInterface: %p", webAPIAdapterInterface);
     setObjectName(m_featureId);

--- a/plugins/feature/map/map.h
+++ b/plugins/feature/map/map.h
@@ -23,7 +23,7 @@
 #include <QHash>
 #include <QNetworkRequest>
 #include <QDateTime>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "feature/feature.h"
 #include "util/message.h"
@@ -187,7 +187,7 @@ private:
     QDateTime m_mapDateTime;
     QDateTime m_systemDateTime;
     double m_multiplier;
-    QMutex m_dateTimeMutex;
+    QRecursiveMutex m_dateTimeMutex;
 
 private slots:
     void networkManagerFinished(QNetworkReply *reply);

--- a/plugins/feature/pertester/pertesterworker.cpp
+++ b/plugins/feature/pertester/pertesterworker.cpp
@@ -40,7 +40,6 @@ PERTesterWorker::PERTesterWorker() :
     m_msgQueueToFeature(nullptr),
     m_msgQueueToGUI(nullptr),
     m_running(false),
-    m_mutex(QMutex::Recursive),
     m_rxUDPSocket(nullptr),
     m_txUDPSocket(this),
     m_txTimer(this),

--- a/plugins/feature/pertester/pertesterworker.h
+++ b/plugins/feature/pertester/pertesterworker.h
@@ -72,7 +72,7 @@ private:
     MessageQueue *m_msgQueueToGUI;
     PERTesterSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     QUdpSocket *m_rxUDPSocket;                  //!< UDP socket to receive packets on
     QUdpSocket m_txUDPSocket;
     QTimer m_txTimer;

--- a/plugins/feature/rigctlserver/rigctlserverworker.cpp
+++ b/plugins/feature/rigctlserver/rigctlserverworker.cpp
@@ -55,8 +55,7 @@ RigCtlServerWorker::RigCtlServerWorker(WebAPIAdapterInterface *webAPIAdapterInte
     m_clientConnection(nullptr),
     m_webAPIAdapterInterface(webAPIAdapterInterface),
     m_msgQueueToFeature(nullptr),
-    m_running(false),
-    m_mutex(QMutex::Recursive)
+    m_running(false)
 {
     qDebug("RigCtlServerWorker::RigCtlServerWorker");
 }

--- a/plugins/feature/rigctlserver/rigctlserverworker.h
+++ b/plugins/feature/rigctlserver/rigctlserverworker.h
@@ -118,7 +118,7 @@ private:
     MessageQueue *m_msgQueueToFeature; //!< Queue to report channel change to main feature object
     RigCtlServerSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     static const unsigned int m_CmdLength;
     static const unsigned int m_ResponseLength;

--- a/plugins/feature/satellitetracker/satellitetrackerworker.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackerworker.cpp
@@ -56,7 +56,6 @@ SatelliteTrackerWorker::SatelliteTrackerWorker(SatelliteTracker* satelliteTracke
     m_msgQueueToFeature(nullptr),
     m_msgQueueToGUI(nullptr),
     m_running(false),
-    m_mutex(QMutex::Recursive),
     m_pollTimer(this),
     m_recalculatePasses(true),
     m_flipRotation(false),

--- a/plugins/feature/satellitetracker/satellitetrackerworker.h
+++ b/plugins/feature/satellitetracker/satellitetrackerworker.h
@@ -111,7 +111,7 @@ private:
     MessageQueue *m_msgQueueToGUI;
     SatelliteTrackerSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     QTimer m_pollTimer;
     QHash<QString, SatNogsSatellite *> m_satellites;
     QHash<QString, SatWorkerState *> m_workerState;

--- a/plugins/feature/simpleptt/simplepttworker.cpp
+++ b/plugins/feature/simpleptt/simplepttworker.cpp
@@ -42,8 +42,7 @@ SimplePTTWorker::SimplePTTWorker(WebAPIAdapterInterface *webAPIAdapterInterface)
     m_voxLevel(1.0),
     m_voxHoldCount(0),
     m_voxState(false),
-    m_updateTimer(this),
-    m_mutex(QMutex::Recursive)
+    m_updateTimer(this)
 {
     m_audioReadBuffer.resize(16384);
     m_audioReadBufferFill = 0;

--- a/plugins/feature/simpleptt/simplepttworker.h
+++ b/plugins/feature/simpleptt/simplepttworker.h
@@ -106,7 +106,7 @@ private:
     int m_voxHoldCount;
     bool m_voxState;
 	QTimer m_updateTimer;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const SimplePTTSettings& settings, bool force = false);

--- a/plugins/feature/startracker/startrackerworker.cpp
+++ b/plugins/feature/startracker/startrackerworker.cpp
@@ -51,7 +51,6 @@ StarTrackerWorker::StarTrackerWorker(StarTracker* starTracker, WebAPIAdapterInte
     m_msgQueueToFeature(nullptr),
     m_msgQueueToGUI(nullptr),
     m_running(false),
-    m_mutex(QMutex::Recursive),
     m_pollTimer(this),
     m_tcpServer(nullptr),
     m_clientConnection(nullptr),

--- a/plugins/feature/startracker/startrackerworker.h
+++ b/plugins/feature/startracker/startrackerworker.h
@@ -82,7 +82,7 @@ private:
     MessageQueue *m_msgQueueToGUI;
     StarTrackerSettings m_settings;
     bool m_running;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     QTimer m_pollTimer;
     QTcpServer *m_tcpServer;
     QTcpSocket *m_clientConnection;

--- a/plugins/feature/vorlocalizer/vorlocalizerworker.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizerworker.cpp
@@ -47,7 +47,6 @@ VorLocalizerWorker::VorLocalizerWorker(WebAPIAdapterInterface *webAPIAdapterInte
     m_availableChannels(nullptr),
     m_running(false),
     m_updateTimer(this),
-    m_mutex(QMutex::Recursive),
     m_rrTimer(this)
 {
     qDebug("VorLocalizerWorker::VorLocalizerWorker");

--- a/plugins/feature/vorlocalizer/vorlocalizerworker.h
+++ b/plugins/feature/vorlocalizer/vorlocalizerworker.h
@@ -148,7 +148,7 @@ private:
     QHash<ChannelAPI*, VORLocalizerSettings::AvailableChannel> *m_availableChannels;
     bool m_running;
 	QTimer m_updateTimer;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     QTimer m_rrTimer;
     std::vector<std::vector<RRTurnPlan>> m_rrPlans; //!< Round robin plans for each device
     std::vector<int> m_rrTurnCounters; //!< Round robin turn count for each device

--- a/plugins/samplemimo/metismiso/metismisoudphandler.cpp
+++ b/plugins/samplemimo/metismiso/metismisoudphandler.cpp
@@ -34,7 +34,6 @@ MetisMISOUDPHandler::MetisMISOUDPHandler(SampleMIFifo *sampleMIFifo, SampleMOFif
     m_sampleCount(0),
     m_sampleTxCount(0),
 	m_messageQueueToGUI(nullptr),
-    m_mutex(QMutex::Recursive),
     m_commandBase(0),
     m_receiveSequence(0),
     m_receiveSequenceError(0)

--- a/plugins/samplemimo/metismiso/metismisoudphandler.h
+++ b/plugins/samplemimo/metismiso/metismisoudphandler.h
@@ -21,7 +21,7 @@
 #include <QObject>
 #include <QUdpSocket>
 #include <QHostAddress>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/decimators.h"
 #include "util/messagequeue.h"
@@ -88,7 +88,7 @@ private:
 	MessageQueue *m_messageQueueToGUI;
     MessageQueue m_inputMessageQueue;
     MetisMISOSettings m_settings;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     MetisMISODecimators m_decimators;
 
     unsigned long m_sendSequence;

--- a/plugins/samplemimo/testmi/testmiworker.cpp
+++ b/plugins/samplemimo/testmi/testmiworker.cpp
@@ -61,8 +61,7 @@ TestMIWorker::TestMIWorker(SampleMIFifo* sampleFifo, int streamIndex, QObject* p
 	m_frequency(435*1000),
 	m_fcPosShift(0),
     m_throttlems(TESTMI_THROTTLE_MS),
-    m_throttleToggle(false),
-    m_mutex(QMutex::Recursive)
+    m_throttleToggle(false)
 {
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
 }

--- a/plugins/samplemimo/testmi/testmiworker.h
+++ b/plugins/samplemimo/testmi/testmiworker.h
@@ -105,7 +105,7 @@ private:
     QTimer m_timer;
     QElapsedTimer m_elapsedTimer;
     bool m_throttleToggle;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     MessageQueue m_inputMessageQueue;
 

--- a/plugins/samplesource/remoteinput/remoteinput.cpp
+++ b/plugins/samplesource/remoteinput/remoteinput.cpp
@@ -51,7 +51,6 @@ MESSAGE_CLASS_DEFINITION(RemoteInput::MsgRequestFixedData, Message)
 RemoteInput::RemoteInput(DeviceAPI *deviceAPI) :
     m_deviceAPI(deviceAPI),
     m_sampleRate(48000),
-    m_mutex(QMutex::Recursive),
     m_settings(),
 	m_remoteInputUDPHandler(nullptr),
 	m_deviceDescription("RemoteInput"),

--- a/plugins/samplesource/remoteinput/remoteinput.h
+++ b/plugins/samplesource/remoteinput/remoteinput.h
@@ -403,7 +403,7 @@ public:
 private:
 	DeviceAPI *m_deviceAPI;
     int m_sampleRate;
-	QMutex m_mutex;
+	QRecursiveMutex m_mutex;
 	RemoteInputSettings m_settings;
     RemoteChannelSettings m_remoteChannelSettings;
 	RemoteInputUDPHandler* m_remoteInputUDPHandler;

--- a/plugins/samplesource/remotetcpinput/remotetcpinput.cpp
+++ b/plugins/samplesource/remotetcpinput/remotetcpinput.cpp
@@ -44,7 +44,6 @@ MESSAGE_CLASS_DEFINITION(RemoteTCPInput::MsgReportTCPBuffer, Message)
 
 RemoteTCPInput::RemoteTCPInput(DeviceAPI *deviceAPI) :
     m_deviceAPI(deviceAPI),
-    m_mutex(QMutex::Recursive),
     m_settings(),
     m_remoteInputTCPPHandler(nullptr),
     m_deviceDescription("RemoteTCPInput")

--- a/plugins/samplesource/remotetcpinput/remotetcpinput.h
+++ b/plugins/samplesource/remotetcpinput/remotetcpinput.h
@@ -177,7 +177,7 @@ public:
 
 private:
     DeviceAPI *m_deviceAPI;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     RemoteTCPInputSettings m_settings;
     RemoteTCPInputTCPHandler* m_remoteInputTCPPHandler;
     QString m_deviceDescription;

--- a/plugins/samplesource/remotetcpinput/remotetcpinputtcphandler.cpp
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputtcphandler.cpp
@@ -43,7 +43,6 @@ RemoteTCPInputTCPHandler::RemoteTCPInputTCPHandler(SampleSinkFifo *sampleFifo, D
     m_reconnectTimer(this),
     m_converterBuffer(nullptr),
     m_converterBufferNbSamples(0),
-    m_mutex(QMutex::Recursive),
     m_settings()
 {
     m_tcpBuf = new char[m_sampleFifo->size()*2*4];

--- a/plugins/samplesource/remotetcpinput/remotetcpinputtcphandler.h
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputtcphandler.h
@@ -22,7 +22,7 @@
 #include <QObject>
 #include <QTcpSocket>
 #include <QHostAddress>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QDateTime>
 
 #include "util/messagequeue.h"
@@ -138,7 +138,7 @@ private:
     int32_t *m_converterBuffer;
     uint32_t m_converterBufferNbSamples;
 
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     RemoteTCPInputSettings m_settings;
 
     void applyTCPLink(const QString& address, quint16 port);

--- a/plugins/samplesource/testsource/testsourceworker.cpp
+++ b/plugins/samplesource/testsource/testsourceworker.cpp
@@ -60,7 +60,6 @@ TestSourceWorker::TestSourceWorker(SampleSinkFifo* sampleFifo, QObject* parent) 
 	m_fcPosShift(0),
     m_throttlems(TESTSOURCE_THROTTLE_MS),
     m_throttleToggle(false),
-    m_mutex(QMutex::Recursive),
     m_histoCounter(0)
 {
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);

--- a/plugins/samplesource/testsource/testsourceworker.h
+++ b/plugins/samplesource/testsource/testsourceworker.h
@@ -105,7 +105,7 @@ private:
     QTimer m_timer;
     QElapsedTimer m_elapsedTimer;
     bool m_throttleToggle;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     MessageQueue m_inputMessageQueue;
 

--- a/qrtplib/rtpudptransmitter.cpp
+++ b/qrtplib/rtpudptransmitter.cpp
@@ -41,8 +41,7 @@
 namespace qrtplib
 {
 
-RTPUDPTransmitter::RTPUDPTransmitter() :
-    m_rawPacketQueueLock(QMutex::Recursive)
+RTPUDPTransmitter::RTPUDPTransmitter()
 {
     m_created = false;
     m_init = false;

--- a/qrtplib/rtpudptransmitter.h
+++ b/qrtplib/rtpudptransmitter.h
@@ -40,7 +40,7 @@
 #include <QHostAddress>
 #include <QNetworkInterface>
 #include <QQueue>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include <stdint.h>
 #include <list>
@@ -362,7 +362,7 @@ private:
     std::list<RTPAddress> m_acceptList;
     std::list<RTPAddress> m_ignoreList;
     QQueue<RTPRawPacket*> m_rawPacketQueue;
-    QMutex m_rawPacketQueueLock;
+    QRecursiveMutex m_rawPacketQueueLock;
 
     bool ShouldAcceptData(const RTPAddress& address);
 

--- a/sdrbase/audio/audioinputdevice.cpp
+++ b/sdrbase/audio/audioinputdevice.cpp
@@ -23,7 +23,6 @@
 #include "audio/audiofifo.h"
 
 AudioInputDevice::AudioInputDevice() :
-	m_mutex(QMutex::Recursive),
 	m_audioInput(0),
 	m_audioUsageCount(0),
 	m_onExit(false),

--- a/sdrbase/audio/audioinputdevice.h
+++ b/sdrbase/audio/audioinputdevice.h
@@ -18,7 +18,7 @@
 #ifndef SDRBASE_AUDIO_AUDIOINPUTDEVICE_H_
 #define SDRBASE_AUDIO_AUDIOINPUTDEVICE_H_
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QIODevice>
 #include <QAudioFormat>
 #include <list>
@@ -47,7 +47,7 @@ public:
 	void setVolume(float volume);
 
 private:
-	QMutex m_mutex;
+	QRecursiveMutex m_mutex;
 	QAudioInput* m_audioInput;
 	uint m_audioUsageCount;
 	bool m_onExit;

--- a/sdrbase/audio/audioopus.cpp
+++ b/sdrbase/audio/audioopus.cpp
@@ -27,8 +27,7 @@
 
 AudioOpus::AudioOpus() :
     m_encoderState(0),
-    m_encoderOK(false),
-    m_mutex(QMutex::Recursive)
+    m_encoderOK(false)
 {
     qDebug("AudioOpus::AudioOpus: libopus version %s", opus_get_version_string());
 }

--- a/sdrbase/audio/audioopus.h
+++ b/sdrbase/audio/audioopus.h
@@ -20,7 +20,7 @@
 #define SDRBASE_AUDIO_AUDIOOPUS_H_
 
 #include <stdint.h>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include "export.h"
 
 struct OpusEncoder;
@@ -40,7 +40,7 @@ public:
 private:
     OpusEncoder *m_encoderState;
     bool m_encoderOK;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 };
 
 #endif /* SDRBASE_AUDIO_AUDIOOPUS_H_ */

--- a/sdrbase/audio/audiooutputdevice.cpp
+++ b/sdrbase/audio/audiooutputdevice.cpp
@@ -25,7 +25,6 @@
 #include "audionetsink.h"
 
 AudioOutputDevice::AudioOutputDevice() :
-	m_mutex(QMutex::Recursive),
 	m_audioOutput(0),
 	m_audioNetSink(0),
 	m_copyAudioToUdp(false),

--- a/sdrbase/audio/audiooutputdevice.h
+++ b/sdrbase/audio/audiooutputdevice.h
@@ -19,7 +19,7 @@
 #ifndef INCLUDE_AUDIOOUTPUTDEVICE_H
 #define INCLUDE_AUDIOOUTPUTDEVICE_H
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QIODevice>
 #include <QAudioFormat>
 #include <list>
@@ -74,7 +74,7 @@ public:
 	void setVolume(float volume);
 
 private:
-	QMutex m_mutex;
+	QRecursiveMutex m_mutex;
 	QAudioOutput* m_audioOutput;
 	AudioNetSink* m_audioNetSink;
 	bool m_copyAudioToUdp;

--- a/sdrbase/channel/remotedataqueue.cpp
+++ b/sdrbase/channel/remotedataqueue.cpp
@@ -29,7 +29,6 @@
 
 RemoteDataQueue::RemoteDataQueue(QObject* parent) :
 	QObject(parent),
-	m_lock(QMutex::Recursive),
 	m_queue()
 {
 }

--- a/sdrbase/channel/remotedataqueue.h
+++ b/sdrbase/channel/remotedataqueue.h
@@ -26,7 +26,7 @@
 #define CHANNEL_REMOTEDATAQUEUE_H_
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QQueue>
 
 #include "export.h"
@@ -50,7 +50,7 @@ signals:
     void dataBlockEnqueued();
 
 private:
-    QMutex m_lock;
+    QRecursiveMutex m_lock;
     QQueue<RemoteDataFrame*> m_queue;
 };
 

--- a/sdrbase/dsp/cwkeyer.cpp
+++ b/sdrbase/dsp/cwkeyer.cpp
@@ -161,7 +161,6 @@ const signed char CWKeyer::m_asciiToMorse[128][7] = {
 };
 
 CWKeyer::CWKeyer() :
-    m_mutex(QMutex::Recursive),
     m_textPointer(0),
 	m_elementPointer(0),
     m_samplePointer(0),

--- a/sdrbase/dsp/cwkeyer.h
+++ b/sdrbase/dsp/cwkeyer.h
@@ -20,7 +20,7 @@
 #define SDRBASE_DSP_CWKEYER_H_
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "export.h"
 #include "util/message.h"
@@ -41,7 +41,7 @@ public:
     bool getFadeSample(bool on, float& sample);
 
 private:
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     unsigned int m_fadeInCounter;
     unsigned int m_fadeOutCounter;
     unsigned int m_nbFadeSamples;
@@ -129,7 +129,7 @@ public:
     );
 
 private:
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     CWKeyerSettings m_settings;
     MessageQueue m_inputMessageQueue;
     int m_dotLength;   //!< dot length in samples

--- a/sdrbase/dsp/datafifo.cpp
+++ b/sdrbase/dsp/datafifo.cpp
@@ -41,8 +41,7 @@ void DataFifo::reset()
 DataFifo::DataFifo(QObject* parent) :
 	QObject(parent),
 	m_data(),
-	m_currentDataType(DataTypeI16),
-	m_mutex(QMutex::Recursive)
+	m_currentDataType(DataTypeI16)
 {
 	setObjectName("DataFifo");
 	m_suppressed = -1;
@@ -55,8 +54,7 @@ DataFifo::DataFifo(QObject* parent) :
 DataFifo::DataFifo(int size, QObject* parent) :
 	QObject(parent),
 	m_data(),
-	m_currentDataType(DataTypeI16),
-	m_mutex(QMutex::Recursive)
+	m_currentDataType(DataTypeI16)
 {
 	setObjectName("DataFifo");
 	m_suppressed = -1;
@@ -66,8 +64,7 @@ DataFifo::DataFifo(int size, QObject* parent) :
 DataFifo::DataFifo(const DataFifo& other) :
     QObject(other.parent()),
     m_data(other.m_data),
-	m_currentDataType(DataTypeI16),
-	m_mutex(QMutex::Recursive)
+	m_currentDataType(DataTypeI16)
 {
 	setObjectName("DataFifo");
   	m_suppressed = -1;

--- a/sdrbase/dsp/datafifo.h
+++ b/sdrbase/dsp/datafifo.h
@@ -20,7 +20,7 @@
 #define INCLUDE_DATAFIFO_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QElapsedTimer>
 #include <QByteArray>
 
@@ -65,7 +65,7 @@ private:
 	int m_suppressed;
 	QByteArray m_data;
 	DataType m_currentDataType;
-	QMutex m_mutex;
+	QRecursiveMutex m_mutex;
 
 	unsigned int m_size;
 	unsigned int m_fill;

--- a/sdrbase/dsp/fftfactory.cpp
+++ b/sdrbase/dsp/fftfactory.cpp
@@ -19,8 +19,7 @@
 #include "fftfactory.h"
 
 FFTFactory::FFTFactory(const QString& fftwWisdomFileName) :
-    m_fftwWisdomFileName(fftwWisdomFileName),
-    m_mutex(QMutex::Recursive)
+    m_fftwWisdomFileName(fftwWisdomFileName)
 {}
 
 FFTFactory::~FFTFactory()

--- a/sdrbase/dsp/fftfactory.h
+++ b/sdrbase/dsp/fftfactory.h
@@ -21,7 +21,7 @@
 #include <map>
 #include <vector>
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QString>
 
 #include "export.h"
@@ -52,7 +52,7 @@ private:
     QString m_fftwWisdomFileName;
     std::map<unsigned int, std::vector<AllocatedEngine>> m_fftEngineBySize;
     std::map<unsigned int, std::vector<AllocatedEngine>> m_invFFTEngineBySize;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 };
 
 #endif // _SDRBASE_FFTWFACTORY_H

--- a/sdrbase/dsp/filerecord.cpp
+++ b/sdrbase/dsp/filerecord.cpp
@@ -35,8 +35,7 @@ FileRecord::FileRecord(quint32 sampleRate, quint64 centerFrequency) :
 	m_recordOn(false),
     m_recordStart(false),
     m_byteCount(0),
-    m_msShift(0),
-    m_mutex(QMutex::Recursive)
+    m_msShift(0)
 {
 	setObjectName("FileRecord");
 }
@@ -48,8 +47,7 @@ FileRecord::FileRecord(const QString& fileBase) :
     m_centerFrequency(0),
     m_recordOn(false),
     m_recordStart(false),
-    m_byteCount(0),
-    m_mutex(QMutex::Recursive)
+    m_byteCount(0)
 {
     setObjectName("FileRecord");
 }

--- a/sdrbase/dsp/filerecord.h
+++ b/sdrbase/dsp/filerecord.h
@@ -77,7 +77,7 @@ private:
     QString m_curentFileName;
     quint64 m_byteCount;
     qint64 m_msShift;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 
     void writeHeader();
 };

--- a/sdrbase/dsp/samplemififo.cpp
+++ b/sdrbase/dsp/samplemififo.cpp
@@ -53,14 +53,12 @@ SampleMIFifo::SampleMIFifo(QObject *parent) :
     m_nbStreams(0),
     m_size(0),
     m_fill(0),
-    m_head(0),
-    m_mutex(QMutex::Recursive)
+    m_head(0)
 {
 }
 
 SampleMIFifo::SampleMIFifo(unsigned int nbStreams, unsigned int size, QObject *parent) :
-    QObject(parent),
-    m_mutex(QMutex::Recursive)
+    QObject(parent)
 {
     init(nbStreams, size);
 }

--- a/sdrbase/dsp/samplemififo.h
+++ b/sdrbase/dsp/samplemififo.h
@@ -19,7 +19,7 @@
 #define INCLUDE_SAMPLEMIFIFO_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <vector>
 #include "dsp/dsptypes.h"
 #include "export.h"
@@ -95,7 +95,7 @@ private:
     unsigned int m_head;               //!< Number of samples read from beginning of samples vector (sync)
     std::vector<unsigned int> m_vFill; //!< Number of samples written from beginning of samples vector (async)
     std::vector<unsigned int> m_vHead; //!< Number of samples read from beginning of samples vector (async)
-	QMutex m_mutex;
+	QRecursiveMutex m_mutex;
 };
 
 #endif // INCLUDE_SAMPLEMIFIFO_H

--- a/sdrbase/dsp/samplemofifo.cpp
+++ b/sdrbase/dsp/samplemofifo.cpp
@@ -22,13 +22,11 @@ const unsigned int SampleMOFifo::m_guardDivisor = 10;
 
 SampleMOFifo::SampleMOFifo(QObject *parent) :
     QObject(parent),
-    m_nbStreams(0),
-    m_mutex(QMutex::Recursive)
+    m_nbStreams(0)
 {}
 
 SampleMOFifo::SampleMOFifo(unsigned int nbStreams, unsigned int size, QObject *parent) :
-    QObject(parent),
-    m_mutex(QMutex::Recursive)
+    QObject(parent)
 {
     init(nbStreams, size);
 }

--- a/sdrbase/dsp/samplemofifo.h
+++ b/sdrbase/dsp/samplemofifo.h
@@ -19,7 +19,7 @@
 #define INCLUDE_SAMPLEMOFIFO_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include "dsp/dsptypes.h"
 #include "export.h"
 
@@ -102,7 +102,7 @@ private:
     std::vector<unsigned int> m_vReadCount;
     std::vector<unsigned int> m_vReadHead;
     std::vector<unsigned int> m_vWriteHead;
-	QMutex m_mutex;
+	QRecursiveMutex m_mutex;
 };
 
 #endif // INCLUDE_SAMPLEMOFIFO_H

--- a/sdrbase/dsp/samplesinkfifo.cpp
+++ b/sdrbase/dsp/samplesinkfifo.cpp
@@ -45,8 +45,7 @@ SampleSinkFifo::SampleSinkFifo(QObject* parent) :
 	m_data(),
 	m_total(0),
 	m_writtenSignalCount(0),
-	m_writtenSignalRateDivider(1),
-	m_mutex(QMutex::Recursive)
+	m_writtenSignalRateDivider(1)
 {
 	m_suppressed = -1;
 	m_size = 0;
@@ -60,8 +59,7 @@ SampleSinkFifo::SampleSinkFifo(int size, QObject* parent) :
 	m_data(),
 	m_total(0),
 	m_writtenSignalCount(0),
-	m_writtenSignalRateDivider(1),
-	m_mutex(QMutex::Recursive)
+	m_writtenSignalRateDivider(1)
 {
 	m_suppressed = -1;
 	create(size);
@@ -72,8 +70,7 @@ SampleSinkFifo::SampleSinkFifo(const SampleSinkFifo& other) :
     m_data(other.m_data),
 	m_total(0),
 	m_writtenSignalCount(0),
-	m_writtenSignalRateDivider(1),
-	m_mutex(QMutex::Recursive)
+	m_writtenSignalRateDivider(1)
 {
   	m_suppressed = -1;
 	m_size = m_data.size();

--- a/sdrbase/dsp/samplesinkfifo.h
+++ b/sdrbase/dsp/samplesinkfifo.h
@@ -20,7 +20,7 @@
 #define INCLUDE_SAMPLEFIFO_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QElapsedTimer>
 #include "dsp/dsptypes.h"
 #include "export.h"
@@ -35,7 +35,7 @@ private:
 	int m_total;
 	unsigned int m_writtenSignalCount;
 	unsigned int m_writtenSignalRateDivider;
-	QMutex m_mutex;
+	QRecursiveMutex m_mutex;
 
 	unsigned int m_size;
 	unsigned int m_fill;

--- a/sdrbase/dsp/scopevis.cpp
+++ b/sdrbase/dsp/scopevis.cpp
@@ -63,7 +63,6 @@ ScopeVis::ScopeVis() :
     m_traceDiscreteMemory(GLScopeSettings::m_nbTraceMemories),
     m_freeRun(true),
     m_maxTraceDelay(0),
-    m_mutex(QMutex::Recursive),
     m_triggerOneShot(false),
     m_triggerWaitForReset(false),
     m_currentTraceMemoryIndex(0)

--- a/sdrbase/dsp/scopevis.h
+++ b/sdrbase/dsp/scopevis.h
@@ -1242,7 +1242,7 @@ private:
     bool m_freeRun;                                //!< True if free running (trigger globally disabled)
     int m_maxTraceDelay;                           //!< Maximum trace delay
     TriggerComparator m_triggerComparator;         //!< Compares sample level to trigger level
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     Real m_projectorCache[(int) Projector::nbProjectionTypes];
     bool m_triggerOneShot;                         //!< True when one shot mode is active
     bool m_triggerWaitForReset;                    //!< In one shot mode suspended until reset by UI

--- a/sdrbase/dsp/spectrumvis.cpp
+++ b/sdrbase/dsp/spectrumvis.cpp
@@ -55,8 +55,7 @@ SpectrumVis::SpectrumVis(Real scalef) :
     m_sampleRate(48000),
 	m_ofs(0),
     m_powFFTDiv(1.0),
-    m_guiMessageQueue(nullptr),
-	m_mutex(QMutex::Recursive)
+    m_guiMessageQueue(nullptr)
 {
 	setObjectName("SpectrumVis");
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()));

--- a/sdrbase/dsp/spectrumvis.h
+++ b/sdrbase/dsp/spectrumvis.h
@@ -19,7 +19,7 @@
 #define INCLUDE_SPECTRUMVIS_H
 
 #include <QObject>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "dsp/basebandsamplesink.h"
 #include "dsp/fftengine.h"
@@ -246,7 +246,7 @@ private:
     MessageQueue m_inputMessageQueue;
     MessageQueue *m_guiMessageQueue;  //!< Input message queue to the GUI
 
-	QMutex m_mutex;
+	QRecursiveMutex m_mutex;
 
     void processFFT(bool positiveOnly);
     void setRunning(bool running) { m_running = running; }

--- a/sdrbase/pipes/elementpipesregistrations.h
+++ b/sdrbase/pipes/elementpipesregistrations.h
@@ -21,7 +21,7 @@
 #include <QMap>
 #include <QHash>
 #include <QList>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include "elementpipescommon.h"
 
@@ -31,7 +31,7 @@ class ElementPipesRegistrations
 public:
     ElementPipesRegistrations() :
         m_typeCount(0),
-        m_mutex(QMutex::Recursive)
+        m_mutex(QRecursiveMutex::Recursive)
     {}
 
     ~ElementPipesRegistrations()
@@ -125,7 +125,7 @@ public:
 
     QMap<ElementPipesCommon::RegistrationKey<Producer>, QList<Element*>> *getElements() { return &m_elements; }
     QMap<ElementPipesCommon::RegistrationKey<Producer>, QList<Consumer*>>  *getConsumers() { return &m_consumers; }
-    QMutex *getMutex() { return &m_mutex; }
+    QRecursiveMutex *getMutex() { return &m_mutex; }
 
 
 private:
@@ -133,7 +133,7 @@ private:
     int m_typeCount;
     QMap<ElementPipesCommon::RegistrationKey<Producer>, QList<Element*>> m_elements;
     QMap<ElementPipesCommon::RegistrationKey<Producer>, QList<Consumer*>> m_consumers;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 };
 
 #endif // SDRBASE_PIPES_ELEMNTPIPESREGISTRATION_H_

--- a/sdrbase/pipes/objectpipesregistrations.cpp
+++ b/sdrbase/pipes/objectpipesregistrations.cpp
@@ -20,8 +20,7 @@
 ObjectPipesRegistrations::ObjectPipesRegistrations(ObjectPipeElementsStore *objectPipeElementsStore) :
     m_typeCount(0),
     m_pipeId(0),
-    m_objectPipeElementsStore(objectPipeElementsStore),
-    m_mutex(QMutex::Recursive)
+    m_objectPipeElementsStore(objectPipeElementsStore)
 {}
 
 ObjectPipesRegistrations::~ObjectPipesRegistrations()

--- a/sdrbase/pipes/objectpipesregistrations.h
+++ b/sdrbase/pipes/objectpipesregistrations.h
@@ -24,7 +24,7 @@
 #include <QPair>
 #include <QSet>
 #include <QString>
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include <tuple>
 
@@ -69,7 +69,7 @@ private:
     QMap<std::tuple<const QObject*, int>, QList<ObjectPipe*>> m_producerAndTypeIdPipes;
     QMap<std::tuple<const QObject*, const QObject*, int>, ObjectPipe*> m_pipeMap;
 
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 };
 
 #endif // SDRBASE_PIPES_OBJECTPIPESREGISTRATION_H_

--- a/sdrbase/util/messagequeue.cpp
+++ b/sdrbase/util/messagequeue.cpp
@@ -23,7 +23,6 @@
 
 MessageQueue::MessageQueue(QObject* parent) :
 	QObject(parent),
-	m_lock(QMutex::Recursive),
 	m_queue()
 {
 	setObjectName("MessageQueue");

--- a/sdrbase/util/messagequeue.h
+++ b/sdrbase/util/messagequeue.h
@@ -21,7 +21,7 @@
 
 #include <QObject>
 #include <QQueue>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include "export.h"
 
 class Message;
@@ -43,7 +43,7 @@ signals:
 	void messageEnqueued();
 
 private:
-	QMutex m_lock;
+	QRecursiveMutex m_lock;
 	QQueue<Message*> m_queue;
 };
 

--- a/sdrbase/util/rtpsink.cpp
+++ b/sdrbase/util/rtpsink.cpp
@@ -28,8 +28,7 @@ RTPSink::RTPSink(QUdpSocket *udpSocket, int sampleRate, bool stereo) :
     m_bufferSize(0),
     m_sampleBufferIndex(0),
     m_byteBuffer(0),
-    m_destport(9998),
-    m_mutex(QMutex::Recursive)
+    m_destport(9998)
 {
 	m_rtpSessionParams.SetOwnTimestampUnit(1.0 / (double) m_sampleRate);
     m_rtpTransmissionParams.SetRTCPMultiplexing(true); // do not allocate another socket for RTCP

--- a/sdrbase/util/rtpsink.h
+++ b/sdrbase/util/rtpsink.h
@@ -20,7 +20,7 @@
 #define SDRBASE_UTIL_RTPSINK_H_
 
 #include <QString>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QDebug>
 #include <QHostAddress>
 #include <stdint.h>
@@ -84,7 +84,7 @@ protected:
     qrtplib::RTPUDPTransmissionParams m_rtpTransmissionParams;
     qrtplib::RTPUDPTransmitter m_rtpTransmitter;
     bool m_endianReverse;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 };
 
 

--- a/sdrgui/gui/tvscreen.cpp
+++ b/sdrgui/gui/tvscreen.cpp
@@ -34,7 +34,6 @@
 // Note: When this object is created, QWidget* is converted to bool
 TVScreen::TVScreen(bool color, QWidget* parent) :
     QOpenGLWidget(parent),
-    m_mutex(QMutex::Recursive),
     m_glShaderArray(color)
 {
     setAttribute(Qt::WA_OpaquePaintEvent);

--- a/sdrgui/gui/tvscreen.h
+++ b/sdrgui/gui/tvscreen.h
@@ -25,7 +25,7 @@
 #include <QOpenGLWidget>
 #include <QPen>
 #include <QTimer>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QFont>
 #include <QMatrix4x4>
 #include "dsp/dsptypes.h"
@@ -77,7 +77,7 @@ private:
 
 	// state
     QTimer m_timer;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     bool m_dataChanged;
 
     GLShaderTVArray m_glShaderArray;


### PR DESCRIPTION
The goal here is to reduce noise during compiling.

The `QMutex m_mutex(QMutex::Recursive)` construct is deprecated and should be replaced by `QRecursiveMutex`.