### PR TITLE
#1423 - Workaround Linux bug in color picker in map settings

### DIFF
--- a/plugins/feature/map/mapcolordialog.cpp
+++ b/plugins/feature/map/mapcolordialog.cpp
@@ -25,9 +25,10 @@
 MapColorDialog::MapColorDialog(const QColor &initial, QWidget *parent) :
     QDialog(parent)
 {
-    m_colorDialog = new QColorDialog(initial);
+    m_colorDialog = new QColorDialog();
     m_colorDialog->setWindowFlags(Qt::Widget);
     m_colorDialog->setOptions(QColorDialog::ShowAlphaChannel | QColorDialog::NoButtons | QColorDialog::DontUseNativeDialog);
+    m_colorDialog->setCurrentColor(initial); // Needs to be set after setOptions on Linux, which seems to overwrite QColorDialog(initial)
     QVBoxLayout *v = new QVBoxLayout(this);
     v->addWidget(m_colorDialog);
     QHBoxLayout *h = new QHBoxLayout();


### PR DESCRIPTION
Workaround Linux bug in color picker in Map feature settings for #1423.

It appears that initial color passed to QColorDialog is lost on Linux if setOptions(QColorDialog::DontUseNativeDialog) is called. So need to call setCurrentColor after setOptions.