### PR TITLE
TestSource: Fix timing on Windows

### DIFF
--- a/plugins/samplesource/testsource/testsourceworker.cpp
+++ b/plugins/samplesource/testsource/testsourceworker.cpp
@@ -64,6 +64,7 @@ TestSourceWorker::TestSourceWorker(SampleSinkFifo* sampleFifo, QObject* parent) 
 {
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     connect(&m_timer, SIGNAL(timeout()), this, SLOT(tick()));
+    m_timer.setTimerType(Qt::PreciseTimer);
     m_timer.start(50);
 }
 
@@ -76,7 +77,6 @@ TestSourceWorker::~TestSourceWorker()
 void TestSourceWorker::startWork()
 {
     qDebug("TestSourceWorker::startWork");
-    m_timer.setTimerType(Qt::PreciseTimer);
     m_running = true;
 }
 


### PR DESCRIPTION
On Windows, there can be audio drop outs when using the TestSource. This is because the timer needs to be set to precise before calling start, otherwise it doesn't have an affect.

Just for future reference, there's some code to generate a histogram of timer accuracy in the test source. As the code was, it's all over the place on Windows:

2023-03-08 16:11:40.272 (D) TestSourceWorker::tick: 43: 1
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 44: 1
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 45: 1
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 46: 2
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 48: 1
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 50: 1
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 51: 7
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 52: 3
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 53: 9
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 54: 5
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 55: 10
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 56: 18
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 57: 8
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 58: 18
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 59: 25
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 60: 29
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 61: 37
2023-03-08 16:11:40.273 (D) TestSourceWorker::tick: 62: 28
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 63: 22
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 64: 13
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 65: 19
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 66: 14
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 67: 10
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 68: 13
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 69: 16
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 70: 5
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 71: 15
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 72: 6
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 73: 3
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 74: 2
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 75: 2
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 76: 3
2023-03-08 16:11:40.274 (D) TestSourceWorker::tick: 77: 2

With the change:

2023-03-08 16:32:42.647 (D) TestSourceWorker::tick: 40: 1
2023-03-08 16:32:42.647 (D) TestSourceWorker::tick: 43: 1
2023-03-08 16:32:42.647 (D) TestSourceWorker::tick: 44: 1
2023-03-08 16:32:42.647 (D) TestSourceWorker::tick: 45: 3
2023-03-08 16:32:42.647 (D) TestSourceWorker::tick: 46: 6
2023-03-08 16:32:42.647 (D) TestSourceWorker::tick: 47: 14
2023-03-08 16:32:42.647 (D) TestSourceWorker::tick: 48: 28
2023-03-08 16:32:42.647 (D) TestSourceWorker::tick: 49: 100
2023-03-08 16:32:42.647 (D) TestSourceWorker::tick: 50: 84
2023-03-08 16:32:42.648 (D) TestSourceWorker::tick: 51: 41
2023-03-08 16:32:42.648 (D) TestSourceWorker::tick: 52: 6
2023-03-08 16:32:42.648 (D) TestSourceWorker::tick: 53: 4
2023-03-08 16:32:42.648 (D) TestSourceWorker::tick: 54: 1
2023-03-08 16:32:42.648 (D) TestSourceWorker::tick: 55: 4
2023-03-08 16:32:42.648 (D) TestSourceWorker::tick: 57: 2
2023-03-08 16:32:42.648 (D) TestSourceWorker::tick: 58: 1

On Linux the old code was fine:

2023-03-08 16:13:40.506 (D) TestSourceWorker::tick: 47: 2
2023-03-08 16:13:40.506 (D) TestSourceWorker::tick: 48: 24
2023-03-08 16:13:40.506 (D) TestSourceWorker::tick: 49: 183
2023-03-08 16:13:40.506 (D) TestSourceWorker::tick: 50: 163
2023-03-08 16:13:40.506 (D) TestSourceWorker::tick: 51: 26
2023-03-08 16:13:40.506 (D) TestSourceWorker::tick: 115: 1
