### PR TITLE
Fix recurring typo

### DIFF
--- a/plugins/channeltx/modatv/atvmodsource.h
+++ b/plugins/channeltx/modatv/atvmodsource.h
@@ -208,7 +208,7 @@ private:
     bool m_videoOK;
 
     std::vector<ATVCamera> m_cameras; //!< vector of available cameras
-    int m_cameraIndex;           //!< curent camera index in list of available cameras
+    int m_cameraIndex;           //!< current camera index in list of available cameras
 
     std::string m_overlayText;
     QString m_imageFileName;

--- a/sdrbase/dsp/filerecord.cpp
+++ b/sdrbase/dsp/filerecord.cpp
@@ -117,8 +117,8 @@ bool FileRecord::startRecording()
     if (!m_sampleFile.is_open())
     {
     	qDebug() << "FileRecord::startRecording";
-        m_curentFileName = QString("%1.%2.sdriq").arg(m_fileBase).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddTHH_mm_ss_zzz"));
-        m_sampleFile.open(m_curentFileName.toStdString().c_str(), std::ios::binary);
+        m_currentFileName = QString("%1.%2.sdriq").arg(m_fileBase).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddTHH_mm_ss_zzz"));
+        m_sampleFile.open(m_currentFileName.toStdString().c_str(), std::ios::binary);
         if (!m_sampleFile.is_open())
         {
             qWarning() << "FileRecord::startRecording: failed to open file: " << m_curentFileName;

--- a/sdrbase/dsp/filerecord.cpp
+++ b/sdrbase/dsp/filerecord.cpp
@@ -121,7 +121,7 @@ bool FileRecord::startRecording()
         m_sampleFile.open(m_currentFileName.toStdString().c_str(), std::ios::binary);
         if (!m_sampleFile.is_open())
         {
-            qWarning() << "FileRecord::startRecording: failed to open file: " << m_curentFileName;
+            qWarning() << "FileRecord::startRecording: failed to open file: " << m_currentFileName;
             return false;
         }
         m_recordOn = true;
@@ -143,7 +143,7 @@ bool FileRecord::stopRecording()
         m_recordStart = false;
         if (m_sampleFile.bad())
         {
-            qWarning() << "FileRecord::stopRecording: an error occurred while writing to " << m_curentFileName;
+            qWarning() << "FileRecord::stopRecording: an error occurred while writing to " << m_currentFileName;
             return false;
         }
     }

--- a/sdrbase/dsp/filerecord.h
+++ b/sdrbase/dsp/filerecord.h
@@ -50,7 +50,7 @@ public:
 
     quint64 getByteCount() const { return m_byteCount; }
     void setMsShift(qint64 shift) { m_msShift = shift; }
-    const QString& getCurrentFileName() { return m_curentFileName; }
+    const QString& getCurrentFileName() { return m_currentFileName; }
 
     void genUniqueFileName(uint deviceUID, int istream = -1);
 
@@ -74,7 +74,7 @@ private:
 	bool m_recordOn;
     bool m_recordStart;
     std::ofstream m_sampleFile;
-    QString m_curentFileName;
+    QString m_currentFileName;
     quint64 m_byteCount;
     qint64 m_msShift;
     QRecursiveMutex m_mutex;

--- a/sdrbase/dsp/wavfilerecord.cpp
+++ b/sdrbase/dsp/wavfilerecord.cpp
@@ -133,7 +133,7 @@ bool WavFileRecord::startRecording()
         m_sampleFile.open(m_currentFileName.toStdString().c_str(), std::ios::binary);
         if (!m_sampleFile.is_open())
         {
-            qWarning() << "WavFileRecord::startRecording: failed to open file: " << m_curentFileName;
+            qWarning() << "WavFileRecord::startRecording: failed to open file: " << m_currentFileName;
             return false;
         }
         m_recordOn = true;
@@ -161,7 +161,7 @@ bool WavFileRecord::stopRecording()
         m_recordStart = false;
         if (m_sampleFile.bad())
         {
-            qWarning() << "WavFileRecord::stopRecording: an error occurred while writing to " << m_curentFileName;
+            qWarning() << "WavFileRecord::stopRecording: an error occurred while writing to " << m_currentFileName;
             return false;
         }
     }

--- a/sdrbase/dsp/wavfilerecord.cpp
+++ b/sdrbase/dsp/wavfilerecord.cpp
@@ -129,8 +129,8 @@ bool WavFileRecord::startRecording()
     if (!m_sampleFile.is_open())
     {
         qDebug() << "WavFileRecord::startRecording";
-        m_curentFileName = QString("%1.%2.wav").arg(m_fileBase).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddTHH_mm_ss_zzz"));
-        m_sampleFile.open(m_curentFileName.toStdString().c_str(), std::ios::binary);
+        m_currentFileName = QString("%1.%2.wav").arg(m_fileBase).arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddTHH_mm_ss_zzz"));
+        m_sampleFile.open(m_currentFileName.toStdString().c_str(), std::ios::binary);
         if (!m_sampleFile.is_open())
         {
             qWarning() << "WavFileRecord::startRecording: failed to open file: " << m_curentFileName;

--- a/sdrbase/dsp/wavfilerecord.h
+++ b/sdrbase/dsp/wavfilerecord.h
@@ -92,7 +92,7 @@ public:
     quint64 getByteCount() const { return m_byteCount; }
     void setMsShift(qint64 shift) override { m_msShift = shift; }
     virtual int getBytesPerSample() override { return 4; };
-    const QString& getCurrentFileName() override { return m_curentFileName; }
+    const QString& getCurrentFileName() override { return m_currentFileName; }
 
     void genUniqueFileName(uint deviceUID, int istream = -1);
 
@@ -120,7 +120,7 @@ private:
     bool m_recordOn;
     bool m_recordStart;
     std::ofstream m_sampleFile;
-    QString m_curentFileName;
+    QString m_currentFileName;
     quint64 m_byteCount;
     qint64 m_msShift;
 

--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -2042,7 +2042,7 @@ void MainWindow::on_action_saveAll_triggered()
 {
     saveConfiguration(m_mainCore->m_settings.getWorkingConfiguration());
     m_mainCore->m_settings.save();
-    QMessageBox::information(this, tr("Done"), tr("All curent settings saved"));
+    QMessageBox::information(this, tr("Done"), tr("All current settings saved"));
 }
 
 void MainWindow::on_action_Quick_Start_triggered()


### PR DESCRIPTION
"curent" to "current"
User Visible:
mainwindow.cpp
Function names/Comments:
filerecord.cpp
filerecord.h
wavfilerecord.h
wavfilerecord.cpp
atvmodsource.h