### PR TITLE
Set window width to account for minimum width required for visible rollups

### DIFF
--- a/plugins/channelrx/chanalyzer/chanalyzergui.cpp
+++ b/plugins/channelrx/chanalyzer/chanalyzergui.cpp
@@ -467,7 +467,8 @@ void ChannelAnalyzerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/demodais/aisdemodgui.cpp
+++ b/plugins/channelrx/demodais/aisdemodgui.cpp
@@ -369,19 +369,6 @@ void AISDemodGUI::filter()
 
 void AISDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
-    if (widget == ui->scopeContainer)
-    {
-        if (rollDown)
-        {
-            // Make wide enough for scope controls
-            setMinimumWidth(716);
-        }
-        else
-        {
-            setMinimumWidth(352);
-        }
-    }
-
     RollupContents *rollupContents = getRollupContents();
 
     if (rollupContents->hasExpandableWidgets()) {
@@ -391,7 +378,8 @@ void AISDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/demodais/aisdemodgui.ui
+++ b/plugins/channelrx/demodais/aisdemodgui.ui
@@ -721,9 +721,15 @@
     <rect>
      <x>20</x>
      <y>400</y>
-     <width>351</width>
+     <width>716</width>
      <height>341</height>
     </rect>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>714</width>
+     <height>0</height>
+    </size>
    </property>
    <property name="windowTitle">
     <string>Waveforms</string>
@@ -912,26 +918,26 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ButtonSwitch</class>
-   <extends>QToolButton</extends>
-   <header>gui/buttonswitch.h</header>
-  </customwidget>
-  <customwidget>
    <class>RollupContents</class>
    <extends>QWidget</extends>
    <header>gui/rollupcontents.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ValueDialZ</class>
-   <extends>QWidget</extends>
-   <header>gui/valuedialz.h</header>
-   <container>1</container>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
   </customwidget>
   <customwidget>
    <class>LevelMeterSignalDB</class>
    <extends>QWidget</extends>
    <header>gui/levelmeter.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ValueDialZ</class>
+   <extends>QWidget</extends>
+   <header>gui/valuedialz.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/plugins/channelrx/demodapt/aptdemodgui.cpp
+++ b/plugins/channelrx/demodapt/aptdemodgui.cpp
@@ -556,7 +556,8 @@ void APTDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/demodbfm/bfmdemodgui.cpp
+++ b/plugins/channelrx/demodbfm/bfmdemodgui.cpp
@@ -325,7 +325,8 @@ void BFMDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/demodbfm/bfmdemodgui.ui
+++ b/plugins/channelrx/demodbfm/bfmdemodgui.ui
@@ -18,7 +18,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>642</width>
+    <width>450</width>
     <height>0</height>
    </size>
   </property>
@@ -48,7 +48,7 @@
    </property>
    <property name="minimumSize">
     <size>
-     <width>640</width>
+     <width>450</width>
      <height>0</height>
     </size>
    </property>
@@ -553,7 +553,7 @@
    </property>
    <property name="minimumSize">
     <size>
-     <width>640</width>
+     <width>760</width>
      <height>0</height>
     </size>
    </property>

--- a/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
@@ -338,7 +338,8 @@ void ChirpChatDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/demoddab/dabdemodgui.cpp
+++ b/plugins/channelrx/demoddab/dabdemodgui.cpp
@@ -401,7 +401,8 @@ void DABDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
@@ -257,7 +257,8 @@ void FreeDVDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/demodpacket/packetdemodgui.cpp
+++ b/plugins/channelrx/demodpacket/packetdemodgui.cpp
@@ -383,7 +383,8 @@ void PacketDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/demodpager/pagerdemodgui.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodgui.cpp
@@ -418,19 +418,6 @@ void PagerDemodGUI::filter()
 
 void PagerDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
-    if (widget == ui->scopeContainer)
-    {
-        if (rollDown)
-        {
-            // Make wide enough for scope controls
-            setMinimumWidth(716);
-        }
-        else
-        {
-            setMinimumWidth(352);
-        }
-    }
-
     RollupContents *rollupContents = getRollupContents();
 
     if (rollupContents->hasExpandableWidgets()) {
@@ -440,7 +427,8 @@ void PagerDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/demodpager/pagerdemodgui.ui
+++ b/plugins/channelrx/demodpager/pagerdemodgui.ui
@@ -816,9 +816,15 @@
     <rect>
      <x>20</x>
      <y>400</y>
-     <width>351</width>
+     <width>714</width>
      <height>341</height>
     </rect>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>714</width>
+     <height>0</height>
+    </size>
    </property>
    <property name="windowTitle">
     <string>Waveforms</string>
@@ -1019,10 +1025,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ValueDialZ</class>
-   <extends>QWidget</extends>
-   <header>gui/valuedialz.h</header>
-   <container>1</container>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
   </customwidget>
   <customwidget>
    <class>LevelMeterSignalDB</class>
@@ -1031,9 +1036,10 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ButtonSwitch</class>
-   <extends>QToolButton</extends>
-   <header>gui/buttonswitch.h</header>
+   <class>ValueDialZ</class>
+   <extends>QWidget</extends>
+   <header>gui/valuedialz.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>GLScope</class>

--- a/plugins/channelrx/demodradiosonde/radiosondedemodgui.cpp
+++ b/plugins/channelrx/demodradiosonde/radiosondedemodgui.cpp
@@ -475,19 +475,6 @@ void RadiosondeDemodGUI::filter()
 
 void RadiosondeDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
-    if (widget == ui->scopeContainer)
-    {
-        if (rollDown)
-        {
-            // Make wide enough for scope controls
-            setMinimumWidth(716);
-        }
-        else
-        {
-            setMinimumWidth(352);
-        }
-    }
-
     RollupContents *rollupContents = getRollupContents();
 
     if (rollupContents->hasExpandableWidgets()) {
@@ -497,7 +484,8 @@ void RadiosondeDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/demodradiosonde/radiosondedemodgui.ui
+++ b/plugins/channelrx/demodradiosonde/radiosondedemodgui.ui
@@ -855,9 +855,15 @@
     <rect>
      <x>20</x>
      <y>400</y>
-     <width>351</width>
+     <width>714</width>
      <height>341</height>
     </rect>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>714</width>
+     <height>0</height>
+    </size>
    </property>
    <property name="windowTitle">
     <string>Waveforms</string>
@@ -1061,10 +1067,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ValueDialZ</class>
-   <extends>QWidget</extends>
-   <header>gui/valuedialz.h</header>
-   <container>1</container>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
   </customwidget>
   <customwidget>
    <class>LevelMeterSignalDB</class>
@@ -1073,9 +1078,10 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ButtonSwitch</class>
-   <extends>QToolButton</extends>
-   <header>gui/buttonswitch.h</header>
+   <class>ValueDialZ</class>
+   <extends>QWidget</extends>
+   <header>gui/valuedialz.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>GLScope</class>

--- a/plugins/channelrx/demodssb/ssbdemodgui.cpp
+++ b/plugins/channelrx/demodssb/ssbdemodgui.cpp
@@ -316,19 +316,15 @@ void SSBDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 
     RollupContents *rollupContents = getRollupContents();
 
-    if (rollupContents->hasExpandableWidgets())
-    {
-        qDebug("SSBDemodGUI::onWidgetRolled: set vertical policy expanding");
+    if (rollupContents->hasExpandableWidgets()) {
         setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    }
-    else
-    {
-        qDebug("SSBDemodGUI::onWidgetRolled: set vertical policy fixed");
+    } else {
         setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/demodvormc/vordemodmcgui.cpp
+++ b/plugins/channelrx/demodvormc/vordemodmcgui.cpp
@@ -1116,7 +1116,8 @@ void VORDemodMCGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/filesink/filesinkgui.cpp
+++ b/plugins/channelrx/filesink/filesinkgui.cpp
@@ -364,7 +364,8 @@ void FileSinkGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/freqtracker/freqtrackergui.ui
+++ b/plugins/channelrx/freqtracker/freqtrackergui.ui
@@ -40,6 +40,12 @@
      <height>151</height>
     </rect>
    </property>
+   <property name="minimumSize">
+    <size>
+     <width>300</width>
+     <height>0</height>
+    </size>
+   </property>
    <property name="windowTitle">
     <string>Settings</string>
    </property>
@@ -815,6 +821,17 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
+  </customwidget>
+  <customwidget>
+   <class>LevelMeterSignalDB</class>
+   <extends>QWidget</extends>
+   <header>gui/levelmeter.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>GLSpectrum</class>
    <extends>QWidget</extends>
    <header>gui/glspectrum.h</header>
@@ -831,17 +848,6 @@
    <extends>QWidget</extends>
    <header>gui/valuedialz.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>LevelMeterSignalDB</class>
-   <extends>QWidget</extends>
-   <header>gui/levelmeter.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ButtonSwitch</class>
-   <extends>QToolButton</extends>
-   <header>gui/buttonswitch.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/plugins/channelrx/localsink/localsinkgui.ui
+++ b/plugins/channelrx/localsink/localsinkgui.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -42,9 +42,15 @@
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>301</width>
+     <width>302</width>
      <height>91</height>
     </rect>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>302</width>
+     <height>0</height>
+    </size>
    </property>
    <property name="windowTitle">
     <string>Settings</string>

--- a/plugins/channelrx/noisefigure/noisefiguregui.cpp
+++ b/plugins/channelrx/noisefigure/noisefiguregui.cpp
@@ -546,7 +546,8 @@ void NoiseFigureGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -1915,7 +1915,8 @@ void RadioAstronomyGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/radioclock/radioclockgui.cpp
+++ b/plugins/channelrx/radioclock/radioclockgui.cpp
@@ -209,19 +209,6 @@ void RadioClockGUI::on_timezone_currentIndexChanged(int index)
 
 void RadioClockGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
-    if (widget == ui->scopeContainer)
-    {
-        if (rollDown)
-        {
-            // Make wide enough for scope controls
-            setMinimumWidth(716);
-        }
-        else
-        {
-            setMinimumWidth(352);
-        }
-    }
-
     RollupContents *rollupContents = getRollupContents();
 
     if (rollupContents->hasExpandableWidgets()) {
@@ -231,7 +218,8 @@ void RadioClockGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/radioclock/radioclockgui.ui
+++ b/plugins/channelrx/radioclock/radioclockgui.ui
@@ -591,9 +591,15 @@
     <rect>
      <x>20</x>
      <y>250</y>
-     <width>351</width>
+     <width>714</width>
      <height>341</height>
     </rect>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>714</width>
+     <height>0</height>
+    </size>
    </property>
    <property name="windowTitle">
     <string>Waveforms</string>
@@ -644,15 +650,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ValueDialZ</class>
-   <extends>QWidget</extends>
-   <header>gui/valuedialz.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>LevelMeterSignalDB</class>
    <extends>QWidget</extends>
    <header>gui/levelmeter.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ValueDialZ</class>
+   <extends>QWidget</extends>
+   <header>gui/valuedialz.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/plugins/channelrx/remotetcpsink/remotetcpsinkgui.ui
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinkgui.ui
@@ -24,7 +24,7 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>360</width>
+    <width>560</width>
     <height>16777215</height>
    </size>
   </property>
@@ -44,6 +44,12 @@
      <width>340</width>
      <height>141</height>
     </rect>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>334</width>
+     <height>0</height>
+    </size>
    </property>
    <property name="windowTitle">
     <string>Settings</string>
@@ -448,6 +454,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>RollupContents</class>
+   <extends>QWidget</extends>
+   <header>gui/rollupcontents.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>ValueDialZ</class>
    <extends>QWidget</extends>
    <header>gui/valuedialz.h</header>
@@ -457,12 +469,6 @@
    <class>ValueDial</class>
    <extends>QWidget</extends>
    <header>gui/valuedial.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>RollupContents</class>
-   <extends>QWidget</extends>
-   <header>gui/rollupcontents.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/plugins/channelrx/sigmffilesink/sigmffilesinkgui.cpp
+++ b/plugins/channelrx/sigmffilesink/sigmffilesinkgui.cpp
@@ -356,7 +356,8 @@ void SigMFFileSinkGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channelrx/udpsink/udpsinkgui.cpp
+++ b/plugins/channelrx/udpsink/udpsinkgui.cpp
@@ -609,7 +609,8 @@ void UDPSinkGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_modgui.cpp
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_modgui.cpp
@@ -329,7 +329,8 @@ void IEEE_802_15_4_ModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channeltx/modais/aismodgui.cpp
+++ b/plugins/channeltx/modais/aismodgui.cpp
@@ -352,7 +352,8 @@ void AISModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channeltx/modfreedv/freedvmodgui.cpp
+++ b/plugins/channeltx/modfreedv/freedvmodgui.cpp
@@ -304,7 +304,8 @@ void FreeDVModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channeltx/modpacket/packetmodgui.cpp
+++ b/plugins/channeltx/modpacket/packetmodgui.cpp
@@ -389,7 +389,8 @@ void PacketModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channeltx/modssb/ssbmodgui.cpp
+++ b/plugins/channeltx/modssb/ssbmodgui.cpp
@@ -368,7 +368,8 @@ void SSBModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/channeltx/udpsource/udpsourcegui.cpp
+++ b/plugins/channeltx/udpsource/udpsourcegui.cpp
@@ -491,7 +491,8 @@ void UDPSourceGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/feature/ais/aisgui.cpp
+++ b/plugins/feature/ais/aisgui.cpp
@@ -176,7 +176,8 @@ void AISGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/feature/antennatools/antennatoolsgui.cpp
+++ b/plugins/feature/antennatools/antennatoolsgui.cpp
@@ -120,7 +120,8 @@ void AntennaToolsGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/feature/demodanalyzer/demodanalyzergui.cpp
+++ b/plugins/feature/demodanalyzer/demodanalyzergui.cpp
@@ -135,7 +135,8 @@ void DemodAnalyzerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/feature/radiosonde/radiosondegui.cpp
+++ b/plugins/feature/radiosonde/radiosondegui.cpp
@@ -127,7 +127,8 @@ void RadiosondeGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/feature/satellitetracker/satellitetrackergui.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackergui.cpp
@@ -239,7 +239,8 @@ void SatelliteTrackerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/feature/startracker/startrackergui.cpp
+++ b/plugins/feature/startracker/startrackergui.cpp
@@ -234,7 +234,8 @@ void StarTrackerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/plugins/feature/vorlocalizer/vorlocalizergui.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizergui.cpp
@@ -807,7 +807,8 @@ void VORLocalizerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     }
 
     int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
+    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
+    resize(w, h);
 
     rollupContents->saveState(m_rollupState);
     applySettings();

--- a/sdrgui/channel/channelgui.h
+++ b/sdrgui/channel/channelgui.h
@@ -97,6 +97,7 @@ protected:
     void updateIndexLabel();
     int getAdditionalHeight() const { return 22 + 22; }  // height of top and bottom bars
     void setHighlighted(bool highlighted);
+    int gripSize() { return m_resizer.m_gripSize; } // size in pixels of resize grip around the window
 
     DeviceType m_deviceType;
     int m_deviceSetIndex;

--- a/sdrgui/feature/featuregui.h
+++ b/sdrgui/feature/featuregui.h
@@ -74,6 +74,7 @@ protected:
     void mouseMoveEvent(QMouseEvent* event) override;
     void resetContextMenuType() { m_contextMenuType = ContextMenuNone; }
     int getAdditionalHeight() const { return 22 + 22; } // height of top and bottom bars
+    int gripSize() { return m_resizer.m_gripSize; } // size in pixels of resize grip around the window
 
     Feature *m_feature;
     int m_featureIndex;

--- a/sdrgui/gui/rollupcontents.cpp
+++ b/sdrgui/gui/rollupcontents.cpp
@@ -95,11 +95,11 @@ bool RollupContents::hasExpandableWidgets()
 
     return false;
 }
-
 int RollupContents::arrangeRollups()
 {
     QFontMetrics fm(font());
     int pos;
+    int minWidth = 0;
 
     // First calculate minimum height needed, to determine how much extra space
     // we have that can be split between expanding widgets
@@ -123,12 +123,14 @@ int RollupContents::arrangeRollups()
                 } else {
                     h = r->minimumSizeHint().height();
                 }
+                minWidth = std::max(minWidth, r->minimumSize().width());
                 pos += h + 5;
             }
         }
     }
 
     setMinimumHeight(pos);
+    setMinimumWidth(minWidth);
 
     // Split extra space equally between widgets
     // If there's a remainder, we give it to the first widget


### PR DESCRIPTION
This patch updates RollupContents to calculate and set the minimum width required for the visible widgets.

The window resize in onWidgetRolled in channels and features has been updated to take this into account, so that the window should resize to respect the minimum size when a widget is rolled up/down.

As such, a few places where I'd hacked this in with hardcoded constants have been removed.

The practical result of this, is that a channel such as the Broadcast FM Demod, can be made a bit smaller when the RDS Rollup is not visible. 
