### PR TITLE
Heat map sample rate

### DIFF
--- a/plugins/channelrx/heatmap/heatmapgui.cpp
+++ b/plugins/channelrx/heatmap/heatmapgui.cpp
@@ -109,7 +109,6 @@ bool HeatMapGUI::handleMessage(const Message& message)
         DSPSignalNotification& notif = (DSPSignalNotification&) message;
         m_deviceCenterFrequency = notif.getCenterFrequency();
         m_basebandSampleRate = notif.getSampleRate();
-        ui->rfBW->setMaximum(m_basebandSampleRate/100);
         ui->deltaFrequency->setValueRange(false, 7, -m_basebandSampleRate/2, m_basebandSampleRate/2);
         ui->deltaFrequencyLabel->setToolTip(tr("Range %1 %L2 Hz").arg(QChar(0xB1)).arg(m_basebandSampleRate/2));
         updateAbsoluteCenterFrequency();
@@ -211,14 +210,15 @@ void HeatMapGUI::on_averagePeriod_valueChanged(int value)
 }
 
 const QStringList HeatMapGUI::m_sampleRateTexts = {
-     "10", "100", "1k", "10k", "100k", "1M"
+     "100", "1k", "10k", "100k", "1M", "10M"
 };
 
 void HeatMapGUI::on_sampleRate_valueChanged(int value)
 {
     m_settings.m_sampleRate = (int)std::pow(10.0f, (float)value);
-    ui->sampleRateText->setText(m_sampleRateTexts[value-1]);
-    ui->averagePeriod->setMinimum(std::max(1, static_cast<int> ( m_averagePeriodTexts.size()) - value));
+    ui->sampleRateText->setText(m_sampleRateTexts[value-2]); // value range is [2,7]
+    ui->averagePeriod->setMinimum(std::max(1, static_cast<int> (m_averagePeriodTexts.size()) - value));
+    ui->rfBW->setMaximum(m_settings.m_sampleRate/100);
     m_scopeVis->setLiveRate(m_settings.m_sampleRate);
     applySettings();
 }
@@ -695,7 +695,8 @@ void HeatMapGUI::displaySettings()
 
     value = (int)std::log10(m_settings.m_sampleRate);
     ui->sampleRate->setValue(value);
-    ui->sampleRateText->setText(m_sampleRateTexts[value-1]);
+    int idx = std::min(std::max(0, value-2), m_sampleRateTexts.size() - 1);
+    ui->sampleRateText->setText(m_sampleRateTexts[idx]);
     ui->averagePeriod->setMinimum(std::max(1, static_cast<int> (m_averagePeriodTexts.size()) - value));
 
     ui->txPosition->setChecked(m_settings.m_txPosValid);

--- a/plugins/channelrx/heatmap/heatmapgui.ui
+++ b/plugins/channelrx/heatmap/heatmapgui.ui
@@ -334,13 +334,16 @@
          <string>Sample rate</string>
         </property>
         <property name="minimum">
-         <number>1</number>
+         <number>2</number>
         </property>
         <property name="maximum">
-         <number>6</number>
+         <number>7</number>
         </property>
         <property name="pageStep">
          <number>1</number>
+        </property>
+        <property name="value">
+         <number>5</number>
         </property>
        </widget>
       </item>
@@ -1543,21 +1546,31 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
+  </customwidget>
+  <customwidget>
    <class>RollupContents</class>
    <extends>QWidget</extends>
    <header>gui/rollupcontents.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>LevelMeterSignalDB</class>
-   <extends>QWidget</extends>
-   <header>gui/levelmeter.h</header>
-   <container>1</container>
+   <class>QChartView</class>
+   <extends>QGraphicsView</extends>
+   <header>QtCharts</header>
   </customwidget>
   <customwidget>
    <class>ValueDialZ</class>
    <extends>QWidget</extends>
    <header>gui/valuedialz.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LevelMeterSignalDB</class>
+   <extends>QWidget</extends>
+   <header>gui/levelmeter.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -1571,16 +1584,6 @@
    <extends>QWidget</extends>
    <header>gui/glscopegui.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ButtonSwitch</class>
-   <extends>QToolButton</extends>
-   <header>gui/buttonswitch.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QChartView</class>
-   <extends>QGraphicsView</extends>
-   <header>QtCharts</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/plugins/channelrx/heatmap/heatmapsettings.cpp
+++ b/plugins/channelrx/heatmap/heatmapsettings.cpp
@@ -40,7 +40,7 @@ void HeatMapSettings::resetToDefaults()
     m_mode = Average;
     m_pulseThreshold= -50.0f;
     m_averagePeriodUS = 100000;
-    m_sampleRate = 100;
+    m_sampleRate = 100000;
     m_txPosValid = false;
     m_txLatitude = 0.0f;
     m_txLongitude = 0.0f;
@@ -138,7 +138,7 @@ bool HeatMapSettings::deserialize(const QByteArray& data)
         d.readS32(6, (int*)&m_mode, (int)Average);
         d.readFloat(7, &m_pulseThreshold, 50.0f);
         d.readS32(8, &m_averagePeriodUS, 100000);
-        d.readS32(9, &m_sampleRate, 100);
+        d.readS32(9, &m_sampleRate, 100000);
         d.readBool(10, &m_txPosValid, false);
         d.readFloat(11, &m_txLatitude);
         d.readFloat(12, &m_txLongitude);

--- a/plugins/channelrx/heatmap/readme.md
+++ b/plugins/channelrx/heatmap/readme.md
@@ -49,7 +49,7 @@ Displays the heat map resolution in metres per pixel. Currently this is fixed at
 
 <h3>6: SR - Sample Rate</h3>
 
-Sets the sample rate at which channel power is sampled and measured. Values range from 1MS/s to 100S/s in powers of 10.
+Sets the sample rate at which channel power is sampled and measured. Values range from 100S/s to 10MS/s in powers of 10.
 
 <h3>7: Tavg - Average Time</h3>
 


### PR DESCRIPTION
Add 10MS/s sample rate, and link bandwidth setting to channel sample rate instead of baseband sample rate.