### PR TITLE
Maximize windows part 2

### DIFF
--- a/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodgui.cpp
+++ b/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodgui.cpp
@@ -16,7 +16,6 @@
 ///////////////////////////////////////////////////////////////////////////////////
 
 #include <QLocale>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 #include "gui/basicchannelsettingsdialog.h"
@@ -60,14 +59,6 @@ bool BeamSteeringCWModGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void BeamSteeringCWModGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool BeamSteeringCWModGUI::handleMessage(const Message& message)

--- a/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodgui.h
+++ b/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodgui.h
@@ -94,9 +94,6 @@ private:
     void applyInterpolation();
     void applyPosition();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private slots:
     void handleSourceMessages();
     void on_channelOutput_currentIndexChanged(int index);

--- a/plugins/channelmimo/doa2/doa2gui.cpp
+++ b/plugins/channelmimo/doa2/doa2gui.cpp
@@ -283,18 +283,7 @@ void DOA2GUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelmimo/interferometer/interferometergui.cpp
+++ b/plugins/channelmimo/interferometer/interferometergui.cpp
@@ -252,18 +252,7 @@ void InterferometerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/chanalyzer/chanalyzergui.cpp
+++ b/plugins/channelrx/chanalyzer/chanalyzergui.cpp
@@ -458,19 +458,7 @@ void ChannelAnalyzerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -3783,18 +3783,7 @@ void ADSBDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demodais/aisdemodgui.cpp
+++ b/plugins/channelrx/demodais/aisdemodgui.cpp
@@ -372,19 +372,7 @@ void AISDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demodam/amdemodgui.cpp
+++ b/plugins/channelrx/demodam/amdemodgui.cpp
@@ -18,7 +18,6 @@
 #include <QDockWidget>
 #include <QMainWindow>
 #include <QDebug>
-#include <QResizeEvent>
 
 #include "amdemodgui.h"
 #include "amdemodssbdialog.h"
@@ -71,14 +70,6 @@ bool AMDemodGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void AMDemodGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool AMDemodGUI::handleMessage(const Message& message)

--- a/plugins/channelrx/demodam/amdemodgui.h
+++ b/plugins/channelrx/demodam/amdemodgui.h
@@ -47,9 +47,6 @@ public slots:
 	void channelMarkerChangedByCursor();
 	void channelMarkerHighlightedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
 	Ui::AMDemodGUI* ui;
 	PluginAPI* m_pluginAPI;

--- a/plugins/channelrx/demodapt/aptdemodgui.cpp
+++ b/plugins/channelrx/demodapt/aptdemodgui.cpp
@@ -547,19 +547,7 @@ void APTDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demodatv/atvdemodgui.cpp
+++ b/plugins/channelrx/demodatv/atvdemodgui.cpp
@@ -18,7 +18,6 @@
 
 #include <QDockWidget>
 #include <QMainWindow>
-#include <QResizeEvent>
 
 #include "atvdemodgui.h"
 
@@ -75,14 +74,6 @@ bool ATVDemodGUI::deserialize(const QByteArray& data)
         applySettings(true); // will have true
         return false;
     }
-}
-
-void ATVDemodGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 void ATVDemodGUI::displaySettings()

--- a/plugins/channelrx/demodatv/atvdemodgui.h
+++ b/plugins/channelrx/demodatv/atvdemodgui.h
@@ -66,9 +66,6 @@ public slots:
 	void channelMarkerChangedByCursor();
     void channelMarkerHighlightedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
 	Ui::ATVDemodGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channelrx/demodbfm/bfmdemodgui.cpp
+++ b/plugins/channelrx/demodbfm/bfmdemodgui.cpp
@@ -316,19 +316,7 @@ void BFMDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
@@ -329,19 +329,7 @@ void ChirpChatDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demoddab/dabdemodgui.cpp
+++ b/plugins/channelrx/demoddab/dabdemodgui.cpp
@@ -392,19 +392,7 @@ void DABDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demoddatv/datvdemodgui.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodgui.cpp
@@ -20,7 +20,6 @@
 #include <QDockWidget>
 #include <QMainWindow>
 #include <QMediaMetaData>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 #include "dsp/dspengine.h"
@@ -91,14 +90,6 @@ bool DATVDemodGUI::deserialize(const QByteArray& arrData)
         resetToDefaults();
         return false;
     }
-}
-
-void DATVDemodGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool DATVDemodGUI::handleMessage(const Message& message)

--- a/plugins/channelrx/demoddatv/datvdemodgui.h
+++ b/plugins/channelrx/demoddatv/datvdemodgui.h
@@ -65,9 +65,6 @@ public:
 
     static const char* const m_strChannelID;
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private slots:
     void channelMarkerChangedByCursor();
     void channelMarkerHighlightedByCursor();

--- a/plugins/channelrx/demoddatv/datvdemodgui.ui
+++ b/plugins/channelrx/demoddatv/datvdemodgui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>540</width>
+    <width>556</width>
     <height>476</height>
    </rect>
   </property>
@@ -18,13 +18,13 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>540</width>
+    <width>556</width>
     <height>442</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>540</width>
+    <width>556</width>
     <height>476</height>
    </size>
   </property>

--- a/plugins/channelrx/demoddsd/dsddemodgui.cpp
+++ b/plugins/channelrx/demoddsd/dsddemodgui.cpp
@@ -82,14 +82,6 @@ bool DSDDemodGUI::deserialize(const QByteArray& data)
     }
 }
 
-void DSDDemodGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
-}
-
 bool DSDDemodGUI::handleMessage(const Message& message)
 {
     if (DSDDemod::MsgConfigureDSDDemod::match(message))

--- a/plugins/channelrx/demoddsd/dsddemodgui.h
+++ b/plugins/channelrx/demoddsd/dsddemodgui.h
@@ -68,9 +68,6 @@ public slots:
 	void channelMarkerChangedByCursor();
     void channelMarkerHighlightedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
 //	typedef enum
 //	{

--- a/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
@@ -248,19 +248,7 @@ void FreeDVDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demodm17/m17demodgui.cpp
+++ b/plugins/channelrx/demodm17/m17demodgui.cpp
@@ -86,14 +86,6 @@ bool M17DemodGUI::deserialize(const QByteArray& data)
     }
 }
 
-void M17DemodGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
-}
-
 bool M17DemodGUI::handleMessage(const Message& message)
 {
     if (M17Demod::MsgConfigureM17Demod::match(message))

--- a/plugins/channelrx/demodm17/m17demodgui.h
+++ b/plugins/channelrx/demodm17/m17demodgui.h
@@ -70,9 +70,6 @@ public slots:
 	void channelMarkerChangedByCursor();
     void channelMarkerHighlightedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     struct BERPoint
     {

--- a/plugins/channelrx/demodnfm/nfmdemodgui.cpp
+++ b/plugins/channelrx/demodnfm/nfmdemodgui.cpp
@@ -55,14 +55,6 @@ bool NFMDemodGUI::deserialize(const QByteArray& data)
     }
 }
 
