### PR TITLE
Prevent MDI scrolling when trying to zoom in on spectrum.

### DIFF
--- a/sdrgui/gui/glspectrumview.cpp
+++ b/sdrgui/gui/glspectrumview.cpp
@@ -4285,6 +4285,7 @@ void GLSpectrumView::wheelEvent(QWheelEvent *event)
             channelMarkerMove(event, 1);
         }
     }
+    event->accept();
 }
 
 void GLSpectrumView::zoomFactor(const QPointF& p, float factor)


### PR DESCRIPTION
Currently, if the MDI area has scroll bars, when zooming in to the spectrum using the mouse wheel, not only will you zoom in, but the MDI area will be scrolled. This fixes that.