### PR TITLE
Fix settings keys in Star Tracker and GUI connections in Radio Astronomy

### DIFF
--- a/plugins/channelrx/radioastronomy/radioastronomy.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomy.cpp
@@ -60,6 +60,7 @@ MESSAGE_CLASS_DEFINITION(RadioAstronomy::MsgStartSweep, Message)
 MESSAGE_CLASS_DEFINITION(RadioAstronomy::MsgStopSweep, Message)
 MESSAGE_CLASS_DEFINITION(RadioAstronomy::MsgSweepComplete, Message)
 MESSAGE_CLASS_DEFINITION(RadioAstronomy::MsgSweepStatus, Message)
+MESSAGE_CLASS_DEFINITION(RadioAstronomy::MsgScanAvailableFeatures, Message)
 MESSAGE_CLASS_DEFINITION(RadioAstronomy::MsgReportAvailableFeatures, Message)
 MESSAGE_CLASS_DEFINITION(RadioAstronomy::MsgReportAvailableRotators, Message)
 
@@ -326,6 +327,11 @@ bool RadioAstronomy::handleMessage(const Message& cmd)
         {
             m_basebandSink->getInputMessageQueue()->push(MsgStopMeasurements::create());
         }
+        return true;
+    }
+    else if (MsgScanAvailableFeatures::match(cmd))
+    {
+        scanAvailableFeatures();
         return true;
     }
     else

--- a/plugins/channelrx/radioastronomy/radioastronomy.h
+++ b/plugins/channelrx/radioastronomy/radioastronomy.h
@@ -307,6 +307,24 @@ public:
         }
     };
 
+    class MsgScanAvailableFeatures : public Message {
+        MESSAGE_CLASS_DECLARATION
+
+    public:
+
+        static MsgScanAvailableFeatures* create()
+        {
+            return new MsgScanAvailableFeatures();
+        }
+
+    private:
+
+        MsgScanAvailableFeatures() :
+            Message()
+        {
+        }
+    };
+
     class MsgReportAvailableFeatures : public Message {
         MESSAGE_CLASS_DECLARATION
 

--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -2205,6 +2205,8 @@ RadioAstronomyGUI::RadioAstronomyGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUI
     plotCalSpectrum();
     plotSpectrum();
     plotPowerChart();
+
+    m_radioAstronomy->getInputMessageQueue()->push(RadioAstronomy::MsgScanAvailableFeatures::create());
 }
 
 void RadioAstronomyGUI::customContextMenuRequested(QPoint pos)
@@ -6235,9 +6237,32 @@ void RadioAstronomyGUI::makeUIConnections()
     QObject::connect(ui->powerGaussianHPBW, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_powerGaussianHPBW_valueChanged);
     QObject::connect(ui->runMode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &RadioAstronomyGUI::on_runMode_currentIndexChanged);
     QObject::connect(ui->sweepType, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &RadioAstronomyGUI::on_sweepType_currentIndexChanged);
-    QObject::connect(ui->startStop, &ButtonSwitch::clicked, this, &RadioAstronomyGUI::on_startStop_clicked);
+    QObject::connect(ui->sweep1Start, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_sweep1Start_valueChanged);
+    QObject::connect(ui->sweep1Stop, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_sweep1Stop_valueChanged);
+    QObject::connect(ui->sweep1Step, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_sweep1Step_valueChanged);
+    QObject::connect(ui->sweep1Delay, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_sweep1Delay_valueChanged);
+    QObject::connect(ui->sweep2Start, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_sweep2Start_valueChanged);
+    QObject::connect(ui->sweep2Stop, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_sweep2Stop_valueChanged);
+    QObject::connect(ui->sweep2Step, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_sweep2Step_valueChanged);
+    QObject::connect(ui->sweep2Delay, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_sweep2Delay_valueChanged);
     QObject::connect(ui->sweepStartAtTime, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &RadioAstronomyGUI::on_sweepStartAtTime_currentIndexChanged);
     QObject::connect(ui->sweepStartDateTime, &QDateTimeEdit::dateTimeChanged, this, &RadioAstronomyGUI::on_sweepStartDateTime_dateTimeChanged);