-void NFMDemodGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
-}
-
 bool NFMDemodGUI::handleMessage(const Message& message)
 {
     if (NFMDemodReport::MsgReportCTCSSFreq::match(message))

--- a/plugins/channelrx/demodnfm/nfmdemodgui.h
+++ b/plugins/channelrx/demodnfm/nfmdemodgui.h
@@ -46,9 +46,6 @@ public slots:
 	void channelMarkerChangedByCursor();
     void channelMarkerHighlightedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
 	Ui::NFMDemodGUI* ui;
 	PluginAPI* m_pluginAPI;

--- a/plugins/channelrx/demodpacket/packetdemodgui.cpp
+++ b/plugins/channelrx/demodpacket/packetdemodgui.cpp
@@ -374,19 +374,7 @@ void PacketDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demodpager/pagerdemodgui.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodgui.cpp
@@ -421,19 +421,7 @@ void PagerDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demodradiosonde/radiosondedemodgui.cpp
+++ b/plugins/channelrx/demodradiosonde/radiosondedemodgui.cpp
@@ -478,19 +478,7 @@ void RadiosondeDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demodssb/ssbdemodgui.cpp
+++ b/plugins/channelrx/demodssb/ssbdemodgui.cpp
@@ -314,19 +314,7 @@ void SSBDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demodvor/vordemodgui.cpp
+++ b/plugins/channelrx/demodvor/vordemodgui.cpp
@@ -19,7 +19,6 @@
 #include <limits>
 
 #include <QDebug>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 #include "dsp/dspengine.h"
@@ -75,14 +74,6 @@ bool VORDemodGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void VORDemodGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool VORDemodGUI::handleMessage(const Message& message)

--- a/plugins/channelrx/demodvor/vordemodgui.h
+++ b/plugins/channelrx/demodvor/vordemodgui.h
@@ -64,9 +64,6 @@ public slots:
     void channelMarkerChangedByCursor();
     void channelMarkerHighlightedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::VORDemodGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channelrx/demodvormc/vordemodmcgui.cpp
+++ b/plugins/channelrx/demodvormc/vordemodmcgui.cpp
@@ -1107,19 +1107,7 @@ void VORDemodMCGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/demodwfm/wfmdemodgui.cpp
+++ b/plugins/channelrx/demodwfm/wfmdemodgui.cpp
@@ -55,14 +55,6 @@ bool WFMDemodGUI::deserialize(const QByteArray& data)
     }
 }
 
-void WFMDemodGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
-}
-
 bool WFMDemodGUI::handleMessage(const Message& message)
 {
     if (WFMDemod::MsgConfigureWFMDemod::match(message))

--- a/plugins/channelrx/demodwfm/wfmdemodgui.h
+++ b/plugins/channelrx/demodwfm/wfmdemodgui.h
@@ -44,9 +44,6 @@ public slots:
 	void channelMarkerChangedByCursor();
     void channelMarkerHighlightedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
 	Ui::WFMDemodGUI* ui;
 	PluginAPI* m_pluginAPI;

--- a/plugins/channelrx/filesink/filesinkgui.cpp
+++ b/plugins/channelrx/filesink/filesinkgui.cpp
@@ -355,19 +355,7 @@ void FileSinkGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/localsink/localsinkgui.cpp
+++ b/plugins/channelrx/localsink/localsinkgui.cpp
@@ -16,7 +16,6 @@
 ///////////////////////////////////////////////////////////////////////////////////
 
 #include <QLocale>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 #include "gui/basicchannelsettingsdialog.h"
@@ -67,14 +66,6 @@ bool LocalSinkGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void LocalSinkGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool LocalSinkGUI::handleMessage(const Message& message)

--- a/plugins/channelrx/localsink/localsinkgui.h
+++ b/plugins/channelrx/localsink/localsinkgui.h
@@ -60,9 +60,6 @@ public:
     virtual int getStreamIndex() const { return m_settings.m_streamIndex; }
     virtual void setStreamIndex(int streamIndex) { m_settings.m_streamIndex = streamIndex; }
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::LocalSinkGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channelrx/noisefigure/noisefiguregui.cpp
+++ b/plugins/channelrx/noisefigure/noisefiguregui.cpp
@@ -537,19 +537,7 @@ void NoiseFigureGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -1906,19 +1906,7 @@ void RadioAstronomyGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/radioclock/radioclockgui.cpp
+++ b/plugins/channelrx/radioclock/radioclockgui.cpp
@@ -212,19 +212,7 @@ void RadioClockGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/remotesink/remotesinkgui.cpp
+++ b/plugins/channelrx/remotesink/remotesinkgui.cpp
@@ -16,7 +16,6 @@
 ///////////////////////////////////////////////////////////////////////////////////
 
 #include <QLocale>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 #include "gui/basicchannelsettingsdialog.h"
@@ -62,14 +61,6 @@ bool RemoteSinkGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void RemoteSinkGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool RemoteSinkGUI::handleMessage(const Message& message)

--- a/plugins/channelrx/remotesink/remotesinkgui.h
+++ b/plugins/channelrx/remotesink/remotesinkgui.h
@@ -60,9 +60,6 @@ public:
     virtual int getStreamIndex() const { return m_settings.m_streamIndex; }
     virtual void setStreamIndex(int streamIndex) { m_settings.m_streamIndex = streamIndex; }
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::RemoteSinkGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channelrx/remotetcpsink/remotetcpsinkgui.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinkgui.cpp
@@ -17,7 +17,6 @@
 ///////////////////////////////////////////////////////////////////////////////////
 
 #include <QLocale>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 #include "gui/basicchannelsettingsdialog.h"
@@ -63,14 +62,6 @@ bool RemoteTCPSinkGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void RemoteTCPSinkGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 QString RemoteTCPSinkGUI::displayScaledF(float value, char type, int precision, bool showMult)

--- a/plugins/channelrx/remotetcpsink/remotetcpsinkgui.h
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinkgui.h
@@ -66,9 +66,6 @@ public slots:
     void channelMarkerChangedByCursor();
     void channelMarkerHighlightedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::RemoteTCPSinkGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channelrx/sigmffilesink/sigmffilesinkgui.cpp
+++ b/plugins/channelrx/sigmffilesink/sigmffilesinkgui.cpp
@@ -347,19 +347,7 @@ void SigMFFileSinkGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channelrx/udpsink/udpsinkgui.cpp
+++ b/plugins/channelrx/udpsink/udpsinkgui.cpp
@@ -600,19 +600,7 @@ void UDPSinkGUI::onWidgetRolled(QWidget* widget, bool rollDown)
         m_udpSink->enableSpectrum(rollDown);
 	}
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channeltx/filesource/filesourcegui.cpp
+++ b/plugins/channeltx/filesource/filesourcegui.cpp
@@ -18,7 +18,6 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QDebug>
-#include <QResizeEvent>
 
 #include "device/deviceapi.h"
 #include "device/deviceuiset.h"
@@ -68,14 +67,6 @@ bool FileSourceGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void FileSourceGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool FileSourceGUI::handleMessage(const Message& message)

--- a/plugins/channeltx/filesource/filesourcegui.h
+++ b/plugins/channeltx/filesource/filesourcegui.h
@@ -60,9 +60,6 @@ public:
 public slots:
     void channelMarkerChangedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::FileSourceGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channeltx/localsource/localsourcegui.cpp
+++ b/plugins/channeltx/localsource/localsourcegui.cpp
@@ -16,7 +16,6 @@
 ///////////////////////////////////////////////////////////////////////////////////
 
 #include <QLocale>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 #include "gui/basicchannelsettingsdialog.h"
@@ -62,14 +61,6 @@ bool LocalSourceGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void LocalSourceGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool LocalSourceGUI::handleMessage(const Message& message)

--- a/plugins/channeltx/localsource/localsourcegui.h
+++ b/plugins/channeltx/localsource/localsourcegui.h
@@ -60,9 +60,6 @@ public:
     virtual int getStreamIndex() const { return m_settings.m_streamIndex; }
     virtual void setStreamIndex(int streamIndex) { m_settings.m_streamIndex = streamIndex; }
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::LocalSourceGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_modgui.cpp
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_modgui.cpp
@@ -320,19 +320,7 @@ void IEEE_802_15_4_ModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channeltx/modais/aismodgui.cpp
+++ b/plugins/channeltx/modais/aismodgui.cpp
@@ -343,19 +343,7 @@ void AISModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channeltx/modam/ammodgui.cpp
+++ b/plugins/channeltx/modam/ammodgui.cpp
@@ -20,7 +20,6 @@
 #include <QFileDialog>
 #include <QTime>
 #include <QDebug>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 
