### PR TITLE
Disable MSAA for 2D maps by default

### DIFF
--- a/sdrbase/settings/preferences.cpp
+++ b/sdrbase/settings/preferences.cpp
@@ -102,7 +102,7 @@ bool Preferences::deserialize(const QByteArray& data)
 
         d.readS32((int) Multisampling, &m_multisampling, 0);
         d.readBool((int) AutoUpdatePosition, &m_autoUpdatePosition, true);
-        d.readS32((int) MapMultisampling, &m_mapMultisampling, 16);
+        d.readS32((int) MapMultisampling, &m_mapMultisampling, 0);
         d.readBool((int) MapSmoothing, &m_mapSmoothing, true);
 
 		return true;


### PR DESCRIPTION
As not supported on all systems.