### PR TITLE
Lime: Add missing return value.

### DIFF
--- a/plugins/samplesink/limesdroutput/limesdroutputgui.cpp
+++ b/plugins/samplesink/limesdroutput/limesdroutputgui.cpp
@@ -211,6 +211,8 @@ bool LimeSDROutputGUI::handleMessage(const Message& message)
         } else {
             ui->calibrationLabel->setStyleSheet("QLabel { background-color : red; }");
         }
+
+        return true;
     }
     else if (LimeSDROutput::MsgReportStreamInfo::match(message))
     {

--- a/plugins/samplesource/limesdrinput/limesdrinputgui.cpp
+++ b/plugins/samplesource/limesdrinput/limesdrinputgui.cpp
@@ -198,6 +198,8 @@ bool LimeSDRInputGUI::handleMessage(const Message& message)
         } else {
             ui->calibrationLabel->setStyleSheet("QLabel { background-color : red; }");
         }
+
+        return true;
     }
     else if (LimeSDRInput::MsgReportStreamInfo::match(message))
     {


### PR DESCRIPTION
Small fix to Lime GUIs to return a value in all paths through a function.