### PR TITLE
Add progress dialog for device enumeration, as some drivers are slow on Windows.

### DIFF
--- a/sdrbase/device/deviceenumerator.cpp
+++ b/sdrbase/device/deviceenumerator.cpp
@@ -253,6 +253,7 @@ void DeviceEnumerator::enumerateDevices(PluginAPI::SamplingDeviceRegistrations& 
     for (int i = 0; i < deviceRegistrations.count(); i++)
     {
         qDebug("DeviceEnumerator::enumerateDevices: %s", qPrintable(deviceRegistrations[i].m_deviceId));
+        emit enumeratingDevices(deviceRegistrations[i].m_deviceId);
         deviceRegistrations[i].m_plugin->enumOriginDevices(originDevicesHwIds, originDevices);
         PluginInterface::SamplingDevices samplingDevices;
         if (type == PluginInterface::SamplingDevice::StreamSingleRx) {

--- a/sdrbase/device/deviceenumerator.h
+++ b/sdrbase/device/deviceenumerator.h
@@ -27,8 +27,10 @@
 
 class PluginManager;
 
-class SDRBASE_API DeviceEnumerator
+class SDRBASE_API DeviceEnumerator : public QObject
 {
+	Q_OBJECT
+
 public:
     DeviceEnumerator();
     ~DeviceEnumerator();
@@ -66,6 +68,9 @@ public:
     int getBestRxSamplingDeviceIndex(const QString& deviceId, const QString& serial, int sequence, int deviceItemIndex);
     int getBestTxSamplingDeviceIndex(const QString& deviceId, const QString& serial, int sequence, int deviceItemIndex);
     int getBestMIMOSamplingDeviceIndex(const QString& deviceId, const QString& serial, int sequence);
+
+signals:
+    void enumeratingDevices(const QString &deviceId);
 
 private:
     struct DeviceEnumeration

--- a/sdrgui/gui/samplingdevicedialog.h
+++ b/sdrgui/gui/samplingdevicedialog.h
@@ -23,6 +23,8 @@
 #define SDRGUI_GUI_SAMPLINGDEVICEDIALOG_H_
 
 #include <QDialog>
+#include <QProgressDialog>
+
 #include <vector>
 
 #include "export.h"
@@ -30,6 +32,28 @@
 namespace Ui {
     class SamplingDeviceDialog;
 }
+
+class SDRGUI_API SamplingDeviceDialogWorker : public QObject {
+    Q_OBJECT
+
+public:
+    SamplingDeviceDialogWorker(int deviceType, QProgressDialog *progressDialog) :
+        m_deviceType(deviceType),
+        m_progressDialog(progressDialog)
+    {
+    }
+    void enumerateDevices();
+
+signals:
+    void finishedWork();
+
+private slots:
+    void enumeratingDevices(const QString &deviceId);
+
+private:
+    int m_deviceType;
+    QProgressDialog *m_progressDialog;
+};
 
 class SDRGUI_API SamplingDeviceDialog : public QDialog {
     Q_OBJECT
@@ -60,3 +84,4 @@ private slots:
 };
 
 #endif /* SDRGUI_GUI_SAMPLINGDEVICEDIALOG_H_ */
+


### PR DESCRIPTION
Device enumeration can take some seconds on Windows, so I've added a progress dialog in the SamplingDeviceDialog.

Also, this dialog no longer automatically refreshes the list of devices, to avoid this potential delay.