### PR TITLE
VOR Demod: Improve filtering of voice over Morse ident

### DIFF
--- a/plugins/channelrx/demodvor/readme.md
+++ b/plugins/channelrx/demodvor/readme.md
@@ -8,13 +8,13 @@ VORs transmit two 30Hz signals, one AM at the VOR center frequency and one FM on
 
 VORs also transmit a Morse code ident signal at a 1020Hz offset. This is a 2 or 3 character identifier used to identify the VOR, as multiple VORs can be transmitted on the same frequency. For example, the VOR at London Heathrow transmits .-.. --- -. for LON. The Morse code ident is typically transmitted at 10 seconds intervals at between 7 and 10 wpm. VORs that are under maintenance may transmit TST.
 
-Some VORs also transmit an AM voice identification or information signal between 300-3kHz.
+Some VORs also transmit an AM voice identification or information signal (ATIS) between 300-3kHz.
 
 Note that for aircraft, there is typically a direct line-of-sight to the VOR. This is unlikely to be the case when using an SDR on the ground. To get good results, ideally you want to be on a nice high hill or close to the VOR.
 
 <h2>Using it for localization</h2>
 
-Several instances of this plugin can be created to monitor multiple VORs and collate information in the VOR Localizer feature plugin. The VOR Localizer can also perform a round robin on multiple VORs with just one VOR demodulator. Please refer to [VOR Localizer](../../feature/vorlocalizer/readme.md) for more information about this feature plugin
+Several instances of this plugin can be created to monitor multiple VORs and collate information in the VOR Localizer feature plugin. The VOR Localizer can also perform a round robin on multiple VORs with just one VOR demodulator. Please refer to [VOR Localizer](../../feature/vorlocalizer/readme.md) for more information about this feature plugin.
 
 <h2>Interface</h2>
 
@@ -46,6 +46,10 @@ If you right click on it it will open a dialog to select the audio output device
 
 This is the Morse code ident threshold, expressed as a linear signal to noise (SNR) ratio. This is effectively the signal level required for the Morse demodulator to detect a dot or dash. Setting this to low values will allow the Morse demodulator to detect weak signals, but it also increases the likelihood that noise will incorrectly be interpreted as a signal, resulting in invalid idents being reported.
 
+<h3>Ident bandpass filter</h3>
+
+Click to toggle a narrow bandpass filter around the Morse ident signal. This can be used to filter out the voice signal from the audio output, to make the Morse ident signal clearer.
+
 <h3>6: Squelch threshold</h3>
 
 This is the squelch threshold in dB. The average total power received in the signal bandwidth before demodulation is compared to this value and the squelch input is open above this value. It can be varied continuously in 0.1 dB steps from 0.0 to -100.0 dB using the dial button.
@@ -54,17 +58,17 @@ This is the squelch threshold in dB. The average total power received in the sig
 
 This is the volume of the audio signal from 0.0 (mute) to 10.0 (maximum). It can be varied continuously in 0.1 steps using the dial button.
 
-<h3>8: Radial dircetion</h3>
+<h3>8: Radial direction</h3>
 
 Demodulated radial direction in degrees (unadjusted for magnetic declination). If there is a low confidence the value is correct (due to a weak signal), it will be displayed in red.
 
 <h3>9: Reference signal power in dB</h3>
 
-Magnitude of the received 30Hz FM reference signal in dB
+Magnitude of the received 30Hz FM reference signal in dB.
 
 <h3>10. Variable signal power in dB</h3>
 
-Mangitude of the received 30Hz AM variable signal in dB
+Mangitude of the received 30Hz AM variable signal in dB.
 
 <h3>11. VOR identifier code (decoded)</h3>
 

--- a/plugins/channelrx/demodvor/vordemod.cpp
+++ b/plugins/channelrx/demodvor/vordemod.cpp
@@ -262,6 +262,7 @@ void VORDemod::applySettings(const VORDemodSettings& settings, bool force)
             << " m_navId: " << settings.m_navId
             << " m_volume: " << settings.m_volume
             << " m_squelch: " << settings.m_squelch