@@ -72,14 +71,6 @@ bool AMModGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void AMModGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool AMModGUI::handleMessage(const Message& message)

--- a/plugins/channeltx/modam/ammodgui.h
+++ b/plugins/channeltx/modam/ammodgui.h
@@ -63,9 +63,6 @@ public:
 public slots:
     void channelMarkerChangedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::AMModGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channeltx/modatv/atvmodgui.cpp
+++ b/plugins/channeltx/modatv/atvmodgui.cpp
@@ -21,7 +21,6 @@
 #include <QTime>
 #include <QDebug>
 #include <QMessageBox>
-#include <QResizeEvent>
 
 #include <cmath>
 
@@ -152,14 +151,6 @@ bool ATVModGUI::deserialize(const QByteArray& data)
         applySettings(true); // will have true
         return false;
     }
-}
-
-void ATVModGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool ATVModGUI::handleMessage(const Message& message)

--- a/plugins/channeltx/modatv/atvmodgui.h
+++ b/plugins/channeltx/modatv/atvmodgui.h
@@ -62,9 +62,6 @@ public:
 public slots:
     void channelMarkerChangedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::ATVModGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channeltx/modchirpchat/chirpchatmodgui.cpp
+++ b/plugins/channeltx/modchirpchat/chirpchatmodgui.cpp
@@ -20,7 +20,6 @@
 #include <QFileDialog>
 #include <QTime>
 #include <QDebug>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 #include "plugin/pluginapi.h"
@@ -73,14 +72,6 @@ bool ChirpChatModGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void ChirpChatModGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool ChirpChatModGUI::handleMessage(const Message& message)

--- a/plugins/channeltx/modchirpchat/chirpchatmodgui.h
+++ b/plugins/channeltx/modchirpchat/chirpchatmodgui.h
@@ -61,9 +61,6 @@ public:
 public slots:
     void channelMarkerChangedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::ChirpChatModGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channeltx/moddatv/datvmodgui.cpp
+++ b/plugins/channeltx/moddatv/datvmodgui.cpp
@@ -22,7 +22,6 @@
 #include <QTime>
 #include <QDebug>
 #include <QMessageBox>
-#include <QResizeEvent>
 
 #include <cmath>
 
@@ -151,14 +150,6 @@ bool DATVModGUI::deserialize(const QByteArray& data)
         applySettings(true);
         return false;
     }
-}
-
-void DATVModGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool DATVModGUI::handleMessage(const Message& message)

--- a/plugins/channeltx/moddatv/datvmodgui.h
+++ b/plugins/channeltx/moddatv/datvmodgui.h
@@ -63,9 +63,6 @@ public:
 public slots:
     void channelMarkerChangedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::DATVModGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channeltx/modfreedv/freedvmodgui.cpp
+++ b/plugins/channeltx/modfreedv/freedvmodgui.cpp
@@ -295,19 +295,7 @@ void FreeDVModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channeltx/modm17/m17modgui.cpp
+++ b/plugins/channeltx/modm17/m17modgui.cpp
@@ -21,7 +21,6 @@
 #include <QTime>
 #include <QDebug>
 #include <QRegExp>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 #include "plugin/pluginapi.h"
@@ -73,14 +72,6 @@ bool M17ModGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void M17ModGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool M17ModGUI::handleMessage(const Message& message)

--- a/plugins/channeltx/modm17/m17modgui.h
+++ b/plugins/channeltx/modm17/m17modgui.h
@@ -64,9 +64,6 @@ public:
 public slots:
     void channelMarkerChangedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::M17ModGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channeltx/modnfm/nfmmodgui.cpp
+++ b/plugins/channeltx/modnfm/nfmmodgui.cpp
@@ -21,7 +21,6 @@
 #include <QTime>
 #include <QDebug>
 #include <QRegExp>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 #include "plugin/pluginapi.h"
@@ -73,14 +72,6 @@ bool NFMModGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void NFMModGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool NFMModGUI::handleMessage(const Message& message)

--- a/plugins/channeltx/modnfm/nfmmodgui.h
+++ b/plugins/channeltx/modnfm/nfmmodgui.h
@@ -63,9 +63,6 @@ public:
 public slots:
     void channelMarkerChangedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::NFMModGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channeltx/modpacket/packetmodgui.cpp
+++ b/plugins/channeltx/modpacket/packetmodgui.cpp
@@ -380,19 +380,7 @@ void PacketModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channeltx/modssb/ssbmodgui.cpp
+++ b/plugins/channeltx/modssb/ssbmodgui.cpp
@@ -359,19 +359,7 @@ void SSBModGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/channeltx/modwfm/wfmmodgui.cpp
+++ b/plugins/channeltx/modwfm/wfmmodgui.cpp
@@ -21,7 +21,6 @@
 #include <QFileDialog>
 #include <QTime>
 #include <QDebug>
-#include <QResizeEvent>
 
 #include "device/deviceuiset.h"
 #include "plugin/pluginapi.h"
@@ -72,14 +71,6 @@ bool WFMModGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void WFMModGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool WFMModGUI::handleMessage(const Message& message)

--- a/plugins/channeltx/modwfm/wfmmodgui.h
+++ b/plugins/channeltx/modwfm/wfmmodgui.h
@@ -61,9 +61,6 @@ public:
 public slots:
     void channelMarkerChangedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::WFMModGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channeltx/remotesource/remotesourcegui.cpp
+++ b/plugins/channeltx/remotesource/remotesourcegui.cpp
@@ -16,7 +16,6 @@
 ///////////////////////////////////////////////////////////////////////////////////
 
 #include <QTime>
-#include <QResizeEvent>
 
 #include "device/deviceapi.h"
 #include "device/deviceuiset.h"
@@ -64,14 +63,6 @@ bool RemoteSourceGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void RemoteSourceGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool RemoteSourceGUI::handleMessage(const Message& message)

--- a/plugins/channeltx/remotesource/remotesourcegui.h
+++ b/plugins/channeltx/remotesource/remotesourcegui.h
@@ -62,9 +62,6 @@ public:
 public slots:
     void channelMarkerChangedByCursor();
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::RemoteSourceGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/channeltx/udpsource/udpsourcegui.cpp
+++ b/plugins/channeltx/udpsource/udpsourcegui.cpp
@@ -482,19 +482,7 @@ void UDPSourceGUI::onWidgetRolled(QWidget* widget, bool rollDown)
         m_udpSource->setSpectrum(rollDown);
     }
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 

--- a/plugins/feature/afc/afcgui.cpp
+++ b/plugins/feature/afc/afcgui.cpp
@@ -16,7 +16,6 @@
 ///////////////////////////////////////////////////////////////////////////////////
 
 #include <QMessageBox>
-#include <QResizeEvent>
 
 #include "feature/featureuiset.h"
 #include "device/deviceset.h"
@@ -65,14 +64,6 @@ bool AFCGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void AFCGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool AFCGUI::handleMessage(const Message& message)

--- a/plugins/feature/afc/afcgui.h
+++ b/plugins/feature/afc/afcgui.h
@@ -48,9 +48,6 @@ public:
     virtual void setGeometryBytes(const QByteArray& blob) { m_settings.m_geometryBytes = blob; }
     virtual QByteArray getGeometryBytes() const { return m_settings.m_geometryBytes; }
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
 	Ui::AFCGUI* ui;
 	PluginAPI* m_pluginAPI;

--- a/plugins/feature/ais/aisgui.cpp
+++ b/plugins/feature/ais/aisgui.cpp
@@ -169,16 +169,6 @@ void AISGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 
     RollupContents *rollupContents = getRollupContents();
 
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
     rollupContents->saveState(m_rollupState);
     applySettings();
 }
