### PR TITLE
Maps: Use mapboxgl as default map on Linux,

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
@@ -92,8 +92,8 @@ void ADSBDemodSettings::resetToDefaults()
     m_logEnabled = false;
     m_airspaces = QStringList({"A", "D", "TMZ"});
     m_airspaceRange = 500.0f;
-#if QT_VERSION == QT_VERSION_CHECK(5, 15, 3) || QT_VERSION == QT_VERSION_CHECK(5, 15, 4)
-    m_mapProvider = "mapboxgl"; // osm maps do not work in Qt 5.15.3 - https://github.com/f4exb/sdrangel/issues/1169
+#ifdef LINUX
+    m_mapProvider = "mapboxgl"; // osm maps do not work in some versions of Linux https://github.com/f4exb/sdrangel/issues/1169 & 1369
 #else
     m_mapProvider = "osm";
 #endif
@@ -315,8 +315,8 @@ bool ADSBDemodSettings::deserialize(const QByteArray& data)
         d.readBlob(60, &m_geometryBytes);
         d.readBool(61, &m_hidden, false);
         d.readString(62, &m_checkWXAPIKey, "");
-#if QT_VERSION == QT_VERSION_CHECK(5, 15, 3) || QT_VERSION == QT_VERSION_CHECK(5, 15, 4)
-        d.readString(63, &m_mapProvider, "mapboxgl"); // osm maps do not work in Qt 5.15.3/4 - https://github.com/f4exb/sdrangel/issues/1169
+#ifdef LINUX
+        d.readString(63, &m_mapProvider, "mapboxgl");
 #else
         d.readString(63, &m_mapProvider, "osm");
 #endif

--- a/plugins/feature/map/mapsettings.cpp
+++ b/plugins/feature/map/mapsettings.cpp
@@ -88,8 +88,8 @@ MapSettings::~MapSettings()
 void MapSettings::resetToDefaults()
 {
     m_displayNames = true;
-#if QT_VERSION == QT_VERSION_CHECK(5, 15, 3) || QT_VERSION == QT_VERSION_CHECK(5, 15, 4)
-    m_mapProvider = "mapboxgl"; // osm maps do not work in Qt 5.15.3/4 - https://github.com/f4exb/sdrangel/issues/1169
+#ifdef LINUX
+    m_mapProvider = "mapboxgl"; // osm maps do not work in some versions of Linux https://github.com/f4exb/sdrangel/issues/1169 & 1369
 #else
     m_mapProvider = "osm";
 #endif
@@ -183,8 +183,8 @@ bool MapSettings::deserialize(const QByteArray& data)
         QByteArray blob;
 
         d.readBool(1, &m_displayNames, true);
-#if QT_VERSION == QT_VERSION_CHECK(5, 15, 3) || QT_VERSION == QT_VERSION_CHECK(5, 15, 4)
-        d.readString(2, &m_mapProvider, "mapboxgl"); // osm maps do not work in Qt 5.15.3/4 - https://github.com/f4exb/sdrangel/issues/1169
+#ifdef LINUX
+        d.readString(2, &m_mapProvider, "mapboxgl");
 #else
         d.readString(2, &m_mapProvider, "osm");
 #endif

--- a/plugins/feature/vorlocalizer/vorlocalizergui.h
+++ b/plugins/feature/vorlocalizer/vorlocalizergui.h
@@ -268,6 +268,7 @@ private:
     void updateVORs();
     void readNavAids();
     void updateChannelList();
+    void applyMapSettings();
 
 private slots:
     void on_startStop_toggled(bool checked);

--- a/plugins/feature/vorlocalizer/vorlocalizersettings.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizersettings.cpp
@@ -42,6 +42,11 @@ void VORLocalizerSettings::resetToDefaults()
     m_reverseAPIFeatureSetIndex = 0;
     m_reverseAPIFeatureIndex = 0;
     m_workspaceIndex = 0;
+#ifdef LINUX
+    m_mapProvider = "mapboxgl"; // osm maps do not work in some versions of Linux https://github.com/f4exb/sdrangel/issues/1169 & 1369
+#else
+    m_mapProvider = "osm";
+#endif
 
     for (int i = 0; i < VORDEMOD_COLUMNS; i++)
     {
@@ -71,6 +76,7 @@ QByteArray VORLocalizerSettings::serialize() const
 
     s.writeS32(20, m_workspaceIndex);
     s.writeBlob(21, m_geometryBytes);
+    s.writeString(22, m_mapProvider);
 
     for (int i = 0; i < VORDEMOD_COLUMNS; i++) {
         s.writeS32(100 + i, m_columnIndexes[i]);
@@ -128,6 +134,11 @@ bool VORLocalizerSettings::deserialize(const QByteArray& data)
 
         d.readS32(20, &m_workspaceIndex, 0);
         d.readBlob(21, &m_geometryBytes);
+#ifdef LINUX
+        d.readString(22, &m_mapProvider, "mapboxgl");
+#else
+        d.readString(22, &m_mapProvider, "osm");
+#endif
 
         for (int i = 0; i < VORDEMOD_COLUMNS; i++) {
             d.readS32(100 + i, &m_columnIndexes[i], i);

--- a/plugins/feature/vorlocalizer/vorlocalizersettings.h
+++ b/plugins/feature/vorlocalizer/vorlocalizersettings.h
@@ -76,6 +76,7 @@ struct VORLocalizerSettings
     Serializable *m_rollupState;
     int m_workspaceIndex;
     QByteArray m_geometryBytes;
+    QString m_mapProvider;
 
     static const int VORDEMOD_COLUMNS  = 10;
     static const int VOR_COL_NAME      =  0;


### PR DESCRIPTION
This patch updates Map feature, ADS-B demod and VOR Feature to use mapboxgl as default map provider on all Linux builds. 

Fix for #1369