+            << " m_identBandpassEnable: " << settings.m_identBandpassEnable
             << " m_audioMute: " << settings.m_audioMute
             << " m_audioDeviceName: " << settings.m_audioDeviceName
             << " m_streamIndex: " << settings.m_streamIndex
@@ -296,7 +297,9 @@ void VORDemod::applySettings(const VORDemodSettings& settings, bool force)
     if ((m_settings.m_audioMute != settings.m_audioMute) || force) {
         reverseAPIKeys.append("audioMute");
     }
-
+    if ((m_settings.m_identBandpassEnable != settings.m_identBandpassEnable) || force) {
+        reverseAPIKeys.append("identBandpassEnable");
+    }
     if ((m_settings.m_volume != settings.m_volume) || force) {
         reverseAPIKeys.append("volume");
     }
@@ -431,6 +434,9 @@ void VORDemod::webapiUpdateChannelSettings(
     if (channelSettingsKeys.contains("squelch")) {
         settings.m_squelch = response.getVorDemodSettings()->getSquelch();
     }
+    if (channelSettingsKeys.contains("identBandpassEnable")) {
+        settings.m_identBandpassEnable = response.getVorDemodSettings()->getIdentBandpassEnable();
+    }
     if (channelSettingsKeys.contains("title")) {
         settings.m_title = *response.getVorDemodSettings()->getTitle();
     }
@@ -487,6 +493,7 @@ void VORDemod::webapiFormatChannelSettings(SWGSDRangel::SWGChannelSettings& resp
     response.getVorDemodSettings()->setAudioMute(settings.m_audioMute ? 1 : 0);
     response.getVorDemodSettings()->setRgbColor(settings.m_rgbColor);
     response.getVorDemodSettings()->setSquelch(settings.m_squelch);
+    response.getVorDemodSettings()->setIdentBandpassEnable(settings.m_identBandpassEnable);
     response.getVorDemodSettings()->setVolume(settings.m_volume);
 
     if (response.getVorDemodSettings()->getTitle()) {
@@ -674,6 +681,9 @@ void VORDemod::webapiFormatChannelSettings(
     }
     if (channelSettingsKeys.contains("squelch") || force) {
         swgVORDemodSettings->setSquelch(settings.m_squelch);
+    }
+    if (channelSettingsKeys.contains("identBandpassEnable") || force) {
+        swgVORDemodSettings->setIdentBandpassEnable(settings.m_identBandpassEnable);
     }
     if (channelSettingsKeys.contains("title") || force) {
         swgVORDemodSettings->setTitle(new QString(settings.m_title));

--- a/plugins/channelrx/demodvor/vordemodgui.cpp
+++ b/plugins/channelrx/demodvor/vordemodgui.cpp
@@ -225,6 +225,12 @@ void VORDemodGUI::on_audioMute_toggled(bool checked)
     applySettings();
 }
 
+void VORDemodGUI::on_identBandpassEnable_toggled(bool checked)
+{
+    m_settings.m_identBandpassEnable = checked;
+    applySettings();
+}
+
 void VORDemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
 {
     (void) widget;
@@ -385,6 +391,7 @@ void VORDemodGUI::displaySettings()
     ui->squelchText->setText(QString("%1 dB").arg(m_settings.m_squelch));
 
     ui->audioMute->setChecked(m_settings.m_audioMute);
+    ui->identBandpassEnable->setChecked(m_settings.m_identBandpassEnable);
 
     updateIndexLabel();
 
@@ -462,6 +469,7 @@ void VORDemodGUI::makeUIConnections()
     QObject::connect(ui->volume, &QDial::valueChanged, this, &VORDemodGUI::on_volume_valueChanged);
     QObject::connect(ui->squelch, &QDial::valueChanged, this, &VORDemodGUI::on_squelch_valueChanged);
     QObject::connect(ui->audioMute, &QToolButton::toggled, this, &VORDemodGUI::on_audioMute_toggled);
+    QObject::connect(ui->identBandpassEnable, &QToolButton::toggled, this, &VORDemodGUI::on_identBandpassEnable_toggled);
 }
 
 void VORDemodGUI::updateAbsoluteCenterFrequency()

--- a/plugins/channelrx/demodvor/vordemodgui.h
+++ b/plugins/channelrx/demodvor/vordemodgui.h
@@ -99,6 +99,7 @@ private slots:
     void on_volume_valueChanged(int value);
     void on_squelch_valueChanged(int value);
     void on_audioMute_toggled(bool checked);
+    void on_identBandpassEnable_toggled(bool checked);
     void onWidgetRolled(QWidget* widget, bool rollDown);
     void onMenuDialogCalled(const QPoint& p);
     void handleInputMessages();

--- a/plugins/channelrx/demodvor/vordemodgui.ui
+++ b/plugins/channelrx/demodvor/vordemodgui.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>VORDemodGUI</class>
- <widget class="RollupContents" name="VORDemodSCGUI">
+ <widget class="RollupContents" name="VORDemodGUI">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -326,6 +326,28 @@
        </spacer>
       </item>
       <item>
+       <widget class="ButtonSwitch" name="identBandpassEnable">
+        <property name="toolTip">
+         <string>Toggle Morse identifier bandpass filter to filter voice</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../../sdrgui/resources/res.qrc">
+          <normaloff>:/filter_bandpass.png</normaloff>
+          <normalon>:/filter_bandpass.png</normalon>:/filter_bandpass.png</iconset>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Line" name="line_3">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Sq</string>
@@ -619,6 +641,11 @@
   </widget>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
+  </customwidget>
   <customwidget>
    <class>RollupContents</class>
    <extends>QWidget</extends>

--- a/plugins/channelrx/demodvor/vordemodsettings.cpp
+++ b/plugins/channelrx/demodvor/vordemodsettings.cpp
@@ -37,6 +37,7 @@ void VORDemodSettings::resetToDefaults()
     m_squelch = -60.0;
     m_volume = 2.0;
     m_audioMute = false;
+    m_identBandpassEnable = false;
     m_rgbColor = QColor(255, 255, 102).rgb();
     m_title = "VOR Demodulator";
     m_audioDeviceName = AudioDeviceManager::m_defaultDeviceName;
@@ -49,7 +50,7 @@ void VORDemodSettings::resetToDefaults()
     m_workspaceIndex = 0;
     m_hidden = false;
 
-    m_identThreshold = 2.0;
+    m_identThreshold = 4.0;
     m_refThresholdDB = -45.0;
     m_varThresholdDB = -90.0;
 }
@@ -65,6 +66,7 @@ QByteArray VORDemodSettings::serialize() const
     if (m_channelMarker) {
         s.writeBlob(6, m_channelMarker->serialize());
     }
+    s.writeBool(8, m_identBandpassEnable);
 
     s.writeU32(7, m_rgbColor);
     s.writeString(9, m_title);
@@ -118,6 +120,7 @@ bool VORDemodSettings::deserialize(const QByteArray& data)
             d.readBlob(6, &bytetmp);
             m_channelMarker->deserialize(bytetmp);
         }
+        d.readBool(8, &m_identBandpassEnable, false);
 
         d.readU32(7, &m_rgbColor, QColor(255, 255, 102).rgb());
         d.readString(9, &m_title, "VOR Demodulator");
@@ -136,7 +139,7 @@ bool VORDemodSettings::deserialize(const QByteArray& data)
         m_reverseAPIDeviceIndex = utmp > 99 ? 99 : utmp;
         d.readU32(18, &utmp, 0);
         m_reverseAPIChannelIndex = utmp > 99 ? 99 : utmp;
-        d.readReal(20, &m_identThreshold, 2.0);
+        d.readReal(20, &m_identThreshold, 4.0);
         d.readReal(21, &m_refThresholdDB, -45.0);
         d.readReal(22, &m_varThresholdDB, -90.0);
 

--- a/plugins/channelrx/demodvor/vordemodsettings.h
+++ b/plugins/channelrx/demodvor/vordemodsettings.h
@@ -31,6 +31,7 @@ struct VORDemodSettings
     Real m_squelch;
     Real m_volume;
     bool m_audioMute;
+    bool m_identBandpassEnable;
     quint32 m_rgbColor;
     QString m_title;
     Serializable *m_channelMarker;

--- a/plugins/channelrx/demodvor/vordemodsink.h
+++ b/plugins/channelrx/demodvor/vordemodsink.h
@@ -29,10 +29,10 @@
 #include "util/movingaverage.h"
 #include "util/doublebufferfifo.h"
 #include "util/messagequeue.h"
+#include <QFile>
+#include <QTextStream>
 
 #include "vordemodsettings.h"
-
-#include <vector>
 
 class VORDemodSCSink : public ChannelSampleSink {
 public:
@@ -119,12 +119,12 @@ private:
     NCO m_ncoIdent;
     NCO m_ncoRef;
     Lowpass<Complex> m_lowpassRef;
+    Bandpass<Complex> m_bandpassIdent;
     Lowpass<Complex> m_lowpassIdent;
+    Highpass<Real> m_highpassIdent;
     Complex m_refPrev;
     MovingAverageUtilVar<Real, double> m_movingAverageIdent;
-    static const int m_identBins = 10;
-    Real m_identMins[m_identBins];
-    Real m_identMin;
+    static const int m_identBins = 20;
     Real m_identMaxs[m_identBins];
     Real m_identNoise;
     int m_binSampleCnt;
@@ -136,6 +136,8 @@ private:
     QString m_ident;
     Goertzel m_varGoertzel;
     Goertzel m_refGoertzel;
+    //QFile m_file;
+    //QTextStream m_stream;
 
     void processOneSample(Complex &ci);
     void processOneAudioSample(Complex &ci);

--- a/plugins/channelrx/heatmap/readme.md
+++ b/plugins/channelrx/heatmap/readme.md
@@ -10,6 +10,10 @@ To record data for a heat map, a GPS is required, and Preferences > My Position 
 
 On Windows/Linux/Mac, a GPS supporting NMEA via a serial port at 4800 baud is required.
 The COM port / serial device should be specfied via the QT_NMEA_SERIAL_PORT environment variable before SDRangel is started.
+(E.g. on Linux: export QT_NMEA_SERIAL_PORT=/dev/ttyACM0 or /dev/ttyUSB0 on Windows: Set QT_NMEA_SERIAL_PORT=COM5 via Control Panel)
+This requires the Qt serialnmea plugin, which is not available in the libqt5positioning5-plugins package on Debian / Ubuntu.
+It can be downloaded for Ubuntu/x64 from http://sdrangel.org/downloads/libqtposition_serialnmea.so and should be installed in usr/lib/x86_64-linux-gnu/qt5/plugins/position/.
+This custom build of the pluging also allows setting the baud rate via the QT_NMEA_SERIAL_BAUD_RATE option (which is not supported on Windows nor Mac).
 
 On Android, GPS setup should be automatic. GPS position updates may stop on Android when the screen is off. To keep the screen on, press the View > Keep Screen On menu.
 

--- a/swagger/sdrangel/api/swagger/include/VORDemod.yaml
+++ b/swagger/sdrangel/api/swagger/include/VORDemod.yaml
@@ -16,6 +16,8 @@ VORDemodSettings:
       format: float
     audioMute:
       type: integer
+    identBandpassEnable:
+      type: integer
     rgbColor:
       type: integer
     title:

--- a/swagger/sdrangel/code/qt5/client/SWGVORDemodSettings.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGVORDemodSettings.cpp
@@ -38,6 +38,8 @@ SWGVORDemodSettings::SWGVORDemodSettings() {
     m_volume_isSet = false;
     audio_mute = 0;
     m_audio_mute_isSet = false;
+    ident_bandpass_enable = 0;
+    m_ident_bandpass_enable_isSet = false;
     rgb_color = 0;
     m_rgb_color_isSet = false;
     title = nullptr;
@@ -80,6 +82,8 @@ SWGVORDemodSettings::init() {
     m_volume_isSet = false;
     audio_mute = 0;
     m_audio_mute_isSet = false;
+    ident_bandpass_enable = 0;
+    m_ident_bandpass_enable_isSet = false;
     rgb_color = 0;
     m_rgb_color_isSet = false;
     title = new QString("");
@@ -108,6 +112,7 @@ SWGVORDemodSettings::init() {
 
 void
 SWGVORDemodSettings::cleanup() {
+
 
 
 
@@ -157,6 +162,8 @@ SWGVORDemodSettings::fromJsonObject(QJsonObject &pJson) {
     ::SWGSDRangel::setValue(&volume, pJson["volume"], "float", "");
     
     ::SWGSDRangel::setValue(&audio_mute, pJson["audioMute"], "qint32", "");
+    
+    ::SWGSDRangel::setValue(&ident_bandpass_enable, pJson["identBandpassEnable"], "qint32", "");
     
     ::SWGSDRangel::setValue(&rgb_color, pJson["rgbColor"], "qint32", "");
     
@@ -212,6 +219,9 @@ SWGVORDemodSettings::asJsonObject() {
     }
     if(m_audio_mute_isSet){
         obj->insert("audioMute", QJsonValue(audio_mute));
+    }
+    if(m_ident_bandpass_enable_isSet){
+        obj->insert("identBandpassEnable", QJsonValue(ident_bandpass_enable));
     }
     if(m_rgb_color_isSet){
         obj->insert("rgbColor", QJsonValue(rgb_color));
@@ -301,6 +311,16 @@ void
 SWGVORDemodSettings::setAudioMute(qint32 audio_mute) {
     this->audio_mute = audio_mute;
     this->m_audio_mute_isSet = true;
+}
+
+qint32
+SWGVORDemodSettings::getIdentBandpassEnable() {
+    return ident_bandpass_enable;
+}
+void
+SWGVORDemodSettings::setIdentBandpassEnable(qint32 ident_bandpass_enable) {
+    this->ident_bandpass_enable = ident_bandpass_enable;
+    this->m_ident_bandpass_enable_isSet = true;
 }
 
 qint32
@@ -441,6 +461,9 @@ SWGVORDemodSettings::isSet(){
             isObjectUpdated = true; break;
         }
         if(m_audio_mute_isSet){
+            isObjectUpdated = true; break;
+        }
+        if(m_ident_bandpass_enable_isSet){
             isObjectUpdated = true; break;
         }
         if(m_rgb_color_isSet){

--- a/swagger/sdrangel/code/qt5/client/SWGVORDemodSettings.h
+++ b/swagger/sdrangel/code/qt5/client/SWGVORDemodSettings.h
@@ -59,6 +59,9 @@ public:
     qint32 getAudioMute();
     void setAudioMute(qint32 audio_mute);
 
+    qint32 getIdentBandpassEnable();
+    void setIdentBandpassEnable(qint32 ident_bandpass_enable);
+
     qint32 getRgbColor();
     void setRgbColor(qint32 rgb_color);
 
@@ -113,6 +116,9 @@ private:
 
     qint32 audio_mute;
     bool m_audio_mute_isSet;
+
+    qint32 ident_bandpass_enable;
+    bool m_ident_bandpass_enable_isSet;
 
     qint32 rgb_color;
     bool m_rgb_color_isSet;


### PR DESCRIPTION
For #1590, this PR improves the filtering of voice over the Morse ident.
It also adds a button in the GUI to enable voice filtering for the audio output.