@@ -196,7 +186,6 @@ AISGUI::AISGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *featur
     m_helpURL = "plugins/feature/ais/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/ambe/ambegui.cpp
+++ b/plugins/feature/ambe/ambegui.cpp
@@ -46,7 +46,6 @@ AMBEGUI::AMBEGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feat
     m_helpURL = "plugins/feature/ambe/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 
@@ -101,14 +100,6 @@ void AMBEGUI::setWorkspaceIndex(int index)
 {
     m_settings.m_workspaceIndex = index;
     m_feature->setWorkspaceIndex(index);
-}
-
-void AMBEGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 void AMBEGUI::onWidgetRolled(QWidget* widget, bool rollDown)

--- a/plugins/feature/ambe/ambegui.h
+++ b/plugins/feature/ambe/ambegui.h
@@ -52,9 +52,6 @@ public:
     virtual void setGeometryBytes(const QByteArray& blob) { m_settings.m_geometryBytes = blob; }
     virtual QByteArray getGeometryBytes() const { return m_settings.m_geometryBytes; }
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
 	Ui::AMBEGUI* ui;
     AMBE *m_ambe;

--- a/plugins/feature/antennatools/antennatoolsgui.cpp
+++ b/plugins/feature/antennatools/antennatoolsgui.cpp
@@ -71,12 +71,6 @@ bool AntennaToolsGUI::deserialize(const QByteArray& data)
     }
 }
 
-void AntennaToolsGUI::resizeEvent(QResizeEvent* size)
-{
-    adjustSize();
-    size->accept();
-}
-
 bool AntennaToolsGUI::handleMessage(const Message& message)
 {
     if (AntennaTools::MsgConfigureAntennaTools::match(message))
@@ -113,16 +107,6 @@ void AntennaToolsGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 
     RollupContents *rollupContents = getRollupContents();
 
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
     rollupContents->saveState(m_rollupState);
     applySettings();
 }
@@ -140,7 +124,6 @@ AntennaToolsGUI::AntennaToolsGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISe
     m_helpURL = "plugins/feature/antennatools/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/antennatools/antennatoolsgui.h
+++ b/plugins/feature/antennatools/antennatoolsgui.h
@@ -51,9 +51,6 @@ public:
     virtual void setGeometryBytes(const QByteArray& blob) { m_settings.m_geometryBytes = blob; }
     virtual QByteArray getGeometryBytes() const { return m_settings.m_geometryBytes; }
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::AntennaToolsGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/feature/antennatools/antennatoolsgui.ui
+++ b/plugins/feature/antennatools/antennatoolsgui.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>

--- a/plugins/feature/aprs/aprsgui.cpp
+++ b/plugins/feature/aprs/aprsgui.cpp
@@ -436,7 +436,6 @@ APRSGUI::APRSGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feat
     m_helpURL = "plugins/feature/aprs/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 
@@ -670,12 +669,13 @@ void APRSGUI::updateChannelList()
     ui->sourcePipes->blockSignals(false);
 }
 
-void APRSGUI::resizeEvent(QResizeEvent*)
+void APRSGUI::resizeEvent(QResizeEvent* event)
 {
     // Replot graphs to ensure Axis are visible
     plotWeather();
     plotTelemetry();
     plotMotion();
+    FeatureGUI::resizeEvent(event);
 }
 
 void APRSGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/feature/demodanalyzer/demodanalyzergui.cpp
+++ b/plugins/feature/demodanalyzer/demodanalyzergui.cpp
@@ -128,16 +128,6 @@ void DemodAnalyzerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 
     RollupContents *rollupContents = getRollupContents();
 
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
     rollupContents->saveState(m_rollupState);
     applySettings();
 }
@@ -157,7 +147,6 @@ DemodAnalyzerGUI::DemodAnalyzerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUI
     m_helpURL = "plugins/feature/demodanalyzer/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/gs232controller/gs232controllergui.cpp
+++ b/plugins/feature/gs232controller/gs232controllergui.cpp
@@ -19,7 +19,6 @@
 #include <cmath>
 #include <QMessageBox>
 #include <QSerialPortInfo>
-#include <QResizeEvent>
 
 #include "SWGTargetAzimuthElevation.h"
 
@@ -70,14 +69,6 @@ bool GS232ControllerGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void GS232ControllerGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool GS232ControllerGUI::handleMessage(const Message& message)
@@ -137,6 +128,7 @@ void GS232ControllerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
     (void) rollDown;
+
     getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
@@ -155,7 +147,6 @@ GS232ControllerGUI::GS232ControllerGUI(PluginAPI* pluginAPI, FeatureUISet *featu
     m_helpURL = "plugins/feature/gs232controller/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/gs232controller/gs232controllergui.h
+++ b/plugins/feature/gs232controller/gs232controllergui.h
@@ -50,9 +50,6 @@ public:
     virtual void setGeometryBytes(const QByteArray& blob) { m_settings.m_geometryBytes = blob; }
     virtual QByteArray getGeometryBytes() const { return m_settings.m_geometryBytes; }
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::GS232ControllerGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/feature/jogdialcontroller/jogdialcontrollergui.cpp
+++ b/plugins/feature/jogdialcontroller/jogdialcontrollergui.cpp
@@ -17,7 +17,6 @@
 
 #include <QMessageBox>
 #include <QMouseEvent>
-#include <QResizeEvent>
 
 #include "feature/featureuiset.h"
 #include "gui/basicfeaturesettingsdialog.h"
@@ -66,14 +65,6 @@ bool JogdialControllerGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void JogdialControllerGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool JogdialControllerGUI::handleMessage(const Message& message)
@@ -160,7 +151,6 @@ JogdialControllerGUI::JogdialControllerGUI(PluginAPI* pluginAPI, FeatureUISet *f
     m_helpURL = "plugins/feature/jogdialcontroller/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/jogdialcontroller/jogdialcontrollergui.h
+++ b/plugins/feature/jogdialcontroller/jogdialcontrollergui.h
@@ -55,7 +55,6 @@ public:
 protected:
     void focusInEvent(QFocusEvent* e);
     void focusOutEvent(QFocusEvent *e);
-    void resizeEvent(QResizeEvent* size);
 
 private:
 	Ui::JogdialControllerGUI* ui;

--- a/plugins/feature/limerfe/limerfegui.cpp
+++ b/plugins/feature/limerfe/limerfegui.cpp
@@ -74,14 +74,6 @@ void LimeRFEGUI::setWorkspaceIndex(int index)
     m_feature->setWorkspaceIndex(index);
 }
 
-void LimeRFEGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
-}
-
 void LimeRFEGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
@@ -141,7 +133,6 @@ LimeRFEGUI::LimeRFEGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature
     m_helpURL = "plugins/feature/limerfe/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/limerfe/limerfegui.h
+++ b/plugins/feature/limerfe/limerfegui.h
@@ -54,9 +54,6 @@ public:
     virtual void setGeometryBytes(const QByteArray& blob) { m_settings.m_geometryBytes = blob; }
     virtual QByteArray getGeometryBytes() const { return m_settings.m_geometryBytes; }
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
 	Ui::LimeRFEGUI* ui;
 	PluginAPI* m_pluginAPI;

--- a/plugins/feature/map/mapgui.cpp
+++ b/plugins/feature/map/mapgui.cpp
@@ -163,18 +163,7 @@ void MapGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) widget;
     (void) rollDown;
 
-    RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    resize(width(), h);
-
-    rollupContents->saveState(m_rollupState);
+    getRollupContents()->saveState(m_rollupState);
     applySettings();
 }
 
