### PR TITLE
Add missing setting key in Rotator Controller.

### DIFF
--- a/plugins/feature/gs232controller/gs232controllersettings.cpp
+++ b/plugins/feature/gs232controller/gs232controllersettings.cpp
@@ -208,6 +208,9 @@ void GS232ControllerSettings::applySettings(const QStringList& settingsKeys, con
     if (settingsKeys.contains("baudRate")) {
         m_baudRate = settings.m_baudRate;
     }
+    if (settingsKeys.contains("track")) {
+        m_track = settings.m_track;
+    }
     if (settingsKeys.contains("source")) {
         m_source = settings.m_source;
     }


### PR DESCRIPTION
Tracking is not working due to a missing setting key. Similar to #1642