### PR TITLE
Airspy and RTL SDR support on Android

### DIFF
--- a/plugins/samplesource/airspy/CMakeLists.txt
+++ b/plugins/samplesource/airspy/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(${TARGET_NAME}
 	${TARGET_LIB_GUI}
     swagger
     ${LIBAIRSPY_LIBRARIES}
+    ${LIBUSB_LIBRARIES}
 )
 
 install(TARGETS ${TARGET_NAME} DESTINATION ${INSTALL_FOLDER})

--- a/plugins/samplesource/airspyhf/airspyhfinput.cpp
+++ b/plugins/samplesource/airspyhf/airspyhfinput.cpp
@@ -36,6 +36,9 @@
 #include "airspyhfplugin.h"
 #include "airspyhfsettings.h"
 #include "airspyhfworker.h"
+#ifdef ANDROID
+#include "util/android.h"
+#endif
 
 MESSAGE_CLASS_DEFINITION(AirspyHFInput::MsgConfigureAirspyHF, Message)
 MESSAGE_CLASS_DEFINITION(AirspyHFInput::MsgStartStop, Message)
@@ -581,7 +584,13 @@ airspyhf_device_t *AirspyHFInput::open_airspyhf_from_serial(const QString& seria
     }
     else
     {
+#ifdef ANDROID
+        QString serialString = QString("AIRSPYHF SN:%1").arg(serial, 0, 16).toUpper();
+        int fd = Android::openUSBDevice(serialString);
+        rc = (airspyhf_error) airspyhf_open_fd(&devinfo, fd);
+#else
         rc = (airspyhf_error) airspyhf_open_sn(&devinfo, serial);
+#endif
 
         if (rc == AIRSPYHF_SUCCESS) {
             return devinfo;

--- a/plugins/samplesource/audioinput/audioinputplugin.cpp
+++ b/plugins/samplesource/audioinput/audioinputplugin.cpp
@@ -73,6 +73,7 @@ void AudioInputPlugin::enumOriginDevices(QStringList& listedHwIds, OriginDevices
         1, // nb Rx
         0  // nb Tx
     ));
+    listedHwIds.append(m_hardwareID);
 }
 
 PluginInterface::SamplingDevices AudioInputPlugin::enumSampleSources(const OriginDevices& originDevices)

--- a/plugins/samplesource/rtlsdr/CMakeLists.txt
+++ b/plugins/samplesource/rtlsdr/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(${TARGET_NAME}
 	${TARGET_LIB_GUI}
         swagger
         ${LIBRTLSDR_LIBRARIES}
+        ${LIBUSB_LIBRARIES}
 )
 
 install(TARGETS ${TARGET_NAME} DESTINATION ${INSTALL_FOLDER})

--- a/plugins/samplesource/rtlsdr/rtlsdrplugin.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrplugin.cpp
@@ -11,6 +11,9 @@
 #endif
 #include "rtlsdrplugin.h"
 #include "rtlsdrwebapiadapter.h"