@@ -891,6 +880,8 @@ void MapGUI::applyMap3DSettings(bool reloadMap)
         m_webServer->addSubstitution("/map/map/map3d.html", "$CESIUM_ION_API_KEY$", cesiumIonAPIKey());
         //ui->web->page()->profile()->clearHttpCache();
         ui->web->load(QUrl(QString("http://127.0.0.1:%1/map/map/map3d.html").arg(m_webPort)));
+        //ui->web->load(QUrl(QString("http://webglreport.com/")));
+        //ui->web->load(QUrl(QString("https://sandcastle.cesium.com/")));
         //ui->web->load(QUrl("chrome://gpu/"));
         ui->web->show();
     }

--- a/plugins/feature/pertester/pertestergui.cpp
+++ b/plugins/feature/pertester/pertestergui.cpp
@@ -19,7 +19,6 @@
 #include <cmath>
 #include <QMessageBox>
 #include <QLineEdit>
-#include <QResizeEvent>
 
 #include "feature/featureuiset.h"
 #include "gui/basicfeaturesettingsdialog.h"
@@ -68,14 +67,6 @@ bool PERTesterGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void PERTesterGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool PERTesterGUI::handleMessage(const Message& message)
@@ -141,7 +132,6 @@ PERTesterGUI::PERTesterGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Fea
     m_helpURL = "plugins/feature/pertester/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/pertester/pertestergui.h
+++ b/plugins/feature/pertester/pertestergui.h
@@ -50,9 +50,6 @@ public:
     virtual void setGeometryBytes(const QByteArray& blob) { m_settings.m_geometryBytes = blob; }
     virtual QByteArray getGeometryBytes() const { return m_settings.m_geometryBytes; }
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
     Ui::PERTesterGUI* ui;
     PluginAPI* m_pluginAPI;

--- a/plugins/feature/radiosonde/radiosondegui.cpp
+++ b/plugins/feature/radiosonde/radiosondegui.cpp
@@ -119,17 +119,6 @@ void RadiosondeGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) rollDown;
 
     RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
     rollupContents->saveState(m_rollupState);
     applySettings();
 }
@@ -147,7 +136,6 @@ RadiosondeGUI::RadiosondeGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, F
     m_helpURL = "plugins/feature/radiosonde/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/remotecontrol/remotecontrolgui.cpp
+++ b/plugins/feature/remotecontrol/remotecontrolgui.cpp
@@ -135,7 +135,6 @@ RemoteControlGUI::RemoteControlGUI(PluginAPI* pluginAPI, FeatureUISet *featureUI
     m_helpURL = "plugins/feature/remotecontrol/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/rigctlserver/rigctlservergui.cpp
+++ b/plugins/feature/rigctlserver/rigctlservergui.cpp
@@ -17,7 +17,6 @@
 ///////////////////////////////////////////////////////////////////////////////////
 
 #include <QMessageBox>
-#include <QResizeEvent>
 
 #include "feature/featureuiset.h"
 #include "gui/basicfeaturesettingsdialog.h"
@@ -66,14 +65,6 @@ bool RigCtlServerGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void RigCtlServerGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool RigCtlServerGUI::handleMessage(const Message& message)
@@ -139,7 +130,6 @@ RigCtlServerGUI::RigCtlServerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISe
     m_helpURL = "plugins/feature/rigctlserver/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/rigctlserver/rigctlservergui.h
+++ b/plugins/feature/rigctlserver/rigctlservergui.h
@@ -50,9 +50,6 @@ public:
     virtual void setGeometryBytes(const QByteArray& blob) { m_settings.m_geometryBytes = blob; }
     virtual QByteArray getGeometryBytes() const { return m_settings.m_geometryBytes; }
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
 	Ui::RigCtlServerGUI* ui;
 	PluginAPI* m_pluginAPI;

--- a/plugins/feature/satellitetracker/satellitetrackergui.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackergui.cpp
@@ -231,17 +231,6 @@ void SatelliteTrackerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) rollDown;
 
     RollupContents *rollupContents = getRollupContents();
-
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
     rollupContents->saveState(m_rollupState);
     applySettings();
 }
@@ -265,7 +254,6 @@ SatelliteTrackerGUI::SatelliteTrackerGUI(PluginAPI* pluginAPI, FeatureUISet *fea
     m_helpURL = "plugins/feature/satellitetracker/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/simpleptt/simplepttgui.cpp
+++ b/plugins/feature/simpleptt/simplepttgui.cpp
@@ -16,7 +16,6 @@
 ///////////////////////////////////////////////////////////////////////////////////
 
 #include <QMessageBox>
-#include <QResizeEvent>
 
 #include "feature/featureuiset.h"
 #include "gui/basicfeaturesettingsdialog.h"
@@ -69,14 +68,6 @@ bool SimplePTTGUI::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
-}
-
-void SimplePTTGUI::resizeEvent(QResizeEvent* size)
-{
-    int maxWidth = getRollupContents()->maximumWidth();
-    int minHeight = getRollupContents()->minimumHeight() + getAdditionalHeight();
-    resize(width() < maxWidth ? width() : maxWidth, minHeight);
-    size->accept();
 }
 
 bool SimplePTTGUI::handleMessage(const Message& message)
@@ -165,7 +156,6 @@ SimplePTTGUI::SimplePTTGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Fea
     m_helpURL = "plugins/feature/simpleptt/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/simpleptt/simplepttgui.h
+++ b/plugins/feature/simpleptt/simplepttgui.h
@@ -49,9 +49,6 @@ public:
     virtual void setGeometryBytes(const QByteArray& blob) { m_settings.m_geometryBytes = blob; }
     virtual QByteArray getGeometryBytes() const { return m_settings.m_geometryBytes; }
 
-protected:
-    void resizeEvent(QResizeEvent* size);
-
 private:
 	Ui::SimplePTTGUI* ui;
 	PluginAPI* m_pluginAPI;

--- a/plugins/feature/startracker/startrackergui.cpp
+++ b/plugins/feature/startracker/startrackergui.cpp
@@ -227,16 +227,6 @@ void StarTrackerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 
     RollupContents *rollupContents = getRollupContents();
 
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
     rollupContents->saveState(m_rollupState);
     applySettings();
 }
@@ -272,7 +262,6 @@ StarTrackerGUI::StarTrackerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet,
     m_helpURL = "plugins/feature/startracker/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/plugins/feature/vorlocalizer/vorlocalizergui.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizergui.cpp
@@ -800,16 +800,6 @@ void VORLocalizerGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 
     RollupContents *rollupContents = getRollupContents();
 
-    if (rollupContents->hasExpandableWidgets()) {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
-    } else {
-        setSizePolicy(sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
-    }
-
-    int h = rollupContents->height() + getAdditionalHeight();
-    int w = std::max(width(), rollupContents->minimumWidth() + gripSize() * 2);
-    resize(w, h);
-
     rollupContents->saveState(m_rollupState);
     applySettings();
 }
@@ -945,7 +935,6 @@ VORLocalizerGUI::VORLocalizerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISe
     m_helpURL = "plugins/feature/vorlocalizer/readme.md";
     RollupContents *rollupContents = getRollupContents();
 	ui->setupUi(rollupContents);
-    setSizePolicy(rollupContents->sizePolicy());
     rollupContents->arrangeRollups();
 	connect(rollupContents, SIGNAL(widgetRolled(QWidget*,bool)), this, SLOT(onWidgetRolled(QWidget*,bool)));
 

--- a/sdrgui/channel/channelgui.h
+++ b/sdrgui/channel/channelgui.h
@@ -74,6 +74,7 @@ public:
 	virtual MessageQueue* getInputMessageQueue() = 0;
 
     RollupContents *getRollupContents() { return m_rollupContents; }
+    void sizeToContents();
     void setTitle(const QString& title);
     void setTitleColor(const QColor& c);
     void setDeviceType(DeviceType type);
@@ -109,6 +110,7 @@ protected:
 
 protected slots:
     void shrinkWindow();
