### PR TITLE
Spectrum: Add peak power and frequency in info bar

### DIFF
--- a/sdrgui/gui/glspectrum.h
+++ b/sdrgui/gui/glspectrum.h
@@ -294,6 +294,13 @@ private:
     QMatrix4x4 m_glLeftScaleBoxMatrix;
     QMatrix4x4 m_glInfoBoxMatrix;
 
+    QString m_peakLabelStr;
+    int m_peakLabelWidth;
+    int m_peakSpaceWidth;
+    int m_peakSpaceMidWidth;
+    int m_peakPowerMaxWidth;
+    int m_peakFrequencyMaxWidth;
+
     QRgb m_waterfallPalette[240];
     QImage* m_waterfallBuffer;
     int m_waterfallBufferPos;
@@ -402,10 +409,13 @@ private:
     void enterEvent(QEvent* event);
     void leaveEvent(QEvent* event);
 
+    static QString displayFull(int64_t value);
     static QString displayScaled(int64_t value, char type, int precision, bool showMult);
     static QString displayScaledF(float value, char type, int precision, bool showMult);
     static QString displayPower(float value, char type, int precision);
     int getPrecision(int value);
+    void findPeak(float &power, float &frequency) const;
+    void drawPeakText(float power, int64_t frequency, bool units=true);
     void drawTextOverlay(      //!< Draws a text overlay
             const QString& text,
             const QColor& color,


### PR DESCRIPTION
This patch adds the peak power and frequency into the spectrum info bar.

![image](https://user-images.githubusercontent.com/57259258/191731304-21dfe067-a8a5-41ae-b3de-931e8df1a1a9.png)

Currently always enabled, but could add a button to make it optional if desired.