### PR TITLE
Remote TCP Input fixes for #1467

### DIFF
--- a/plugins/samplesource/remotetcpinput/readme.md
+++ b/plugins/samplesource/remotetcpinput/readme.md
@@ -30,11 +30,11 @@ This is the correction to be applied to the remote device's local oscillator in 
 
 <h3>5: DC offset correction</h3>
 
-Check this button to enable DC offset correction on the remote device. This is only supported when the remote server is SDRangel.
+Check this button to enable DC offset correction.
 
 <h3>6: IQ imbalance correction</h3>
 
-Check this button to enable IQ imbalance correction on the remote device. This is only supported when the remote server is SDRangel.
+Check this button to enable IQ imbalance correction.
 
 <h3>7: Bias tee</h3>
 

--- a/plugins/samplesource/remotetcpinput/remotetcpinput.cpp
+++ b/plugins/samplesource/remotetcpinput/remotetcpinput.cpp
@@ -224,6 +224,15 @@ void RemoteTCPInput::applySettings(const RemoteTCPInputSettings& settings, const
     std::ostringstream os;
     bool forwardChange = false;
 
+    // Should this only be applied if not applied on remote?
+    if (settingsKeys.contains("dcBlock") || settingsKeys.contains("iqCorrection") || force)
+    {
+        m_deviceAPI->configureCorrections(settings.m_dcBlock, settings.m_iqCorrection);
+        qDebug("RemoteTCPInput::applySettings: corrections: DC block: %s IQ imbalance: %s",
+                settings.m_dcBlock ? "true" : "false",
+                settings.m_iqCorrection ? "true" : "false");
+    }
+
     if (settingsKeys.contains("centerFrequency") || force) {
         forwardChange = true;
     }

--- a/plugins/samplesource/remotetcpinput/remotetcpinputgui.cpp
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputgui.cpp
@@ -241,8 +241,6 @@ bool RemoteTCPInputGui::handleMessage(const Message& message)
                 ui->sampleBits->removeItem(ui->sampleBits->count() - 1);
             }
         }
-        ui->dcOffset->setVisible(sdra);
-        ui->iqImbalance->setVisible(sdra);
         if (sdra && (ui->decim->count() != 7))
         {
             ui->decim->addItem("2");

--- a/plugins/samplesource/remotetcpinput/remotetcpinputtcphandler.h
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputtcphandler.h
@@ -137,6 +137,7 @@ private:
     QTimer m_timer;
     QTimer m_reconnectTimer;
     QDateTime m_prevDateTime;
+    bool m_sdra;
 
     int32_t *m_converterBuffer;
     uint32_t m_converterBufferNbSamples;
@@ -155,6 +156,7 @@ private:
     void setCenterFrequency(quint64 frequency);
     void setTunerAGC(bool agc);
     void setTunerGain(int gain);
+    void setGainByIndex(int gain);
     void setFreqCorrection(int correction);
     void setIFGain(quint16 stage, quint16 gain);
     void setAGC(bool agc);


### PR DESCRIPTION
Treat 8-bit IQ data as unsigned. 
Add DC/IQ correction for RTL0. 
Don't send SDRA commands when RTL0. 

Fixes #1467