### PR TITLE
Spectrum: Keep frequency displayed while channel is being dragged

### DIFF
--- a/sdrgui/gui/glspectrumview.cpp
+++ b/sdrgui/gui/glspectrumview.cpp
@@ -3931,8 +3931,13 @@ void GLSpectrumView::mouseMoveEvent(QMouseEvent* event)
             }
             else if (m_channelMarkerStates[i]->m_channelMarker->getHighlighted())
             {
-                m_channelMarkerStates[i]->m_channelMarker->setHighlightedByCursor(false);
-                channelMarkerChanged();
+                // Don't clear highlight while dragging a channel, as we want the
+                // frequency of the channel to be continuously displayed
+                if (m_cursorState != CSChannelMoving)
+                {
+                    m_channelMarkerStates[i]->m_channelMarker->setHighlightedByCursor(false);
+                    channelMarkerChanged();
+                }
             }
         }
     }


### PR DESCRIPTION
As reported on the mailing list, the channel frequency can disappear if a channel marker is dragged quickly.

This patch prevents that, but not allowing a channel marker to be un-highlighted while a channel is being moved.