+#ifdef ANDROID
+#include "util/android.h"
+#endif
 
 const PluginDescriptor RTLSDRPlugin::m_pluginDescriptor = {
     QStringLiteral("RTLSDR"),
@@ -46,6 +49,83 @@ void RTLSDRPlugin::enumOriginDevices(QStringList& listedHwIds, OriginDevices& or
         return;
     }
 
+#ifdef ANDROID
+    typedef struct rtlsdr_dongle {
+        uint16_t vid;
+        uint16_t pid;
+        const char *name;
+    } rtlsdr_dongle_t;
+
+    // This list comes from librtlsdr.c
+    rtlsdr_dongle_t known_devices[] = {
+        { 0x0bda, 0x2832, "Generic RTL2832U" },
+        { 0x0bda, 0x2838, "Generic RTL2832U OEM" },
+        { 0x0413, 0x6680, "DigitalNow Quad DVB-T PCI-E card" },
+        { 0x0413, 0x6f0f, "Leadtek WinFast DTV Dongle mini D" },
+        { 0x0458, 0x707f, "Genius TVGo DVB-T03 USB dongle (Ver. B)" },
+        { 0x0ccd, 0x00a9, "Terratec Cinergy T Stick Black (rev 1)" },
+        { 0x0ccd, 0x00b3, "Terratec NOXON DAB/DAB+ USB dongle (rev 1)" },
+        { 0x0ccd, 0x00b4, "Terratec Deutschlandradio DAB Stick" },
+        { 0x0ccd, 0x00b5, "Terratec NOXON DAB Stick - Radio Energy" },
+        { 0x0ccd, 0x00b7, "Terratec Media Broadcast DAB Stick" },
+        { 0x0ccd, 0x00b8, "Terratec BR DAB Stick" },
+        { 0x0ccd, 0x00b9, "Terratec WDR DAB Stick" },
+        { 0x0ccd, 0x00c0, "Terratec MuellerVerlag DAB Stick" },
+        { 0x0ccd, 0x00c6, "Terratec Fraunhofer DAB Stick" },
+        { 0x0ccd, 0x00d3, "Terratec Cinergy T Stick RC (Rev.3)" },
+        { 0x0ccd, 0x00d7, "Terratec T Stick PLUS" },
+        { 0x0ccd, 0x00e0, "Terratec NOXON DAB/DAB+ USB dongle (rev 2)" },
+        { 0x1554, 0x5020, "PixelView PV-DT235U(RN)" },
+        { 0x15f4, 0x0131, "Astrometa DVB-T/DVB-T2" },
+        { 0x15f4, 0x0133, "HanfTek DAB+FM+DVB-T" },
+        { 0x185b, 0x0620, "Compro Videomate U620F"},
+        { 0x185b, 0x0650, "Compro Videomate U650F"},
+        { 0x185b, 0x0680, "Compro Videomate U680F"},
+        { 0x1b80, 0xd393, "GIGABYTE GT-U7300" },
+        { 0x1b80, 0xd394, "DIKOM USB-DVBT HD" },
+        { 0x1b80, 0xd395, "Peak 102569AGPK" },
+        { 0x1b80, 0xd397, "KWorld KW-UB450-T USB DVB-T Pico TV" },
+        { 0x1b80, 0xd398, "Zaapa ZT-MINDVBZP" },
+        { 0x1b80, 0xd39d, "SVEON STV20 DVB-T USB & FM" },
+        { 0x1b80, 0xd3a4, "Twintech UT-40" },
+        { 0x1b80, 0xd3a8, "ASUS U3100MINI_PLUS_V2" },
+        { 0x1b80, 0xd3af, "SVEON STV27 DVB-T USB & FM" },
+        { 0x1b80, 0xd3b0, "SVEON STV21 DVB-T USB & FM" },
+        { 0x1d19, 0x1101, "Dexatek DK DVB-T Dongle (Logilink VG0002A)" },
+        { 0x1d19, 0x1102, "Dexatek DK DVB-T Dongle (MSI DigiVox mini II V3.0)" },
+        { 0x1d19, 0x1103, "Dexatek Technology Ltd. DK 5217 DVB-T Dongle" },
+        { 0x1d19, 0x1104, "MSI DigiVox Micro HD" },
+        { 0x1f4d, 0xa803, "Sweex DVB-T USB" },
+        { 0x1f4d, 0xb803, "GTek T803" },
+        { 0x1f4d, 0xc803, "Lifeview LV5TDeluxe" },
+        { 0x1f4d, 0xd286, "MyGica TD312" },
+        { 0x1f4d, 0xd803, "PROlectrix DV107669" },
+    };
+
+    int deviceNo = 0;
+    for (int i = 0; i < sizeof(known_devices)/sizeof(rtlsdr_dongle_t); i++)
+    {
+        QStringList serialStrings = Android::listUSBDeviceSerials(known_devices[i].vid, known_devices[i].pid);
+
+        for (const auto serial : serialStrings)
+        {
+            QString displayableName(QString("RTL-SDR[%1] %2").arg(deviceNo).arg(serial));
+
+            originDevices.append(OriginDevice(
+                displayableName,
+                m_hardwareID,
+                serial,
+                deviceNo, // sequence
+                1, // Nb Rx
+                0  // Nb Tx
+            ));
+
+            deviceNo++;
+        }
+    }
+
+    listedHwIds.append(m_hardwareID);
+#else
 	int count = rtlsdr_get_device_count();
 	char vendor[256];
 	char product[256];
@@ -72,6 +152,7 @@ void RTLSDRPlugin::enumOriginDevices(QStringList& listedHwIds, OriginDevices& or
 	}
 
     listedHwIds.append(m_hardwareID);
+#endif
 }
 
 PluginInterface::SamplingDevices RTLSDRPlugin::enumSampleSources(const OriginDevices& originDevices)


### PR DESCRIPTION
On Android, USB devices need to be accessed slightly differently to other OSes.

Device discovery is performed via Android specific code using VID/PID, rather than the device library. Then we have to open devices using a file descriptor, obtained from an Android call.

Similar changes would need to be made to other divers, although the libraries need to have support added for file descriptors.