### PR TITLE
Spectrum measurements - Size splitter to table

### DIFF
--- a/sdrgui/gui/glspectrum.cpp
+++ b/sdrgui/gui/glspectrum.cpp
@@ -32,6 +32,7 @@ GLSpectrum::GLSpectrum(QWidget *parent) :
     m_spectrum->setMeasurements(m_measurements);
     m_splitter->addWidget(m_spectrum);
     m_splitter->addWidget(m_measurements);
+    m_position = SpectrumSettings::PositionBelow;
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(m_splitter);
@@ -66,4 +67,77 @@ void GLSpectrum::setMeasurementsPosition(SpectrumSettings::MeasurementsPosition 
         m_splitter->insertWidget(0, m_spectrum);
         break;
     }
+    m_position = position;
+}
+
+void GLSpectrum::setMeasurementParams(SpectrumSettings::Measurement measurement,
+                                      int centerFrequencyOffset, int bandwidth, int chSpacing, int adjChBandwidth,
+                                      int harmonics, int peaks, bool highlight, int precision)
+{
+    m_spectrum->setMeasurementParams(measurement, centerFrequencyOffset, bandwidth, chSpacing, adjChBandwidth, harmonics, peaks, highlight, precision);
+    // Resize splitter so there's just enough space for the measurements table
+    // But don't use more than 50%
+    QList<int> sizes = m_splitter->sizes();
+    if ((sizes[0] == 0) && (sizes[1] == 0))
+    {
+        // Initial sizing when first created
+        QSize s = parentWidget()->size();
+        switch (m_position)
+        {
+        case SpectrumSettings::PositionAbove:
+            sizes[0] = m_measurements->sizeHint().height();
+            sizes[1] = s.height() - sizes[0] - m_splitter->handleWidth();
+            sizes[1] = std::max(sizes[1], sizes[0]);
+            break;
+        case SpectrumSettings::PositionLeft:
+            sizes[0] = m_measurements->sizeHint().width();
+            sizes[1] = s.width() - sizes[0] - m_splitter->handleWidth();
+            sizes[1] = std::max(sizes[1], sizes[0]);
+            break;
+        case SpectrumSettings::PositionBelow:
+            sizes[1] = m_measurements->sizeHint().height();
+            sizes[0] = s.height() - sizes[1] - m_splitter->handleWidth();
+            sizes[0] = std::max(sizes[0], sizes[1]);
+            break;
+        case SpectrumSettings::PositionRight:
+            sizes[1] = m_measurements->sizeHint().width();
+            sizes[0] = s.width() - sizes[1] - m_splitter->handleWidth();
+            sizes[0] = std::max(sizes[0], sizes[1]);
+            break;
+        }
+    }
+    else
+    {
+        // When measurement type is changed when already visible
+        int diff = 0;
+        switch (m_position)
+        {
+        case SpectrumSettings::PositionAbove:
+            diff = m_measurements->sizeHint().height() - sizes[0];
+            sizes[0] += diff;
+            sizes[1] -= diff;
+            sizes[1] = std::max(sizes[1], sizes[0]);
+            break;
+        case SpectrumSettings::PositionLeft:
+            diff = m_measurements->sizeHint().width() - sizes[0];
+            sizes[0] += diff;
+            sizes[1] -= diff;
+            sizes[1] = std::max(sizes[1], sizes[0]);
+            break;
+        case SpectrumSettings::PositionBelow:
+            diff = m_measurements->sizeHint().height() - sizes[1];
+            sizes[1] += diff;
+            sizes[0] -= diff;
+            sizes[0] = std::max(sizes[0], sizes[1]);
+            break;
+        case SpectrumSettings::PositionRight:
+            diff = m_measurements->sizeHint().width() - sizes[1];
+            sizes[1] += diff;
+            sizes[0] -= diff;
+            sizes[0] = std::max(sizes[0], sizes[1]);
+            break;
+        }
+    }
+    m_splitter->setSizes(sizes);
+    //resize(size().expandedTo(minimumSizeHint()));
 }