+    void maximizeWindow();
 
 private:
     bool isOnMovingPad();
@@ -121,6 +123,7 @@ private:
     QPushButton *m_helpButton;
     QPushButton *m_moveButton;
     QPushButton *m_shrinkButton;
+    QPushButton *m_maximizeButton;
     QPushButton *m_hideButton;
     QPushButton *m_closeButton;
     QPushButton *m_duplicateButton;
@@ -136,6 +139,7 @@ private:
     QPoint m_DragPosition;
     QMap<QWidget*, int> m_heightsMap;
     FramelessWindowResizer m_resizer;
+    bool m_disableResize;
 
 private slots:
     void activateSettingsDialog();

--- a/sdrgui/device/devicegui.cpp
+++ b/sdrgui/device/devicegui.cpp
@@ -264,6 +264,9 @@ void DeviceGUI::sizeToContents()
     size.setHeight(std::min(size.height() + getAdditionalHeight(), QWIDGETSIZE_MAX));
     size.setWidth(std::min(size.width() + m_resizer.m_gripSize * 2, QWIDGETSIZE_MAX));
     setMinimumSize(size);
+
+    // Adjust to minimum size needed for widgets
+    adjustSize();
 }
 
 void DeviceGUI::setWorkspaceIndex(int index)

--- a/sdrgui/feature/featuregui.cpp
+++ b/sdrgui/feature/featuregui.cpp
@@ -25,6 +25,7 @@
 #include <QTextEdit>
 #include <QObjectCleanupHandler>
 #include <QDesktopServices>
+#include <QOpenGLWidget>
 
 #include "mainwindow.h"
 #include "gui/workspaceselectiondialog.h"
@@ -35,7 +36,8 @@ FeatureGUI::FeatureGUI(QWidget *parent) :
     m_featureIndex(0),
     m_contextMenuType(ContextMenuNone),
     m_drag(false),
-    m_resizer(this)
+    m_resizer(this),
+    m_disableResize(false)
 {
     qDebug("FeatureGUI::FeatureGUI");
     setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
@@ -81,6 +83,12 @@ FeatureGUI::FeatureGUI(QWidget *parent) :
     m_shrinkButton->setIcon(shrinkIcon);
     m_shrinkButton->setToolTip("Adjust window to minimum size");
 
+    m_maximizeButton = new QPushButton();
+    m_maximizeButton->setFixedSize(20, 20);
+    QIcon maximizeIcon(":/maximize.png");
+    m_maximizeButton->setIcon(maximizeIcon);
+    m_maximizeButton->setToolTip("Adjust window to maximum size");
+
     m_closeButton = new QPushButton();
     m_closeButton->setFixedSize(20, 20);
     QIcon closeIcon(":/cross.png");
@@ -107,6 +115,7 @@ FeatureGUI::FeatureGUI(QWidget *parent) :
     m_topLayout->addWidget(m_helpButton);
     m_topLayout->addWidget(m_moveButton);
     m_topLayout->addWidget(m_shrinkButton);
+    m_topLayout->addWidget(m_maximizeButton);
     m_topLayout->addWidget(m_closeButton);
 
     m_centerLayout = new QHBoxLayout();
@@ -132,6 +141,7 @@ FeatureGUI::FeatureGUI(QWidget *parent) :
     connect(m_helpButton, SIGNAL(clicked()), this, SLOT(showHelp()));
     connect(m_moveButton, SIGNAL(clicked()), this, SLOT(openMoveToWorkspaceDialog()));
     connect(m_shrinkButton, SIGNAL(clicked()), this, SLOT(shrinkWindow()));
+    connect(m_maximizeButton, SIGNAL(clicked()), this, SLOT(maximizeWindow()));
     connect(this, SIGNAL(forceShrink()), this, SLOT(shrinkWindow()));
     connect(m_closeButton, SIGNAL(clicked()), this, SLOT(close()));
 
@@ -156,6 +166,7 @@ FeatureGUI::~FeatureGUI()
     delete m_statusLabel;
     delete m_closeButton;
     delete m_shrinkButton;
+    delete m_maximizeButton;
     delete m_moveButton;
     delete m_helpButton;
     delete m_titleLabel;
@@ -246,25 +257,109 @@ void FeatureGUI::openMoveToWorkspaceDialog()
 
 void FeatureGUI::onWidgetRolled(QWidget *widget, bool show)
 {
-    if (show)
+    sizeToContents();  // set min/max constraints before trying to resize
+
+    // When a window is maximized or returns from maximized to normal,
+    // RolledContents gets QEvent::Hide and QEvent::Show events, which results in
+    // onWidgetRolled being called twice.
+    // We need to make sure we don't save widget heights while this occurs. The
+    // window manager will take care of maximizing/restoring the window size.
+    if (!m_disableResize)
     {
-        // qDebug("FeatureGUI::onWidgetRolled: show: %d %d", m_rollupContents.height(), widget->height());
-        int dh = m_heightsMap.contains(widget) ? m_heightsMap[widget] - widget->height() : widget->minimumHeight();
-        resize(width(), 52 +  m_rollupContents.height() + dh);
+        if (show)
+        {
+            // qDebug("FeatureGUI::onWidgetRolled: show: %d %d", m_rollupContents.height(), widget->height());
+            int dh = m_heightsMap.contains(widget) ? m_heightsMap[widget] - widget->height() : widget->minimumHeight();
+            resize(width(), 52 +  m_rollupContents.height() + dh);
+        }
+        else
+        {
+            // qDebug("FeatureGUI::onWidgetRolled: hide: %d %d", m_rollupContents.height(), widget->height());
+            m_heightsMap[widget] = widget->height();
+            resize(width(), 52 +  m_rollupContents.height());
+        }
+    }
+}
+
+// Size the window according to the size of rollup widget
+void FeatureGUI::sizeToContents()
+{
+    // Adjust policy depending on which widgets are currently visible
+    if (getRollupContents()->hasExpandableWidgets()) {
+        setSizePolicy(getRollupContents()->sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
+    } else {
+        setSizePolicy(getRollupContents()->sizePolicy().horizontalPolicy(), QSizePolicy::Fixed);
+    }
+
+    // If size policy is fixed, hide widgets that resize the window
+    if ((sizePolicy().verticalPolicy() == QSizePolicy::Fixed) && (sizePolicy().horizontalPolicy() == QSizePolicy::Fixed))
+    {
+        m_shrinkButton->hide();
+        m_maximizeButton->hide();
+        m_sizeGripBottomRight->hide();
+    }
+    else if ((sizePolicy().verticalPolicy() == QSizePolicy::Fixed) || (sizePolicy().horizontalPolicy() == QSizePolicy::Fixed))
+    {
+        m_shrinkButton->show();
+        m_maximizeButton->hide();
+        m_sizeGripBottomRight->show();
     }
     else
     {
-        // qDebug("FeatureGUI::onWidgetRolled: hide: %d %d", m_rollupContents.height(), widget->height());
-        m_heightsMap[widget] = widget->height();
-        resize(width(), 52 +  m_rollupContents.height());
+        m_shrinkButton->show();
+        m_maximizeButton->show();
+        m_sizeGripBottomRight->show();
+    }
+
+    // Calculate min/max size for window. This is min/max size of contents, plus
+    // extra needed for window frame and title bar
+    QSize size;
+    size = getRollupContents()->maximumSize();
+    size.setHeight(std::min(size.height() + getAdditionalHeight(), QWIDGETSIZE_MAX));
+    size.setWidth(std::min(size.width() + m_resizer.m_gripSize * 2, QWIDGETSIZE_MAX));
+    setMaximumSize(size);
+
+    // m_resizer uses minimumSizeHint(), m_sizeGripBottomRight uses minimumSize()
+    // QWidget docs says: If minimumSize() is set, the minimum size hint will be ignored.
+    // However, we use maximum of both:
+    //  - minimumSize.width() to respect minimumWidth set in .ui file
+    //  - minimumSizeHint.width() to ensure widgets are fully displayed when larger than above
+    //    which may be the case when we have widgets hidden in a rollup, as the width
+    //    set in .ui file may just be for the smallest of widgets
+    size = getRollupContents()->minimumSize();
+    size = size.expandedTo(getRollupContents()->minimumSizeHint());
+    size = size.expandedTo(m_topLayout->minimumSize());
+    size.setHeight(size.height() + getAdditionalHeight());
+    size.setWidth(size.width() + m_resizer.m_gripSize * 2);
+    setMinimumSize(size);
+}
+
+void FeatureGUI::maximizeWindow()
+{
+    m_disableResize = true;
+    showMaximized();
+    m_disableResize = false;
+    // QOpenGLWidget widgets don't always paint properly first time after being maximized,
+    // so force an update. Should really fix why they aren't painted properly in the first place
+    QList<QOpenGLWidget *> widgets = findChildren<QOpenGLWidget *>();
+    for (auto widget : widgets) {
+        widget->update();
     }
 }
 
 void FeatureGUI::shrinkWindow()
 {
     qDebug("FeatureGUI::shrinkWindow");
-    adjustSize();
-    resize(width(), m_rollupContents.height() + getAdditionalHeight());
+    if (isMaximized())
+    {
+        m_disableResize = true;
+        showNormal();
+        m_disableResize = false;
+    }
+    else
+    {
+        adjustSize();
+    }
 }
 
 void FeatureGUI::setTitle(const QString& title)

--- a/sdrgui/feature/featuregui.h
+++ b/sdrgui/feature/featuregui.h
@@ -60,6 +60,7 @@ public:
 	virtual MessageQueue* getInputMessageQueue() = 0;
 
     RollupContents *getRollupContents() { return &m_rollupContents; }
+    void sizeToContents();
     void setTitleColor(const QColor&) {} // not implemented for a feature
     void setTitle(const QString& title);
     void setIndex(int index);
@@ -85,6 +86,7 @@ protected:
 
 protected slots:
     void shrinkWindow();
+    void maximizeWindow();
 
 private:
     bool isOnMovingPad();
@@ -95,6 +97,7 @@ private:
     QPushButton *m_helpButton;
     QPushButton *m_moveButton;
     QPushButton *m_shrinkButton;
+    QPushButton *m_maximizeButton;
     QPushButton *m_closeButton;
     QLabel *m_statusLabel;
     QVBoxLayout *m_layouts;
@@ -106,6 +109,7 @@ private:
     QPoint m_DragPosition;
     QMap<QWidget*, int> m_heightsMap;
     FramelessWindowResizer m_resizer;
+    bool m_disableResize;
 
 private slots:
     void activateSettingsDialog();

--- a/sdrgui/gui/rollupcontents.cpp
+++ b/sdrgui/gui/rollupcontents.cpp
@@ -99,7 +99,7 @@ int RollupContents::arrangeRollups()
 {
     QFontMetrics fm(font());
     int pos;
-    int minWidth = 0;
+    int minWidthHint = 0;
 
     // First calculate minimum height needed, to determine how much extra space
     // we have that can be split between expanding widgets
@@ -123,14 +123,21 @@ int RollupContents::arrangeRollups()
                 } else {
                     h = r->minimumSizeHint().height();
                 }
-                minWidth = std::max(minWidth, r->minimumSize().width());
+                minWidthHint = std::max(minWidthHint, r->minimumSizeHint().width());
                 pos += h + 5;
             }
         }
     }
 
