### PR TITLE
Check for existing pipes after GUI is created. 

### DIFF
--- a/plugins/feature/gs232controller/gs232controller.cpp
+++ b/plugins/feature/gs232controller/gs232controller.cpp
@@ -44,6 +44,7 @@ MESSAGE_CLASS_DEFINITION(GS232Controller::MsgConfigureGS232Controller, Message)
 MESSAGE_CLASS_DEFINITION(GS232Controller::MsgStartStop, Message)
 MESSAGE_CLASS_DEFINITION(GS232Controller::MsgReportWorker, Message)
 MESSAGE_CLASS_DEFINITION(GS232Controller::MsgReportAvailableChannelOrFeatures, Message)
+MESSAGE_CLASS_DEFINITION(GS232Controller::MsgScanAvailableChannelOrFeatures, Message)
 
 const char* const GS232Controller::m_featureIdURI = "sdrangel.feature.gs232controller";
 const char* const GS232Controller::m_featureId = "GS232Controller";
@@ -195,6 +196,11 @@ bool GS232Controller::handleMessage(const Message& cmd)
             m_state = StError;
             m_errorMessage = report.getMessage();
         }
+        return true;
+    }
+    else if (MsgScanAvailableChannelOrFeatures::match(cmd))
+    {
+        scanAvailableChannelsAndFeatures();
         return true;
     }
     else if (GS232ControllerReport::MsgReportAzAl::match(cmd))

--- a/plugins/feature/gs232controller/gs232controller.h
+++ b/plugins/feature/gs232controller/gs232controller.h
@@ -119,6 +119,22 @@ public:
         {}
     };
 
+    class MsgScanAvailableChannelOrFeatures : public Message {
+        MESSAGE_CLASS_DECLARATION
+
+    public:
+
+        static MsgScanAvailableChannelOrFeatures* create() {
+            return new MsgScanAvailableChannelOrFeatures();
+        }
+
+    protected:
+
+        MsgScanAvailableChannelOrFeatures() :
+            Message()
+        { }
+    };
+
     GS232Controller(WebAPIAdapterInterface *webAPIAdapterInterface);
     virtual ~GS232Controller();
     virtual void destroy() { delete this; }

--- a/plugins/feature/gs232controller/gs232controllergui.cpp
+++ b/plugins/feature/gs232controller/gs232controllergui.cpp
@@ -178,6 +178,9 @@ GS232ControllerGUI::GS232ControllerGUI(PluginAPI* pluginAPI, FeatureUISet *featu
     displaySettings();
     applySettings(true);
     makeUIConnections();
+
+    // Get pre-existing pipes
+    m_gs232Controller->getInputMessageQueue()->push(GS232Controller::MsgScanAvailableChannelOrFeatures::create());
 }
 
 GS232ControllerGUI::~GS232ControllerGUI()


### PR DESCRIPTION
For #1484.

Checks for existing pipes, in case Rotator feature is created after selected source channel/feature.