--- a/sdrgui/gui/glspectrum.h
+++ b/sdrgui/gui/glspectrum.h
@@ -67,10 +67,7 @@ public:
     void setUseCalibration(bool useCalibration) { m_spectrum->setUseCalibration(useCalibration); }
     void setMeasurementParams(SpectrumSettings::Measurement measurement,
                               int centerFrequencyOffset, int bandwidth, int chSpacing, int adjChBandwidth,
-                              int harmonics, int peaks, bool highlight, int precision)
-    {
-        m_spectrum->setMeasurementParams(measurement, centerFrequencyOffset, bandwidth, chSpacing, adjChBandwidth, harmonics, peaks, highlight, precision);
-    }
+                              int harmonics, int peaks, bool highlight, int precision);
     qint32 getSampleRate() const { return m_spectrum->getSampleRate(); }
     void addChannelMarker(ChannelMarker* channelMarker) { m_spectrum->addChannelMarker(channelMarker); }
     void removeChannelMarker(ChannelMarker* channelMarker) { m_spectrum->removeChannelMarker(channelMarker); }
@@ -110,6 +107,7 @@ private:
     QSplitter *m_splitter;
     GLSpectrumView *m_spectrum;
     SpectrumMeasurements *m_measurements;
+    SpectrumSettings::MeasurementsPosition m_position;
 
 };
 

--- a/sdrgui/gui/rollupcontents.cpp
+++ b/sdrgui/gui/rollupcontents.cpp
@@ -373,6 +373,10 @@ bool RollupContents::event(QEvent* event)
         ((QChildEvent*)event)->child()->removeEventFilter(this);
         arrangeRollups();
     }
+    else if (event->type() == QEvent::LayoutRequest)
+    {
+        arrangeRollups();
+    }
 
     return QWidget::event(event);
 }

--- a/sdrgui/gui/rollupwidget.cpp
+++ b/sdrgui/gui/rollupwidget.cpp
@@ -576,6 +576,10 @@ bool RollupWidget::event(QEvent* event)
         ((QChildEvent*)event)->child()->removeEventFilter(this);
         arrangeRollups();
     }
+    else if (event->type() == QEvent::LayoutRequest)
+    {
+        arrangeRollups();
+    }
 
     return QWidget::event(event);
 }

--- a/sdrgui/gui/spectrummeasurements.h
+++ b/sdrgui/gui/spectrummeasurements.h
@@ -25,6 +25,14 @@
 #include "dsp/spectrumsettings.h"
 #include "export.h"
 
+class SDRGUI_API SpectrumMeasurementsTable : public QTableWidget {
+    Q_OBJECT
+
+public:
+    virtual QSize sizeHint() const override;
+    virtual QSize minimumSizeHint() const override;
+};
+
 // Displays spectrum measurements in a table
 class SDRGUI_API SpectrumMeasurements : public QWidget {
     Q_OBJECT
@@ -113,12 +121,12 @@ private:
     SpectrumSettings::Measurement m_measurement;
     int m_precision;
 
-    QTableWidget *m_table;
+    SpectrumMeasurementsTable *m_table;
     QMenu *m_rowMenu;
     QMenu *m_columnMenu;
     QList<Measurement> m_measurements;
 
-    QTableWidget *m_peakTable;
+    SpectrumMeasurementsTable *m_peakTable;
     QBrush m_textBrush;
     QBrush m_redBrush;
 


### PR DESCRIPTION
This patch sizes the spectrum measurements splitter to the size of the measurements table.

This also allows the Auto Stack feature to reduce the width of the spectrum window, when the measurements table is visible.

Also, I've made a change to the RollupWidgets so that they handle Layout Requests from child widgets, which allows the rollups to be resized when a child resizes. Took me a while to find out how to fix this - so there are a few workarounds in other plugins that will be able to be removed (arrangeRollups was being called directly).
