### PR TITLE
Fix DSD Demod crash on exit

### DIFF
--- a/plugins/channelrx/demoddsd/dsddemodgui.cpp
+++ b/plugins/channelrx/demoddsd/dsddemodgui.cpp
@@ -433,6 +433,7 @@ DSDDemodGUI::DSDDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
 
 DSDDemodGUI::~DSDDemodGUI()
 {
+	m_dsdDemod->setScopeXYSink(nullptr);
 	delete m_scopeVisXY;
     ui->screenTV->setParent(nullptr); // Prefer memory leak to core dump... ~TVScreen() is buggy
 	delete ui;


### PR DESCRIPTION
Set scope in sink to nullptr before deleting it in the GUI.

Fixes #1617.