+    QObject::connect(ui->startStop, &ButtonSwitch::clicked, this, &RadioAstronomyGUI::on_startStop_clicked);
+    QObject::connect(ui->power2DAutoscale, &QToolButton::clicked, this, &RadioAstronomyGUI::on_power2DAutoscale_clicked);
+    QObject::connect(ui->power2DLinkSweep, &ButtonSwitch::clicked, this, &RadioAstronomyGUI::on_power2DLinkSweep_toggled);
+    QObject::connect(ui->power2DSweepType, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &RadioAstronomyGUI::on_power2DSweepType_currentIndexChanged);
+    QObject::connect(ui->power2DWidth, QOverload<int>::of(&QSpinBox::valueChanged), this, &RadioAstronomyGUI::on_power2DWidth_valueChanged);
+    QObject::connect(ui->power2DHeight, QOverload<int>::of(&QSpinBox::valueChanged), this, &RadioAstronomyGUI::on_power2DHeight_valueChanged);
+    QObject::connect(ui->power2DXMin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_power2DXMin_valueChanged);
+    QObject::connect(ui->power2DXMax, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_power2DXMax_valueChanged);
+    QObject::connect(ui->power2DYMin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_power2DYMin_valueChanged);
+    QObject::connect(ui->power2DYMax, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_power2DYMax_valueChanged);
+    QObject::connect(ui->powerShowSensor1, &ButtonSwitch::toggled, this, &RadioAstronomyGUI::on_powerShowSensor1_toggled);
+    QObject::connect(ui->powerShowSensor2, &ButtonSwitch::toggled, this, &RadioAstronomyGUI::on_powerShowSensor1_toggled);
+    QObject::connect(ui->powerShowFiltered, &ButtonSwitch::clicked, this, &RadioAstronomyGUI::on_powerShowFiltered_clicked);
+    QObject::connect(ui->powerFilter, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &RadioAstronomyGUI::on_powerFilter_currentIndexChanged);
+    QObject::connect(ui->powerFilterN, QOverload<int>::of(&QSpinBox::valueChanged), this, &RadioAstronomyGUI::on_powerFilterN_valueChanged);
+    QObject::connect(ui->powerShowMeasurement, &ButtonSwitch::clicked, this, &RadioAstronomyGUI::on_powerShowMeasurement_clicked);
     QObject::connect(ui->powerColourAutoscale, &QToolButton::toggled, this, &RadioAstronomyGUI::on_powerColourAutoscale_toggled);
     QObject::connect(ui->powerColourScaleMin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_powerColourScaleMin_valueChanged);
     QObject::connect(ui->powerColourScaleMax, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &RadioAstronomyGUI::on_powerColourScaleMax_valueChanged);

