### PR TITLE
Window arrangement

### DIFF
--- a/sdrbase/settings/configuration.cpp
+++ b/sdrbase/settings/configuration.cpp
@@ -65,6 +65,13 @@ QByteArray Configuration::serialize() const
         s.writeBool(301 + i, m_workspaceAutoStackOptions[i]);
     }
 
+    nitems = m_workspaceTabSubWindowsOptions.size() < 99 ? m_workspaceTabSubWindowsOptions.size() : 99;
+    s.writeS32(400, nitems);
+
+    for (int i = 0; i < nitems; i++) {
+        s.writeBool(401 + i, m_workspaceTabSubWindowsOptions[i]);
+    }
+
 	return s.final();
 }
 
@@ -113,6 +120,14 @@ bool Configuration::deserialize(const QByteArray& data)
             d.readBool(301 + i, &m_workspaceAutoStackOptions.back());
         }
 
+        d.readS32(400, &nitems, 0);
+
+        for (int i = 0; i < nitems; i++)
+        {
+            m_workspaceTabSubWindowsOptions.push_back(true);
+            d.readBool(401 + i, &m_workspaceTabSubWindowsOptions.back());
+        }
+
 		return true;
 	}
 	else
@@ -128,4 +143,5 @@ void Configuration::clearData()
     m_featureSetPreset.clearFeatures();
     m_workspaceGeometries.clear();
     m_workspaceAutoStackOptions.clear();
+    m_workspaceTabSubWindowsOptions.clear();
 }

--- a/sdrbase/settings/configuration.h
+++ b/sdrbase/settings/configuration.h
@@ -52,6 +52,8 @@ public:
     const QList<QByteArray>& getWorkspaceGeometries() const { return m_workspaceGeometries; }
     QList<bool>& getWorkspaceAutoStackOptions() { return m_workspaceAutoStackOptions; }
     const QList<bool>& getWorkspaceAutoStackOptions() const { return m_workspaceAutoStackOptions; }
+    QList<bool>& getWorkspaceTabSubWindowsOptions() { return m_workspaceTabSubWindowsOptions; }
+    const QList<bool>& getWorkspaceTabSubWindowsOptions() const { return m_workspaceTabSubWindowsOptions; }
     FeatureSetPreset& getFeatureSetPreset() { return m_featureSetPreset; }
     const FeatureSetPreset& getFeatureSetPreset() const { return m_featureSetPreset; }
     QList<Preset>& getDeviceSetPresets() { return m_deviceSetPresets; }
@@ -76,6 +78,7 @@ private:
 	QString m_description;
     QList<QByteArray> m_workspaceGeometries;
     QList<bool> m_workspaceAutoStackOptions;
+    QList<bool> m_workspaceTabSubWindowsOptions;
     FeatureSetPreset m_featureSetPreset;
     QList<Preset> m_deviceSetPresets;
 };

--- a/sdrgui/channel/channelgui.h
+++ b/sdrgui/channel/channelgui.h
@@ -141,6 +141,7 @@ private:
     QMap<QWidget*, int> m_heightsMap;
     FramelessWindowResizer m_resizer;
     bool m_disableResize;
+    QMdiArea *m_mdi;                    // Saved pointer to MDI when in full screen mode
 
 private slots:
     void activateSettingsDialog();

--- a/sdrgui/device/devicegui.cpp
+++ b/sdrgui/device/devicegui.cpp
@@ -162,7 +162,7 @@ DeviceGUI::DeviceGUI(QWidget *parent) :
     m_topLayout->addWidget(m_maximizeButton);
     m_topLayout->addWidget(m_closeButton);
 
-    m_centerLayout = new QHBoxLayout();
+    m_centerLayout = new QVBoxLayout();
     m_centerLayout->setContentsMargins(0, 0, 0, 0);
     m_contents = new QWidget(); // Do not delete! Done in child's destructor with "delete ui"
     m_centerLayout->addWidget(m_contents);
@@ -412,6 +412,7 @@ void DeviceGUI::deviceSetPresetsDialog()
 
 void DeviceGUI::setTitle(const QString& title)
 {
+    setWindowTitle(title + " Device");
     m_titleLabel->setText(title);
 }
 

--- a/sdrgui/device/devicegui.h
+++ b/sdrgui/device/devicegui.h
@@ -24,6 +24,7 @@
 #include <QString>
 #include <QByteArray>
 #include <QWidget>
+#include <QLabel>
 
 #include "gui/channeladddialog.h"
 #include "gui/framelesswindowresizer.h"
@@ -32,7 +33,6 @@
 class QCloseEvent;
 class Message;
 class MessageQueue;
-class QLabel;
 class QPushButton;
 class QVBoxLayout;
 class QHBoxLayout;
@@ -87,6 +87,7 @@ protected:
     void mouseMoveEvent(QMouseEvent* event) override;
     void resetContextMenuType() { m_contextMenuType = ContextMenuNone; }
     int getAdditionalHeight() const { return 22 + 22; }
+    void setStatus(const QString &status) { m_statusLabel->setText(status); }
 
     DeviceUISet* m_deviceUISet;
     DeviceType m_deviceType;
@@ -122,7 +123,7 @@ private:
     QLabel *m_statusLabel;
     QVBoxLayout *m_layouts;
     QHBoxLayout *m_topLayout;
-    QHBoxLayout *m_centerLayout;
+    QVBoxLayout *m_centerLayout;
     QHBoxLayout *m_bottomLayout;
     QSizeGrip *m_sizeGripBottomRight;
     bool m_drag;

