### PR TITLE
Feature threading cleanup

### DIFF
--- a/plugins/feature/ais/ais.h
+++ b/plugins/feature/ais/ais.h
@@ -19,7 +19,6 @@
 #ifndef INCLUDE_FEATURE_AIS_H_
 #define INCLUDE_FEATURE_AIS_H_
 
-#include <QThread>
 #include <QNetworkRequest>
 #include <QSet>
 

--- a/plugins/feature/antennatools/antennatools.h
+++ b/plugins/feature/antennatools/antennatools.h
@@ -19,7 +19,6 @@
 #ifndef INCLUDE_FEATURE_ANTENNATOOLS_H_
 #define INCLUDE_FEATURE_ANTENNATOOLS_H_
 
-#include <QThread>
 #include <QHash>
 #include <QNetworkRequest>
 #include <QTimer>
@@ -98,7 +97,6 @@ public:
     static const char* const m_featureId;
 
 private:
-    QThread m_thread;
     AntennaToolsSettings m_settings;
 
     QNetworkAccessManager *m_networkManager;

--- a/plugins/feature/aprs/aprs.cpp
+++ b/plugins/feature/aprs/aprs.cpp
@@ -89,7 +89,7 @@ APRS::~APRS()
 void APRS::start()
 {
     qDebug("APRS::start");
-    m_thread = new QThread(this);
+    m_thread = new QThread();
     m_worker = new APRSWorker(this, m_webAPIAdapterInterface);
     m_worker->moveToThread(m_thread);
 

--- a/plugins/feature/aprs/aprsworker.cpp
+++ b/plugins/feature/aprs/aprsworker.cpp
@@ -51,6 +51,7 @@ APRSWorker::APRSWorker(APRS *aprs, WebAPIAdapterInterface *webAPIAdapterInterfac
 
 APRSWorker::~APRSWorker()
 {
+    stopWork();
     m_inputMessageQueue.clear();
 }
 
@@ -59,7 +60,6 @@ void APRSWorker::startWork()
     qDebug("APRSWorker::startWork");
     QMutexLocker mutexLocker(&m_mutex);
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()));
-    connect(thread(), SIGNAL(finished()), this, SLOT(stopWork()));
     // Handle any messages already on the queue
     handleInputMessages();
 }

--- a/plugins/feature/gs232controller/gs232controller.cpp
+++ b/plugins/feature/gs232controller/gs232controller.cpp
@@ -131,7 +131,7 @@ void GS232Controller::start()
 {
     qDebug("GS232Controller::start");
 
-    m_thread = new QThread(this);
+    m_thread = new QThread();
     m_worker = new GS232ControllerWorker();
     m_worker->moveToThread(m_thread);
     QObject::connect(m_thread, &QThread::started, m_worker, &GS232ControllerWorker::startWork);

--- a/plugins/feature/gs232controller/gs232controllerworker.cpp
+++ b/plugins/feature/gs232controller/gs232controllerworker.cpp
@@ -48,6 +48,7 @@ GS232ControllerWorker::GS232ControllerWorker() :
 GS232ControllerWorker::~GS232ControllerWorker()
 {
     qDebug() << "GS232ControllerWorker::~GS232ControllerWorker";
+    stopWork();
     m_inputMessageQueue.clear();
 }
 
@@ -55,7 +56,6 @@ void GS232ControllerWorker::startWork()
 {
     qDebug() << "GS232ControllerWorker::startWork";
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()));
-    connect(thread(), SIGNAL(finished()), this, SLOT(stopWork()));
     connect(&m_serialPort, &QSerialPort::readyRead, this, &GS232ControllerWorker::readData);
     connect(&m_socket, &QTcpSocket::readyRead, this, &GS232ControllerWorker::readData);
     if (m_settings.m_connection == GS232ControllerSettings::TCP) {

--- a/plugins/feature/map/map.h
+++ b/plugins/feature/map/map.h
@@ -19,7 +19,6 @@
 #ifndef INCLUDE_FEATURE_MAP_H_
 #define INCLUDE_FEATURE_MAP_H_
 
-#include <QThread>
 #include <QHash>
 #include <QNetworkRequest>
 #include <QDateTime>
@@ -171,7 +170,6 @@ public:
     static const char* const m_featureId;
 
 private:
-    QThread m_thread;
     MapSettings m_settings;
     QHash<QObject*, MapSettings::AvailableChannelOrFeature> m_availableChannelOrFeatures;
 

--- a/plugins/feature/pertester/pertester.cpp
+++ b/plugins/feature/pertester/pertester.cpp
@@ -81,7 +81,7 @@ void PERTester::start()
 {
     qDebug("PERTester::start");
 
-    m_thread = new QThread(this);
+    m_thread = new QThread();
     m_worker = new PERTesterWorker();
     m_worker->moveToThread(m_thread);
 

--- a/plugins/feature/pertester/pertesterworker.cpp
+++ b/plugins/feature/pertester/pertesterworker.cpp
@@ -51,6 +51,7 @@ PERTesterWorker::PERTesterWorker() :
 
 PERTesterWorker::~PERTesterWorker()
 {
+    stopWork();
     closeUDP();
     disconnect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()));
     m_inputMessageQueue.clear();
@@ -65,7 +66,6 @@ void PERTesterWorker::startWork()
     if (m_tx >= m_settings.m_packetCount)
         resetStats();
     connect(&m_txTimer, SIGNAL(timeout()), this, SLOT(tx()));
-    connect(thread(), SIGNAL(finished()), this, SLOT(stopWork()));
     m_txTimer.start(m_settings.m_interval * 1000.0);
     // Handle any messages already on the queue
     handleInputMessages();

--- a/plugins/feature/radiosonde/radiosonde.h
+++ b/plugins/feature/radiosonde/radiosonde.h
@@ -19,7 +19,6 @@
 #ifndef INCLUDE_FEATURE_RADIOSONDE_H_
 #define INCLUDE_FEATURE_RADIOSONDE_H_
 
-#include <QThread>
 #include <QNetworkRequest>
 #include <QSet>
 

--- a/plugins/feature/satellitetracker/satellitetracker.cpp
+++ b/plugins/feature/satellitetracker/satellitetracker.cpp
@@ -88,7 +88,7 @@ void SatelliteTracker::start()
         FeatureWebAPIUtils::mapSetDateTime(currentDateTime());
     }
 