+    // We use minimumSizeHint for auto-calculated width, so
+    // minimumWidth can be set by user in .ui file
+    m_minimumSizeHint.setHeight(pos);
+    m_minimumSizeHint.setWidth(minWidthHint);
+
+    // However, we need to set minimumHeight, as the value in the .ui
+    // files is typically set as the minimum height for when widget is unrolled
+    // but when rolled-up, we want it to be smaller
     setMinimumHeight(pos);
-    setMinimumWidth(minWidth);
 
     // Split extra space equally between widgets
     // If there's a remainder, we give it to the first widget

--- a/sdrgui/gui/rollupcontents.h
+++ b/sdrgui/gui/rollupcontents.h
@@ -34,6 +34,7 @@ public:
     void restoreState(const RollupState& state);
     int arrangeRollups();
     bool hasExpandableWidgets();
+    virtual QSize minimumSizeHint() const override { return m_minimumSizeHint; }
 
 signals:
     void widgetRolled(QWidget* widget, bool rollDown);
@@ -59,6 +60,7 @@ private:
     static bool isRollupChild(QWidget *childWidget); //!< chidl is part of rollups (ex: not a dialog)
     // bool m_channelWidget;
     int m_newHeight;
+    QSize m_minimumSizeHint;
 };
 
 #endif // INCLUDE_ROLLUPCONTENTS_H

--- a/sdrgui/gui/workspace.cpp
+++ b/sdrgui/gui/workspace.cpp
@@ -348,11 +348,13 @@ void Workspace::featurePresetsDialog()
 
 void Workspace::cascadeSubWindows()
 {
+    m_autoStackSubWindows->setChecked(false);
     m_mdi->cascadeSubWindows();
 }
 
 void Workspace::tileSubWindows()
 {
+    m_autoStackSubWindows->setChecked(false);
     m_mdi->tileSubWindows();
 }
 
