### PR TITLE
Android power management

### DIFF
--- a/plugins/channelrx/heatmap/readme.md
+++ b/plugins/channelrx/heatmap/readme.md
@@ -8,8 +8,10 @@ To view the Heat Map visually, the [Map Feature](../../feature/map/readme.md) sh
 
 To record data for a heat map, a GPS is required, and Preferences > My Position should have "Auto-update from GPS" enabled.
 
-On Android, GPS setup should be automatic. On Windows/Linux/Mac, a GPS supporting NMEA via a serial port at 4800 baud is required.
+On Windows/Linux/Mac, a GPS supporting NMEA via a serial port at 4800 baud is required.
 The COM port / serial device should be specfied via the QT_NMEA_SERIAL_PORT environment variable before SDRangel is started.
+
+On Android, GPS setup should be automatic. GPS position updates may stop on Android when the screen is off. To keep the screen on, press the View > Keep Screen On menu.
 
 ![A Heat Map](../../../doc/img/HeatMap_plugin_map.png)
 

--- a/sdrbase/maincore.h
+++ b/sdrbase/maincore.h
@@ -892,6 +892,9 @@ public slots:
     void positionUpdated(const QGeoPositionInfo &info);
     void positionUpdateTimeout();
     void positionError(QGeoPositionInfoSource::Error positioningError);
+#ifdef ANDROID
+    void updateWakeLock();
+#endif
 
 signals:
     void deviceSetAdded(int index, DeviceAPI *device);

--- a/sdrbase/util/android.cpp
+++ b/sdrbase/util/android.cpp
@@ -155,8 +155,6 @@ void Android::closeUSBDevice(int fd)
         QAndroidJniObject activity = QAndroidJniObject::callStaticObjectMethod("org/qtproject/qt5/android/QtNative", "activity", "()Landroid/app/Activity;");
         if (activity.isValid()) {
             activity.callMethod<void>("closeUSBDevice", "(I)V", fd);
-        } else {
-            qCritical() << "MainCore::closeUSBDevice: activity is not valid.";
         }
     }
 }
@@ -166,6 +164,38 @@ void Android::moveTaskToBack()
     QAndroidJniObject activity = QAndroidJniObject::callStaticObjectMethod("org/qtproject/qt5/android/QtNative", "activity", "()Landroid/app/Activity;");
     if (activity.isValid()) {
         activity.callMethod<jboolean>("moveTaskToBack", "(Z)Z", true);
+    }
+}
+
+void Android::acquireWakeLock()
+{
+    QAndroidJniObject activity = QAndroidJniObject::callStaticObjectMethod("org/qtproject/qt5/android/QtNative", "activity", "()Landroid/app/Activity;");
+    if (activity.isValid()) {
+        activity.callMethod<void>("acquireWakeLock");
+    }
+}
+
+void Android::releaseWakeLock()
+{
+    QAndroidJniObject activity = QAndroidJniObject::callStaticObjectMethod("org/qtproject/qt5/android/QtNative", "activity", "()Landroid/app/Activity;");
+    if (activity.isValid()) {
+        activity.callMethod<void>("releaseWakeLock");
+    }
+}
+
+void Android::acquireScreenLock()
+{
+    QAndroidJniObject activity = QAndroidJniObject::callStaticObjectMethod("org/qtproject/qt5/android/QtNative", "activity", "()Landroid/app/Activity;");
+    if (activity.isValid()) {
+        activity.callMethod<void>("acquireScreenLock");
+    }
+}
+
+void Android::releaseScreenLock()
+{
+    QAndroidJniObject activity = QAndroidJniObject::callStaticObjectMethod("org/qtproject/qt5/android/QtNative", "activity", "()Landroid/app/Activity;");
+    if (activity.isValid()) {
+        activity.callMethod<void>("releaseScreenLock");
     }
 }
 

--- a/sdrbase/util/android.h
+++ b/sdrbase/util/android.h
@@ -36,6 +36,10 @@ public:
     static void closeUSBDevice(int fd);
     static void moveTaskToBack();
     static void messageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg);
+    static void acquireWakeLock();
+    static void releaseWakeLock();
+    static void acquireScreenLock();
+    static void releaseScreenLock();
 
 };
 

--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -1637,6 +1637,12 @@ void MainWindow::createMenuBar(QToolButton *button)
     fullscreenAction->setToolTip("Toggle fullscreen view");
     fullscreenAction->setCheckable(true);
     QObject::connect(fullscreenAction, &QAction::triggered, this, &MainWindow::on_action_View_Fullscreen_toggled);
+#ifdef ANDROID
+    QAction *keepscreenonAction = viewMenu->addAction("&Keep screen on");
+    keepscreenonAction->setToolTip("Prevent screen from switching off");
+    keepscreenonAction->setCheckable(true);
+    QObject::connect(keepscreenonAction, &QAction::triggered, this, &MainWindow::on_action_View_KeepScreenOn_toggled);
+#endif
 
     QAction *newWorkspaceAction = workspacesMenu->addAction("&New");
     newWorkspaceAction->setToolTip("Add a new workspace");
@@ -2182,6 +2188,17 @@ void MainWindow::removeEmptyWorkspaces()
     }
 #endif
 }
+
+#ifdef ANDROID
+void MainWindow::on_action_View_KeepScreenOn_toggled(bool checked)
+{
+    if (checked) {
+        Android::acquireScreenLock();
+    } else {
+        Android::releaseScreenLock();
+    }
+}
+#endif
 
 void MainWindow::on_action_View_Fullscreen_toggled(bool checked)
 {

--- a/sdrgui/mainwindow.h
+++ b/sdrgui/mainwindow.h
@@ -179,6 +179,9 @@ private slots:
 	void handleMessages();
     void handleWorkspaceVisibility(Workspace *workspace, bool visibility);
 
+#ifdef ANDROID
+	void on_action_View_KeepScreenOn_toggled(bool checked);
+#endif
 	void on_action_View_Fullscreen_toggled(bool checked);
 	void on_action_saveAll_triggered();
     void on_action_Configurations_triggered();


### PR DESCRIPTION
On Android, use a wake lock to prevent app from being put to sleep when devices are running.
Add menu to keep screen on.
