### PR TITLE
Audio Input: Make sure audio device name corresponds to GUI setting.

### DIFF
--- a/plugins/samplesource/audioinput/audioinputgui.h
+++ b/plugins/samplesource/audioinput/audioinputgui.h
@@ -80,6 +80,7 @@ private slots:
     void on_startStop_toggled(bool checked);
     void updateHardware();
     void openDeviceSettingsDialog(const QPoint& p);
+    void updateStatus();
 };
 
 #endif // INCLUDE_AUDIOINPUTGUI_H


### PR DESCRIPTION
If Audio Input device is started without dropdown having been changed, sometimes the audio device will not be opened correctly.

This patch makes sure audio device name corresponds to GUI setting.

It also sets start/stop button background colour according to device status.