@@ -416,7 +418,7 @@ void Workspace::stackSubWindows()
 
     for (auto window : windows)
     {
-        if (window->isVisible())
+        if (window->isVisible() && !window->isMaximized())
         {
             if (window->inherits("DeviceGUI")) {
                 devices.append(qobject_cast<DeviceGUI *>(window));
@@ -470,12 +472,27 @@ void Workspace::stackSubWindows()
     {
         int winMinWidth = std::max(window->minimumSizeHint().width(), window->minimumWidth());
         spectrumMinWidth = std::max(spectrumMinWidth, winMinWidth);
-        spectrumTotalMinHeight += window->minimumSizeHint().height() + spacing;
+        int winMinHeight = std::max(window->minimumSizeHint().height(), window->minimumSize().height());
+        spectrumTotalMinHeight += winMinHeight + spacing;
         expandingSpectrums++;
     }
 
+    // Restrict user defined channel width, to width of largest channel
+    if (channels.size() == 0)
+    {
+        m_userChannelMinWidth = 0;
+    }
+    else
+    {
+        int channelMaxWidth = 0;
+        for (auto window : channels) {
+            channelMaxWidth = std::max(channelMaxWidth, window->maximumWidth());
+        }
+        m_userChannelMinWidth = std::min(m_userChannelMinWidth, channelMaxWidth);
+    }
+
     // Calculate width & height needed for channels
-    int channelMinWidth = channels.size() > 0 ? m_userChannelMinWidth : 0;
+    int channelMinWidth = m_userChannelMinWidth; // channels.size() > 0 ? m_userChannelMinWidth : 0;
     int channelTotalMinHeight = 0;
     int expandingChannels = 0;
     for (auto window : channels)
@@ -521,7 +538,8 @@ void Workspace::stackSubWindows()
     // Will we need scroll bars?
     QSize mdiSize = m_mdi->size();
     int minWidth = devicesFeaturesWidth + spacing1 + spectrumFeaturesMinWidth + spacing2 + channelMinWidth;
-    int minHeight = std::max(std::max(deviceTotalMinHeight + fixedFeaturesTotalMinHeight, channelTotalMinHeight), channelTotalMinHeight + featuresTotalMinHeight);
+    int minHeight = std::max(std::max(deviceTotalMinHeight + fixedFeaturesTotalMinHeight, channelTotalMinHeight), spectrumTotalMinHeight + featuresTotalMinHeight);
+
     bool requiresHScrollBar = minWidth > mdiSize.width();
     bool requiresVScrollBar = minHeight > mdiSize.height();
 
@@ -532,6 +550,11 @@ void Workspace::stackSubWindows()
     }
     if (requiresHScrollBar) {
         mdiSize.setHeight(mdiSize.height() - sbWidth);
+    }
+
+    // If no spectrum/features, expand channels
+    if ((spectrumFeaturesMinWidth == 0) && expandingChannels > 0) {
+        channelMinWidth = mdiSize.width() - devicesFeaturesWidth - spacing1;
     }
 
     // Now position the windows
@@ -609,7 +632,8 @@ void Workspace::stackSubWindows()
     {
         window->move(x, y);
         int w = spectrumFeaturesWidth;
-        int h = window->minimumSizeHint().height() + extraSpacePerWindow + extraSpaceFirstWindow;
+        int minHeight = std::max(window->minimumSizeHint().height(), window->minimumSize().height());
+        int h = minHeight + extraSpacePerWindow + extraSpaceFirstWindow;
         window->resize(w, h);
         extraSpaceFirstWindow = 0;
         y += window->size().height() + spacing;
@@ -734,24 +758,36 @@ bool Workspace::eventFilter(QObject *obj, QEvent *event)
 {
     if (event->type() == QEvent::Show)
     {
-        autoStackSubWindows();
+        QWidget *widget = qobject_cast<QWidget *>(obj);
+        if (!widget->isMaximized()) {
+            autoStackSubWindows();
+        }
     }
     else if (event->type() == QEvent::Hide)
     {
-        autoStackSubWindows();
+        QWidget *widget = qobject_cast<QWidget *>(obj);
+        if (!widget->isMaximized()) {
+            autoStackSubWindows();
+        }
     }
     else if (event->type() == QEvent::Resize)
     {
         if (!m_stacking && m_autoStackSubWindows->isChecked())
         {
+            QWidget *widget = qobject_cast<QWidget *>(obj);
+            QResizeEvent *resizeEvent = static_cast<QResizeEvent *>(event);
             ChannelGUI *channel = qobject_cast<ChannelGUI *>(obj);
-            if (channel)
+            if (channel && !widget->isMaximized())
             {
-                // Allow width of channels column to be set by user when they
-                // resize a channel window
-                QResizeEvent *resizeEvent = static_cast<QResizeEvent *>(event);
-                m_userChannelMinWidth = resizeEvent->size().width();
-                stackSubWindows();
+                // When maximizing, we can get resize event where isMaximized is false, even though it should be true,
+                // but we can tell as window size matches mdi size
+                if (m_mdi->size() != resizeEvent->size())
+                {
+                    // Allow width of channels column to be set by user when they
+                    // resize a channel window
+                    m_userChannelMinWidth = resizeEvent->size().width();
+                    stackSubWindows();
+                }
             }
         }
     }

--- a/sdrgui/mainspectrum/mainspectrumgui.cpp
+++ b/sdrgui/mainspectrum/mainspectrumgui.cpp
@@ -84,6 +84,12 @@ MainSpectrumGUI::MainSpectrumGUI(GLSpectrum *spectrum, GLSpectrumGUI *spectrumGU
     m_shrinkButton->setIcon(shrinkIcon);
     m_shrinkButton->setToolTip("Adjust window to minimum size");
 
+    m_maximizeButton = new QPushButton();
+    m_maximizeButton->setFixedSize(20, 20);
+    QIcon maximizeIcon(":/maximize.png");
+    m_maximizeButton->setIcon(maximizeIcon);
+    m_maximizeButton->setToolTip("Adjust window to maximum size");
+
     m_hideButton = new QPushButton();
     m_hideButton->setFixedSize(20, 20);
     QIcon hideIcon(":/hide.png");
@@ -110,6 +116,7 @@ MainSpectrumGUI::MainSpectrumGUI(GLSpectrum *spectrum, GLSpectrumGUI *spectrumGU
     m_topLayout->addWidget(m_helpButton);
     m_topLayout->addWidget(m_moveButton);
     m_topLayout->addWidget(m_shrinkButton);
+    m_topLayout->addWidget(m_maximizeButton);
     m_topLayout->addWidget(m_hideButton);
 
     m_spectrumLayout = new QHBoxLayout();
@@ -138,6 +145,7 @@ MainSpectrumGUI::MainSpectrumGUI(GLSpectrum *spectrum, GLSpectrumGUI *spectrumGU
     connect(m_helpButton, SIGNAL(clicked()), this, SLOT(showHelp()));
     connect(m_moveButton, SIGNAL(clicked()), this, SLOT(openMoveToWorkspaceDialog()));
     connect(m_shrinkButton, SIGNAL(clicked()), this, SLOT(shrinkWindow()));
+    connect(m_maximizeButton, SIGNAL(clicked()), this, SLOT(maximizeWindow()));
     connect(this, SIGNAL(forceShrink()), this, SLOT(shrinkWindow()));
     connect(m_hideButton, SIGNAL(clicked()), this, SLOT(hide()));
 
@@ -162,6 +170,7 @@ MainSpectrumGUI::~MainSpectrumGUI()
     delete m_statusLabel;
     delete m_hideButton;
     delete m_shrinkButton;
+    delete m_maximizeButton;
     delete m_moveButton;
     delete m_helpButton;
     delete m_titleLabel;
@@ -249,11 +258,23 @@ void MainSpectrumGUI::openMoveToWorkspaceDialog()
     }
 }
 
+void MainSpectrumGUI::maximizeWindow()
+{
+    showMaximized();
+}
+
 void MainSpectrumGUI::shrinkWindow()
 {
     qDebug("MainSpectrumGUI::shrinkWindow");
-    adjustSize();
-    resize(width(), m_MinimumHeight);
+    if (isMaximized())
+    {
+        showNormal();
+    }
+    else
+    {
+        adjustSize();
+        resize(width(), m_MinimumHeight);
+    }
 }
 
 void MainSpectrumGUI::setTitle(const QString& title)

--- a/sdrgui/mainspectrum/mainspectrumgui.h
+++ b/sdrgui/mainspectrum/mainspectrumgui.h
@@ -76,6 +76,7 @@ private:
     QPushButton *m_helpButton;
     QPushButton *m_moveButton;
     QPushButton *m_shrinkButton;
+    QPushButton *m_maximizeButton;
     QPushButton *m_hideButton;
     QLabel *m_statusLabel;
     QVBoxLayout *m_layouts;
@@ -106,6 +107,7 @@ private slots:
     void showHelp();
     void openMoveToWorkspaceDialog();
     void shrinkWindow();
+    void maximizeWindow();
     void onRequestCenterFrequency(qint64 frequency);
 
 signals:


### PR DESCRIPTION
Add maximize button to MainSpectrum and expandible Channels and Features.

Add sizeToContents in ChannelGUI and FeatureGUI, called when widget is rolled, so we can remove resizing code from all of the individual channels and features.

In RollupContents, use minimumSizeHint for calculated size, so that minimumWidth can come from .ui file.

In DeviceGUI::sizeToContents(), call adjustSize(), so Device GUIs start out at minimum needed size (which should restore appearance prior to last patch).

In stackSubWindows, use available space for channels if no spectrum/features present.
In stackSubWindows, fix spectrum from being sized too big, resulting in scroll bars appearing.    
Reset user-defined channel width in stackSubWindows, when channels are removed.
Don't stack maximized windows.

There's one hack in Channel/FeatureGUI::maximizeWindow(). It seems that when maximimzing a window, QOpenGLWidgets aren't always paint properly immediately afterwards, so the code forces an additional update. I can't see why the first call to paintGL doesn't work.

Let me know if you see anything odd.