--- a/sdrgui/feature/featuregui.h
+++ b/sdrgui/feature/featuregui.h
@@ -110,6 +110,7 @@ private:
     QMap<QWidget*, int> m_heightsMap;
     FramelessWindowResizer m_resizer;
     bool m_disableResize;
+    QMdiArea *m_mdi;                    // Saved pointer to MDI when in full screen mode
 
 private slots:
     void activateSettingsDialog();

--- a/sdrgui/gui/workspace.h
+++ b/sdrgui/gui/workspace.h
@@ -28,6 +28,7 @@
 
 class QHBoxLayout;
 class QLabel;
+class QToolButton;
 class QPushButton;
 class QMdiArea;
 class QMdiSubWindow;
@@ -37,7 +38,6 @@ class ChannelGUI;
 class FeatureGUI;
 class DeviceGUI;
 class MainSpectrumGUI;
-
 class SDRGUI_API Workspace : public QDockWidget
 {
     Q_OBJECT
@@ -56,6 +56,8 @@ public:
     void restoreMdiGeometry(const QByteArray& blob);
     bool getAutoStackOption() const;
     void setAutoStackOption(bool autoStack);
+    bool getTabSubWindowsOption() const;
+    void setTabSubWindowsOption(bool tab);
     QList<QMdiSubWindow *> getSubWindowList() const;
     void orderByIndex(QList<ChannelGUI *> &list);
     void orderByIndex(QList<FeatureGUI *> &list);
@@ -63,21 +65,26 @@ public:
     void orderByIndex(QList<MainSpectrumGUI *> &list);
     void adjustSubWindowsAfterRestore();
     void updateStartStopButton(bool checked);
+    QToolButton *getMenuButton() const { return m_menuButton; }
 
 private:
     int m_index;
+    QToolButton *m_menuButton;
+    QPushButton *m_configurationPresetsButton;
+    ButtonSwitch *m_startStopButton;
+    QFrame *m_vline1;
     QPushButton *m_addRxDeviceButton;
     QPushButton *m_addTxDeviceButton;
     QPushButton *m_addMIMODeviceButton;
-    ButtonSwitch *m_startStopButton;
-    QFrame *m_vline1;
+    QFrame *m_vline2;
     QPushButton *m_addFeatureButton;
     QPushButton *m_featurePresetsButton;
-    QFrame *m_vline2;
+    QFrame *m_vline3;
     QPushButton *m_cascadeSubWindows;
     QPushButton *m_tileSubWindows;
+    QPushButton *m_stackVerticalSubWindows;
     QPushButton *m_stackSubWindows;
-    ButtonSwitch *m_autoStackSubWindows;
+    ButtonSwitch *m_tabSubWindows;
     QWidget *m_titleBar;
     QHBoxLayout *m_titleBarLayout;
     QLabel *m_titleLabel;
@@ -86,7 +93,10 @@ private:
     FeatureAddDialog m_featureAddDialog;
     QMdiArea *m_mdi;
     bool m_stacking;                // Set when stackSubWindows() is running
+    bool m_autoStack;               // Automatically stack
     int m_userChannelMinWidth;      // Minimum width of channels column for stackSubWindows(), set by user resizing a channel window
+
+    void unmaximizeSubWindows();
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -98,14 +108,19 @@ private slots:
     void addMIMODeviceClicked();
     void addFeatureDialog();
     void featurePresetsDialog();
+    void configurationPresetsDialog();
     void cascadeSubWindows();
     void tileSubWindows();
+    void stackVerticalSubWindows();
     void stackSubWindows();
     void autoStackSubWindows();
+    void tabSubWindows();
+    void layoutSubWindows();
     void startStopClicked(bool checked = false);
     void addFeatureEmitted(int featureIndex);
     void toggleFloating();
     void deviceStateChanged(int index, DeviceAPI *deviceAPI);
+    void subWindowActivated(QMdiSubWindow *window);
 
 signals:
     void addRxDevice(Workspace *inWorkspace, int deviceIndex);
@@ -113,6 +128,7 @@ signals:
     void addMIMODevice(Workspace *inWorkspace, int deviceIndex);
     void addFeature(Workspace*, int);
     void featurePresetsDialogRequested(QPoint, Workspace*);
+    void configurationPresetsDialogRequested();
     void startAllDevices(Workspace *inWorkspace);
     void stopAllDevices(Workspace *inWorkspace);
 };

--- a/sdrgui/mainspectrum/mainspectrumgui.h
+++ b/sdrgui/mainspectrum/mainspectrumgui.h
@@ -88,6 +88,7 @@ private:
     bool m_drag;
     QPoint m_DragPosition;
     FramelessWindowResizer m_resizer;
+    QMdiArea *m_mdi;                    // Saved pointer to MDI when in full screen mode
     static const int m_MinimumWidth = 380;
     static const int m_MinimumHeight = 200 + 20 + 10 + 6*22 + 5;
 


### PR DESCRIPTION
Add buttons to stack MDI windows vertically and put in tabs.
Use right click to auto-stack sub-windows, rather than having a dedicated button.
Allow maximize button to make window full screen, if already maximized.
Add title to device windows, for when displayed in tabs.
Add menu button to workspace toolbar, for Android only, to avoid having menu bar, which takes up a lot of space.
Add configuration presets button to workspace toolbar. (Will need a following patch to work)
Add icons for window arrangement - please feel free to make some better ones!
