### PR TITLE
Spectrum GUI: Add button to save spectrum data to text file

### DIFF
--- a/sdrgui/gui/glspectrumgui.cpp
+++ b/sdrgui/gui/glspectrumgui.cpp
@@ -21,6 +21,8 @@
 
 #include <QLineEdit>
 #include <QToolTip>
+#include <QFileDialog>
+#include <QMessageBox>
 
 #include "gui/glspectrumgui.h"
 #include "dsp/fftwindow.h"
@@ -489,6 +491,39 @@ void GLSpectrumGUI::on_markers_clicked(bool checked)
 
     displayGotoMarkers();
     applySettings();
+}
+
+// Save spectrum data to a text file
+void GLSpectrumGUI::on_save_clicked(bool checked)
+{
+    // Get filename to write
+    QFileDialog fileDialog(nullptr, "Select file to save data to", "", "*.*");
+    fileDialog.setAcceptMode(QFileDialog::AcceptSave);
+    if (fileDialog.exec())
+    {
+        QStringList fileNames = fileDialog.selectedFiles();
+        if (fileNames.size() > 0)
+        {
+            // Get spectrum data (This vector can be larger than fftSize)
+            std::vector<Real> spectrum;
+            m_spectrumVis->getPowerSpectrumCopy(spectrum);
+
+            // Write to text file
+            QFile file(fileNames[0]);
+            if (file.open(QIODevice::WriteOnly))
+            {
+                QTextStream out(&file);
+                for (int i = 0; i < m_settings.m_fftSize; i++) {
+                    out << spectrum[i] << "\n";
+                }
+                file.close();
+            }
+            else
+            {
+                QMessageBox::critical(this, "Spectrum", QString("Failed to open file %1").arg(fileNames[0]));
+            }
+        }
+    }
 }
 
 void GLSpectrumGUI::on_refLevel_valueChanged(int value)

--- a/sdrgui/gui/glspectrumgui.cpp
+++ b/sdrgui/gui/glspectrumgui.cpp
@@ -496,6 +496,8 @@ void GLSpectrumGUI::on_markers_clicked(bool checked)
 // Save spectrum data to a text file
 void GLSpectrumGUI::on_save_clicked(bool checked)
 {
+    (void) checked;
+
     // Get filename to write
     QFileDialog fileDialog(nullptr, "Select file to save data to", "", "*.*");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);

--- a/sdrgui/gui/glspectrumgui.cpp
+++ b/sdrgui/gui/glspectrumgui.cpp
@@ -493,13 +493,13 @@ void GLSpectrumGUI::on_markers_clicked(bool checked)
     applySettings();
 }
 
-// Save spectrum data to a text file
+// Save spectrum data to a CSV file
 void GLSpectrumGUI::on_save_clicked(bool checked)
 {
     (void) checked;
 
     // Get filename to write
-    QFileDialog fileDialog(nullptr, "Select file to save data to", "", "*.*");
+    QFileDialog fileDialog(nullptr, "Select file to save data to", "", "*.csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {
@@ -515,8 +515,13 @@ void GLSpectrumGUI::on_save_clicked(bool checked)
             if (file.open(QIODevice::WriteOnly))
             {
                 QTextStream out(&file);
-                for (int i = 0; i < m_settings.m_fftSize; i++) {
-                    out << spectrum[i] << "\n";
+                float frequency = m_glSpectrum->getCenterFrequency() - (m_glSpectrum->getSampleRate() / 2.0f);
+                float rbw = m_glSpectrum->getSampleRate() / (float)m_settings.m_fftSize;
+                out << "\"Frequency\",\"Power\"\n";
+                for (int i = 0; i < m_settings.m_fftSize; i++)
+                {
+                    out << frequency << "," << spectrum[i] << "\n";
+                    frequency += rbw;
                 }
                 file.close();
             }

--- a/sdrgui/gui/glspectrumgui.h
+++ b/sdrgui/gui/glspectrumgui.h
@@ -107,6 +107,7 @@ private slots:
     void on_linscale_toggled(bool checked);
     void on_wsSpectrum_toggled(bool checked);
 	void on_markers_clicked(bool checked);
+    void on_save_clicked(bool checked);
 
 	void on_waterfall_toggled(bool checked);
 	void on_spectrogram_toggled(bool checked);

--- a/sdrgui/gui/glspectrumgui.ui
+++ b/sdrgui/gui/glspectrumgui.ui
@@ -1024,6 +1024,20 @@
       </widget>
      </item>
      <item>
+      <widget class="QToolButton" name="save">
+       <property name="toolTip">
+        <string>Save spectrum data to file</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../resources/res.qrc">
+         <normaloff>:/save.png</normaloff>:/save.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="ButtonSwitch" name="wsSpectrum">
        <property name="toolTip">
         <string>Left: toggle websocket spectrum - Right: websocket spectrum parameters</string>


### PR DESCRIPTION
This PR adds a button to the spectrum GUI to save the spectrum data to text file

![image](https://user-images.githubusercontent.com/57259258/192277438-1e2978b6-1431-4c75-841d-f45060a3d439.png)

Thoughts? Not a frequently used operation sure, but not sure where else the button could go other than perhaps a popup menu.