### PR TITLE
APT Demod: Update to latest aptdec. 

### DIFF
--- a/plugins/channelrx/demodapt/aptdemodgui.cpp
+++ b/plugins/channelrx/demodapt/aptdemodgui.cpp
@@ -374,6 +374,11 @@ void APTDemodGUI::on_channels_currentIndexChanged(int index)
     {
         m_settings.m_channels = (APTDemodSettings::ChannelSelection)index;
     }
+    else if (index == (int)APTDemodSettings::VISIBLE)
+    {
+        m_settings.m_channels = APTDemodSettings::VISIBLE;
+        m_settings.m_precipitationOverlay = false;
+    }
     else if (index == (int)APTDemodSettings::TEMPERATURE)
     {
         m_settings.m_channels = APTDemodSettings::TEMPERATURE;
@@ -810,6 +815,7 @@ void APTDemodGUI::displayPalettes()
     ui->channels->addItem("A");
     ui->channels->addItem("B");
     ui->channels->addItem("Temperature");
+    ui->channels->addItem("Visible");
     for (auto palette : m_settings.m_palettes)
     {
         QFileInfo fi(palette);

--- a/plugins/channelrx/demodapt/aptdemodsettings.h
+++ b/plugins/channelrx/demodapt/aptdemodsettings.h
@@ -36,7 +36,7 @@ struct APTDemodSettings
     bool m_histogramEqualise;
     bool m_precipitationOverlay;
     bool m_flip;
-    enum ChannelSelection {BOTH_CHANNELS, CHANNEL_A, CHANNEL_B, TEMPERATURE, PALETTE} m_channels;
+    enum ChannelSelection {BOTH_CHANNELS, CHANNEL_A, CHANNEL_B, TEMPERATURE, VISIBLE, PALETTE} m_channels;
     bool m_decodeEnabled;
     bool m_satelliteTrackerControl;             //! Whether Sat Tracker can set direction of pass
     QString m_satelliteName;                    //!< All, NOAA 15, NOAA 18 or NOAA 19


### PR DESCRIPTION
Updates to use the latest version of aptdec. This will require rebuilding of aptdec library dependency as the API has changed (as per Linux build instructions).

Removes obsolete zenith variable and adds support for visible image calibration.

Fixes #1422