### PR TITLE
Sat tracker: Fix #1472 and #1471

### DIFF
--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -601,6 +601,7 @@ double RadioAstronomyGUI::beamFillingFactor() const
 
 void RadioAstronomyGUI::powerMeasurementReceived(FFTMeasurement *fft, bool skipCalcs)
 {
+    ui->powerTable->setSortingEnabled(false);
     int row = ui->powerTable->rowCount();
     ui->powerTable->setRowCount(row + 1);
 
@@ -659,6 +660,8 @@ void RadioAstronomyGUI::powerMeasurementReceived(FFTMeasurement *fft, bool skipC
     ui->powerTable->setItem(row, POWER_COL_AIR_TEMP, airTempItem);
     ui->powerTable->setItem(row, POWER_COL_SENSOR_1, sensor1Item);
     ui->powerTable->setItem(row, POWER_COL_SENSOR_2, sensor2Item);
+
+    ui->powerTable->setSortingEnabled(true);
 
     QDateTime dateTime = fft->m_dateTime;
     dateItem->setData(Qt::DisplayRole, dateTime.date());

--- a/plugins/feature/satellitetracker/readme.md
+++ b/plugins/feature/satellitetracker/readme.md
@@ -99,7 +99,7 @@ On the Settings tab, you can set:
 * A command/script to be executed on LOS. This applies to all satellites. It is also possible to set a per-satellite command in the SDRangel Control dialog.
 * The Doppler correction period in seconds, which controls how frequently Doppler correction is applied. Which channels have Doppler correction applied is set on a per-channel basis in the SDRangel Control dialog.
 
-For commands, scripts and speech, the following variables can be sustituted: ${aos}, ${los}, ${elevation}, ${aosAzimuth}, ${losAzimuth}, ${northToSouth}, ${latitude}, ${longitude}, ${altitude}, ${azimuth}, ${elevation}, ${range}, ${rangeRate}, ${speed} and ${period}.
+For commands, scripts and speech, the following variables can be substituted: `${name}`, `${duration}`, `${aos}`, `${los}`, `${elevation}`, `${aosAzimuth}`, `${losAzimuth}`, `${northToSouth}`, `${latitude}`, `${longitude}`, `${altitude}`, `${azimuth}`, `${elevation}`, `${range}`, `${rangeRate}`, `${speed}` and `${period}`.
 
 ![Satellite tracker settings dialog](../../../doc/img/SatelliteTracker_plugin_settingsdialog2.png)
 

--- a/plugins/feature/satellitetracker/satellitetrackergui.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackergui.cpp
@@ -1115,6 +1115,7 @@ void SatelliteTrackerGUI::updateTable(SatelliteState *satState)
     if (matches.size() == 0)
     {
         // Add a new row
+        ui->satTable->setSortingEnabled(false);
         int row = ui->satTable->rowCount();
         ui->satTable->setRowCount(row + 1);
         for (int i = 0; i < SAT_COL_COLUMNS; i++)
@@ -1128,6 +1129,7 @@ void SatelliteTrackerGUI::updateTable(SatelliteState *satState)
             items[i]->setToolTip(ui->satTable->horizontalHeaderItem(i)->toolTip());
             ui->satTable->setItem(row, i, items[i]);
         }
+        ui->satTable->setSortingEnabled(true);
         // Static columns
         items[SAT_COL_NAME]->setText(satState->m_name);
         if (m_satellites.contains(satState->m_name))


### PR DESCRIPTION
Fix #1472 by disabling sorting when adding row to table. Also similar fix in Radio Astronomy plugin.
Fix #1471 by adding missing variables and fixing formatting.