### PR TITLE
Device GUIs: Stop timers in destructors.

### DIFF
--- a/plugins/samplesink/audiooutput/audiooutputgui.cpp
+++ b/plugins/samplesink/audiooutput/audiooutputgui.cpp
@@ -65,6 +65,7 @@ AudioOutputGui::AudioOutputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 AudioOutputGui::~AudioOutputGui()
 {
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesink/bladerf1output/bladerf1outputgui.cpp
+++ b/plugins/samplesink/bladerf1output/bladerf1outputgui.cpp
@@ -76,6 +76,8 @@ Bladerf1OutputGui::Bladerf1OutputGui(DeviceUISet *deviceUISet, QWidget* parent) 
 
 Bladerf1OutputGui::~Bladerf1OutputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesink/bladerf2output/bladerf2outputgui.cpp
+++ b/plugins/samplesink/bladerf2output/bladerf2outputgui.cpp
@@ -91,6 +91,8 @@ BladeRF2OutputGui::BladeRF2OutputGui(DeviceUISet *deviceUISet, QWidget* parent) 
 
 BladeRF2OutputGui::~BladeRF2OutputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesink/fileoutput/fileoutputgui.cpp
+++ b/plugins/samplesink/fileoutput/fileoutputgui.cpp
@@ -83,6 +83,8 @@ FileOutputGui::FileOutputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 FileOutputGui::~FileOutputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesink/hackrfoutput/hackrfoutputgui.cpp
+++ b/plugins/samplesink/hackrfoutput/hackrfoutputgui.cpp
@@ -74,6 +74,8 @@ HackRFOutputGui::HackRFOutputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 HackRFOutputGui::~HackRFOutputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesink/limesdroutput/limesdroutputgui.cpp
+++ b/plugins/samplesink/limesdroutput/limesdroutputgui.cpp
@@ -101,6 +101,8 @@ LimeSDROutputGUI::LimeSDROutputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 
 LimeSDROutputGUI::~LimeSDROutputGUI()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesink/localoutput/localoutputgui.cpp
+++ b/plugins/samplesink/localoutput/localoutputgui.cpp
@@ -87,6 +87,8 @@ LocalOutputGui::LocalOutputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 LocalOutputGui::~LocalOutputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesink/plutosdroutput/plutosdroutputgui.cpp
+++ b/plugins/samplesink/plutosdroutput/plutosdroutputgui.cpp
@@ -86,6 +86,8 @@ PlutoSDROutputGUI::PlutoSDROutputGUI(DeviceUISet *deviceUISet, QWidget* parent) 
 
 PlutoSDROutputGUI::~PlutoSDROutputGUI()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesink/remoteoutput/remoteoutputgui.cpp
+++ b/plugins/samplesink/remoteoutput/remoteoutputgui.cpp
@@ -96,6 +96,8 @@ RemoteOutputSinkGui::RemoteOutputSinkGui(DeviceUISet *deviceUISet, QWidget* pare
 
 RemoteOutputSinkGui::~RemoteOutputSinkGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesink/soapysdroutput/soapysdroutputgui.cpp
+++ b/plugins/samplesink/soapysdroutput/soapysdroutputgui.cpp
@@ -107,6 +107,8 @@ SoapySDROutputGui::SoapySDROutputGui(DeviceUISet *deviceUISet, QWidget* parent) 
 
 SoapySDROutputGui::~SoapySDROutputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesink/testsink/testsinkgui.cpp
+++ b/plugins/samplesink/testsink/testsinkgui.cpp
@@ -84,6 +84,8 @@ TestSinkGui::TestSinkGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 TestSinkGui::~TestSinkGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesink/xtrxoutput/xtrxoutputgui.cpp
+++ b/plugins/samplesink/xtrxoutput/xtrxoutputgui.cpp
@@ -84,6 +84,8 @@ XTRXOutputGUI::XTRXOutputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 
 XTRXOutputGUI::~XTRXOutputGUI()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesource/airspy/airspygui.cpp
+++ b/plugins/samplesource/airspy/airspygui.cpp
@@ -73,7 +73,9 @@ AirspyGui::AirspyGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 AirspyGui::~AirspyGui()
 {
-	delete ui;
+    m_statusTimer.stop();
+    m_updateTimer.stop();
+    delete ui;
 }
 
 void AirspyGui::destroy()

--- a/plugins/samplesource/airspyhf/airspyhfgui.cpp
+++ b/plugins/samplesource/airspyhf/airspyhfgui.cpp
@@ -72,6 +72,8 @@ AirspyHFGui::AirspyHFGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 AirspyHFGui::~AirspyHFGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesource/audioinput/audioinputgui.cpp
+++ b/plugins/samplesource/audioinput/audioinputgui.cpp
@@ -60,6 +60,7 @@ AudioInputGui::AudioInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 AudioInputGui::~AudioInputGui()
 {
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesource/bladerf1input/bladerf1inputgui.cpp
+++ b/plugins/samplesource/bladerf1input/bladerf1inputgui.cpp
@@ -82,6 +82,8 @@ Bladerf1InputGui::Bladerf1InputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 Bladerf1InputGui::~Bladerf1InputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesource/bladerf2input/bladerf2inputgui.cpp
+++ b/plugins/samplesource/bladerf2input/bladerf2inputgui.cpp
@@ -104,6 +104,8 @@ BladeRF2InputGui::BladeRF2InputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 BladeRF2InputGui::~BladeRF2InputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesource/fcdpro/fcdprogui.cpp
+++ b/plugins/samplesource/fcdpro/fcdprogui.cpp
@@ -162,6 +162,8 @@ FCDProGui::FCDProGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 FCDProGui::~FCDProGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesource/fcdproplus/fcdproplusgui.cpp
+++ b/plugins/samplesource/fcdproplus/fcdproplusgui.cpp
@@ -80,6 +80,8 @@ FCDProPlusGui::FCDProPlusGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 FCDProPlusGui::~FCDProPlusGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesource/fileinput/fileinputgui.cpp
+++ b/plugins/samplesource/fileinput/fileinputgui.cpp
@@ -85,6 +85,7 @@ FileInputGUI::FileInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 FileInputGUI::~FileInputGUI()
 {
     qDebug("FileInputGUI::~FileInputGUI");
+    m_statusTimer.stop();
 	delete ui;
     qDebug("FileInputGUI::~FileInputGUI: end");
 }

--- a/plugins/samplesource/hackrfinput/hackrfinputgui.cpp
+++ b/plugins/samplesource/hackrfinput/hackrfinputgui.cpp
@@ -78,6 +78,8 @@ HackRFInputGui::HackRFInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 HackRFInputGui::~HackRFInputGui()
 {
     qDebug("HackRFInputGui::~HackRFInputGui");
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
     qDebug("HackRFInputGui::~HackRFInputGui: end");
 }

--- a/plugins/samplesource/limesdrinput/limesdrinputgui.cpp
+++ b/plugins/samplesource/limesdrinput/limesdrinputgui.cpp
@@ -107,6 +107,8 @@ LimeSDRInputGUI::LimeSDRInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 
 LimeSDRInputGUI::~LimeSDRInputGUI()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesource/localinput/localinputgui.cpp
+++ b/plugins/samplesource/localinput/localinputgui.cpp
@@ -100,6 +100,8 @@ LocalInputGui::LocalInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 LocalInputGui::~LocalInputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesource/perseus/perseusgui.cpp
+++ b/plugins/samplesource/perseus/perseusgui.cpp
@@ -70,6 +70,8 @@ PerseusGui::PerseusGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 PerseusGui::~PerseusGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesource/plutosdrinput/plutosdrinputgui.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinputgui.cpp
@@ -88,6 +88,8 @@ PlutoSDRInputGui::PlutoSDRInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 PlutoSDRInputGui::~PlutoSDRInputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesource/remoteinput/remoteinputgui.cpp
+++ b/plugins/samplesource/remoteinput/remoteinputgui.cpp
@@ -105,6 +105,9 @@ RemoteInputGui::RemoteInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 RemoteInputGui::~RemoteInputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
+    m_remoteUpdateTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesource/remotetcpinput/remotetcpinputgui.cpp
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputgui.cpp
@@ -92,6 +92,8 @@ RemoteTCPInputGui::RemoteTCPInputGui(DeviceUISet *deviceUISet, QWidget* parent) 
 
 RemoteTCPInputGui::~RemoteTCPInputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesource/sdrplay/sdrplaygui.cpp
+++ b/plugins/samplesource/sdrplay/sdrplaygui.cpp
@@ -89,6 +89,8 @@ SDRPlayGui::SDRPlayGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 SDRPlayGui::~SDRPlayGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesource/sdrplayv3/sdrplayv3gui.cpp
+++ b/plugins/samplesource/sdrplayv3/sdrplayv3gui.cpp
@@ -125,6 +125,8 @@ SDRPlayV3Gui::SDRPlayV3Gui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 SDRPlayV3Gui::~SDRPlayV3Gui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesource/sigmffileinput/sigmffileinputgui.cpp
+++ b/plugins/samplesource/sigmffileinput/sigmffileinputgui.cpp
@@ -99,6 +99,7 @@ SigMFFileInputGUI::SigMFFileInputGUI(DeviceUISet *deviceUISet, QWidget* parent) 
 
 SigMFFileInputGUI::~SigMFFileInputGUI()
 {
+    m_statusTimer.stop();
 	delete ui;
 }
 

--- a/plugins/samplesource/soapysdrinput/soapysdrinputgui.cpp
+++ b/plugins/samplesource/soapysdrinput/soapysdrinputgui.cpp
@@ -109,6 +109,8 @@ SoapySDRInputGui::SoapySDRInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 SoapySDRInputGui::~SoapySDRInputGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesource/testsource/testsourcegui.cpp
+++ b/plugins/samplesource/testsource/testsourcegui.cpp
@@ -81,6 +81,8 @@ TestSourceGui::TestSourceGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 TestSourceGui::~TestSourceGui()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesource/usrpinput/usrpinputgui.cpp
+++ b/plugins/samplesource/usrpinput/usrpinputgui.cpp
@@ -95,6 +95,8 @@ USRPInputGUI::USRPInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 
 USRPInputGUI::~USRPInputGUI()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 

--- a/plugins/samplesource/xtrxinput/xtrxinputgui.cpp
+++ b/plugins/samplesource/xtrxinput/xtrxinputgui.cpp
@@ -87,6 +87,8 @@ XTRXInputGUI::XTRXInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 
 XTRXInputGUI::~XTRXInputGUI()
 {
+    m_statusTimer.stop();
+    m_updateTimer.stop();
     delete ui;
 }
 


### PR DESCRIPTION
This is a possible fix for #1372 / #1312 - although I can't test it, as I don't have an Airspy.

However, in the bug report, the crash appears to come after DeviceGUI is destroyed:

https://github.com/f4exb/sdrangel/issues/1312#issuecomment-1171906278

This reminded me of [#1408,](https://github.com/f4exb/sdrangel/pull/1408), where a crash was occurring because a timer wasn't stopped in a destructor. So this patch stops all the Device GUI timers in the destructors.