--- a/plugins/feature/startracker/startracker.cpp
+++ b/plugins/feature/startracker/startracker.cpp
@@ -402,8 +402,8 @@ void StarTracker::webapiFormatFeatureSettings(
     response.getStarTrackerSettings()->setElevation(settings.m_el);
     response.getStarTrackerSettings()->setL(settings.m_l);
     response.getStarTrackerSettings()->setB(settings.m_b);
-    response.getStarTrackerSettings()->setAzimuthOffset(settings.m_azOffset);
-    response.getStarTrackerSettings()->setElevationOffset(settings.m_elOffset);
+    response.getStarTrackerSettings()->setAzimuthOffset(settings.m_azimuthOffset);
+    response.getStarTrackerSettings()->setElevationOffset(settings.m_elevationOffset);
 
     if (settings.m_rollupState)
     {
@@ -507,10 +507,10 @@ void StarTracker::webapiUpdateFeatureSettings(
         settings.m_b = response.getStarTrackerSettings()->getB();
     }
     if (featureSettingsKeys.contains("azimuthOffset")) {
-        settings.m_azOffset = response.getStarTrackerSettings()->getAzimuthOffset();
+        settings.m_azimuthOffset = response.getStarTrackerSettings()->getAzimuthOffset();
     }
     if (featureSettingsKeys.contains("elevationOffset")) {
-        settings.m_elOffset = response.getStarTrackerSettings()->getElevationOffset();
+        settings.m_elevationOffset = response.getStarTrackerSettings()->getElevationOffset();
     }
     if (settings.m_rollupState && featureSettingsKeys.contains("rollupState")) {
         settings.m_rollupState->updateFrom(featureSettingsKeys, response.getStarTrackerSettings()->getRollupState());
@@ -595,10 +595,10 @@ void StarTracker::webapiReverseSendSettings(const QList<QString>& featureSetting
         swgStarTrackerSettings->setB(settings.m_b);
     }
     if (featureSettingsKeys.contains("azimuthOffset") || force) {
-        swgStarTrackerSettings->setAzimuthOffset(settings.m_azOffset);
+        swgStarTrackerSettings->setAzimuthOffset(settings.m_azimuthOffset);
     }
     if (featureSettingsKeys.contains("elevationOffset") || force) {
-        swgStarTrackerSettings->setElevationOffset(settings.m_elOffset);
+        swgStarTrackerSettings->setElevationOffset(settings.m_elevationOffset);
     }
 
     QString channelSettingsURL = QString("http://%1:%2/sdrangel/featureset/%3/feature/%4/settings")

--- a/plugins/feature/startracker/startrackergui.cpp
+++ b/plugins/feature/startracker/startrackergui.cpp
@@ -432,8 +432,8 @@ void StarTrackerGUI::displaySettings()
     ui->elevation->setUnits((DMSSpinBox::DisplayUnits)m_settings.m_azElUnits);
     ui->galacticLatitude->setUnits((DMSSpinBox::DisplayUnits)m_settings.m_azElUnits);
     ui->galacticLongitude->setUnits((DMSSpinBox::DisplayUnits)m_settings.m_azElUnits);
-    ui->azimuthOffset->setValue(m_settings.m_azOffset);
-    ui->elevationOffset->setValue(m_settings.m_elOffset);
+    ui->azimuthOffset->setValue(m_settings.m_azimuthOffset);
+    ui->elevationOffset->setValue(m_settings.m_elevationOffset);
 
     if (m_settings.m_target == "Custom RA/Dec")
     {
@@ -578,16 +578,16 @@ void StarTrackerGUI::on_elevation_valueChanged(double value)
 
 void StarTrackerGUI::on_azimuthOffset_valueChanged(double value)
 {
-    m_settings.m_azOffset = value;
-    m_settingsKeys.append("azOffset");
+    m_settings.m_azimuthOffset = value;
+    m_settingsKeys.append("azimuthOffset");
     applySettings();
     plotChart();
 }
 
 void StarTrackerGUI::on_elevationOffset_valueChanged(double value)
 {
-    m_settings.m_elOffset = value;
-    m_settingsKeys.append("elOffset");
+    m_settings.m_elevationOffset = value;
+    m_settingsKeys.append("elevationOffset");
     applySettings();
     plotChart();
 }

--- a/plugins/feature/startracker/startrackersettings.cpp
+++ b/plugins/feature/startracker/startrackersettings.cpp
@@ -75,11 +75,11 @@ void StarTrackerSettings::resetToDefaults()
     m_el = 0.0;
     m_l = 0.0;
     m_b = 0.0;
-    m_azOffset = 0.0;
-    m_elOffset = 0.0;
     m_link = false;
     m_owmAPIKey = "";
     m_weatherUpdatePeriod = 60;
+    m_azimuthOffset = 0.0;
+    m_elevationOffset = 0.0;
     m_drawSunOnSkyTempChart = true;
     m_drawMoonOnSkyTempChart = true;
     m_workspaceIndex = 0;
@@ -128,8 +128,8 @@ QByteArray StarTrackerSettings::serialize() const
     s.writeBool(37, m_link);
     s.writeString(38, m_owmAPIKey);
     s.writeS32(39, m_weatherUpdatePeriod);
-    s.writeDouble(40, m_azOffset);
-    s.writeDouble(41, m_elOffset);
+    s.writeDouble(40, m_azimuthOffset);
+    s.writeDouble(41, m_elevationOffset);
     s.writeBool(42, m_drawSunOnSkyTempChart);
     s.writeBool(43, m_drawMoonOnSkyTempChart);
 
@@ -214,8 +214,8 @@ bool StarTrackerSettings::deserialize(const QByteArray& data)
         d.readBool(37, &m_link, false);
         d.readString(38, &m_owmAPIKey, "");
         d.readS32(39, &m_weatherUpdatePeriod, 60);
-        d.readDouble(40, &m_azOffset, 0.0);
-        d.readDouble(41, &m_elOffset, 0.0);
+        d.readDouble(40, &m_azimuthOffset, 0.0);
+        d.readDouble(41, &m_elevationOffset, 0.0);
         d.readBool(42, &m_drawSunOnSkyTempChart, true);
         d.readBool(43, &m_drawMoonOnSkyTempChart, true);
 
@@ -281,11 +281,11 @@ void StarTrackerSettings::applySettings(const QStringList& settingsKeys, const S
     if (settingsKeys.contains("beamwidth")) {
         m_beamwidth = settings.m_beamwidth;
     }
-    if (settingsKeys.contains("enableServer")) {
-        m_enableServer = settings.m_enableServer;
-    }
     if (settingsKeys.contains("serverPort")) {
         m_serverPort = settings.m_serverPort;
+    }
+    if (settingsKeys.contains("enableServer")) {
+        m_enableServer = settings.m_enableServer;
     }
     if (settingsKeys.contains("azElUnits")) {
         m_azElUnits = settings.m_azElUnits;
@@ -350,12 +350,6 @@ void StarTrackerSettings::applySettings(const QStringList& settingsKeys, const S
     if (settingsKeys.contains("b")) {
         m_b = settings.m_b;
     }
-    if (settingsKeys.contains("azOffset")) {
-        m_azOffset = settings.m_azOffset;
-    }
-    if (settingsKeys.contains("elOffset")) {
-        m_elOffset = settings.m_elOffset;
-    }
     if (settingsKeys.contains("link")) {
         m_link = settings.m_link;
     }
@@ -364,6 +358,12 @@ void StarTrackerSettings::applySettings(const QStringList& settingsKeys, const S
     }
     if (settingsKeys.contains("weatherUpdatePeriod")) {
         m_weatherUpdatePeriod = settings.m_weatherUpdatePeriod;
+    }
+    if (settingsKeys.contains("azimuthOffset")) {
+        m_azimuthOffset = settings.m_azimuthOffset;
+    }
+    if (settingsKeys.contains("elevationOffset")) {
+        m_elevationOffset = settings.m_elevationOffset;
     }
     if (settingsKeys.contains("drawSunOnSkyTempChart")) {
         m_drawSunOnSkyTempChart = settings.m_drawSunOnSkyTempChart;
@@ -422,11 +422,11 @@ QString StarTrackerSettings::getDebugString(const QStringList& settingsKeys, boo
     if (settingsKeys.contains("beamwidth") || force) {
         ostr << " m_beamwidth: " << m_beamwidth;
     }
-    if (settingsKeys.contains("enableServer") || force) {
-        ostr << " m_enableServer: " << m_enableServer;
-    }
     if (settingsKeys.contains("serverPort") || force) {
         ostr << " m_serverPort: " << m_serverPort;
+    }
+    if (settingsKeys.contains("enableServer") || force) {
+        ostr << " m_enableServer: " << m_enableServer;
     }
     if (settingsKeys.contains("azElUnits") || force) {
         ostr << " m_azElUnits: " << m_azElUnits;
@@ -488,12 +488,6 @@ QString StarTrackerSettings::getDebugString(const QStringList& settingsKeys, boo
     if (settingsKeys.contains("b") || force) {
         ostr << " m_b: " << m_b;
     }
-    if (settingsKeys.contains("azOffset") || force) {
-        ostr << " m_azOffset: " << m_azOffset;
-    }
-    if (settingsKeys.contains("elOffset") || force) {
-        ostr << " m_elOffset: " << m_elOffset;
-    }
     if (settingsKeys.contains("link") || force) {
         ostr << " m_link: " << m_link;
     }
@@ -502,6 +496,12 @@ QString StarTrackerSettings::getDebugString(const QStringList& settingsKeys, boo
     }
     if (settingsKeys.contains("weatherUpdatePeriod") || force) {
         ostr << " m_weatherUpdatePeriod: " << m_weatherUpdatePeriod;
+    }
+    if (settingsKeys.contains("azimuthOffset") || force) {
+        ostr << " m_azimuthOffset: " << m_azimuthOffset;
+    }
+    if (settingsKeys.contains("elevationOffset") || force) {
+        ostr << " m_elevationOffset: " << m_elevationOffset;
     }
     if (settingsKeys.contains("drawSunOnSkyTempChart") || force) {
         ostr << " m_drawSunOnSkyTempChart: " << m_drawSunOnSkyTempChart;
@@ -515,3 +515,4 @@ QString StarTrackerSettings::getDebugString(const QStringList& settingsKeys, boo
 
     return QString(ostr.str().c_str());
 }
+

--- a/plugins/feature/startracker/startrackersettings.h
+++ b/plugins/feature/startracker/startrackersettings.h
@@ -67,8 +67,8 @@ struct StarTrackerSettings
     bool m_link;                // Link settings to Radio Astronomy plugin
     QString m_owmAPIKey;        // API key for openweathermap.org
     int m_weatherUpdatePeriod;  // Time in minutes between weather updates
-    double m_azOffset;
-    double m_elOffset;
+    double m_azimuthOffset;
+    double m_elevationOffset;
     bool m_drawSunOnSkyTempChart;
     bool m_drawMoonOnSkyTempChart;
     Serializable *m_rollupState;

--- a/plugins/feature/startracker/startrackerworker.cpp
+++ b/plugins/feature/startracker/startrackerworker.cpp
@@ -145,8 +145,8 @@ void StarTrackerWorker::applySettings(const StarTrackerSettings& settings, const
         || settingsKeys.contains("el")
         || settingsKeys.contains("l")
         || settingsKeys.contains("b")
-        || settingsKeys.contains("azOffset")
-        || settingsKeys.contains("elOffset")
+        || settingsKeys.contains("azimuthOffset")
+        || settingsKeys.contains("elevationOffset")
         || force)
     {
         // Recalculate immediately
@@ -563,8 +563,8 @@ void StarTrackerWorker::update()
     }
 
     // Add user-adjustment
-    aa.alt += m_settings.m_elOffset;
-    aa.az += m_settings.m_azOffset;
+    aa.alt += m_settings.m_elevationOffset;
+    aa.az += m_settings.m_azimuthOffset;
 
     // Send to GUI
     if (getMessageQueueToGUI())


### PR DESCRIPTION
This patch fixes a couple of settings keys in the Star Tracker. (Similar to #1642)
It also fixes a few missing connections in the Radio Astronomy plugin and scans for Features when GUI is created.
