### PR TITLE
Add reset measurements button to Spectrum GUI

### DIFF
--- a/sdrgui/gui/glspectrumgui.cpp
+++ b/sdrgui/gui/glspectrumgui.cpp
@@ -240,6 +240,7 @@ void GLSpectrumGUI::displaySettings()
     ui->linscale->setChecked(m_settings.m_linear);
     setAveragingToolitp();
     ui->calibration->setChecked(m_settings.m_useCalibration);
+    ui->resetMeasurements->setVisible(m_settings.m_measurement >= SpectrumSettings::MeasurementChannelPower);
     displayGotoMarkers();
     displayControls();
 
@@ -1119,8 +1120,18 @@ void GLSpectrumGUI::on_measure_clicked(bool checked)
     measurementsDialog.exec();
 }
 
+void GLSpectrumGUI::on_resetMeasurements_clicked(bool checked)
+{
+    (void) checked;
+
+    if (m_glSpectrum) {
+        m_glSpectrum->getMeasurements()->reset();
+    }
+}
+
 void GLSpectrumGUI::updateMeasurements()
 {
+    ui->resetMeasurements->setVisible(m_settings.m_measurement >= SpectrumSettings::MeasurementChannelPower);
     if (m_glSpectrum)
     {
         m_glSpectrum->setMeasurementsVisible(m_settings.m_measurement != SpectrumSettings::MeasurementNone);

--- a/sdrgui/gui/glspectrumgui.h
+++ b/sdrgui/gui/glspectrumgui.h
@@ -129,6 +129,7 @@ private slots:
     void on_showAllControls_toggled(bool checked);
 
     void on_measure_clicked(bool checked);
+    void on_resetMeasurements_clicked(bool checked);
 
 	void handleInputMessages();
     void openWebsocketSpectrumSettingsDialog(const QPoint& p);

--- a/sdrgui/gui/glspectrumgui.ui
+++ b/sdrgui/gui/glspectrumgui.ui
@@ -1117,6 +1117,20 @@
       </widget>
      </item>
      <item>
+      <widget class="QToolButton" name="resetMeasurements">
+       <property name="toolTip">
+        <string>Reset measurements</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../resources/res.qrc">
+         <normaloff>:/bin.png</normaloff>:/bin.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="ButtonSwitch" name="calibration">
        <property name="toolTip">
         <string>Left: toggle relative / calibrated power - Right: open calibration dialog</string>


### PR DESCRIPTION
This patch adds a Reset Measurements button to the Spectrum GUI (to reset Mean, Std Dev etc)

![image](https://user-images.githubusercontent.com/57259258/212539358-9a9ce5c9-da80-4178-8c5d-45b2ac36d83f.png)

Note that the button is only visible when Measurements are enabled.