-    m_thread = new QThread(this);
+    m_thread = new QThread();
     m_worker = new SatelliteTrackerWorker(this, m_webAPIAdapterInterface);
     m_worker->moveToThread(m_thread);
 

--- a/plugins/feature/satellitetracker/satellitetrackerworker.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackerworker.cpp
@@ -66,6 +66,7 @@ SatelliteTrackerWorker::SatelliteTrackerWorker(SatelliteTracker* satelliteTracke
 SatelliteTrackerWorker::~SatelliteTrackerWorker()
 {
     qDebug() << "SatelliteTrackerWorker::~SatelliteTrackerWorker";
+    stopWork();
     m_inputMessageQueue.clear();
 }
 
@@ -74,7 +75,6 @@ void SatelliteTrackerWorker::startWork()
     qDebug() << "SatelliteTrackerWorker::startWork";
     QMutexLocker mutexLocker(&m_mutex);
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()));
-    connect(thread(), SIGNAL(finished()), this, SLOT(stopWork()));
     m_recalculatePasses = true;
 
      m_pollTimer.start((int)round(m_settings.m_updatePeriod*1000.0));

--- a/plugins/feature/startracker/startracker.cpp
+++ b/plugins/feature/startracker/startracker.cpp
@@ -107,7 +107,7 @@ void StarTracker::start()
 {
     qDebug("StarTracker::start");
 
-    m_thread = new QThread(this);
+    m_thread = new QThread();
     m_worker = new StarTrackerWorker(this, m_webAPIAdapterInterface);
     m_worker->moveToThread(m_thread);
 

--- a/plugins/feature/startracker/startrackerworker.cpp
+++ b/plugins/feature/startracker/startrackerworker.cpp
@@ -60,6 +60,7 @@ StarTrackerWorker::StarTrackerWorker(StarTracker* starTracker, WebAPIAdapterInte
 
 StarTrackerWorker::~StarTrackerWorker()
 {
+    stopWork();
     m_inputMessageQueue.clear();
 }
 
@@ -67,7 +68,6 @@ void StarTrackerWorker::startWork()
 {
     QMutexLocker mutexLocker(&m_mutex);
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()));
-    connect(thread(), SIGNAL(finished()), this, SLOT(stopWork()));
     m_pollTimer.start((int)round(m_settings.m_updatePeriod*1000.0));
     // Handle any messages already on the queue
     handleInputMessages();


### PR DESCRIPTION
Call stopWork() from destructor rather than using a slot (which wasn't declared properly) and to ensure order of deletion.

Also delete some dead code.