### PR TITLE
Fix Qt6 compilation

### DIFF
--- a/plugins/channelrx/demodnavtex/navtexdemodsink.cpp
+++ b/plugins/channelrx/demodnavtex/navtexdemodsink.cpp
@@ -355,7 +355,7 @@ void NavtexDemodSink::receiveBit(bool bit)
                         getMessageQueueToChannel()->push(msg);
                     }
                     // Add character to message buffer
-                    m_messageBuffer.append(c);
+                    m_messageBuffer.append(QChar(c));
                 }
                 else
                 {

--- a/plugins/channelrx/heatmap/heatmapgui.cpp
+++ b/plugins/channelrx/heatmap/heatmapgui.cpp
@@ -695,7 +695,7 @@ void HeatMapGUI::displaySettings()
 
     value = (int)std::log10(m_settings.m_sampleRate);
     ui->sampleRate->setValue(value);
-    int idx = std::min(std::max(0, value-2), m_sampleRateTexts.size() - 1);
+    int idx = std::min(std::max(0, value-2), (int)m_sampleRateTexts.size() - 1);
     ui->sampleRateText->setText(m_sampleRateTexts[idx]);
     ui->averagePeriod->setMinimum(std::max(1, static_cast<int> (m_averagePeriodTexts.size()) - value));
 

--- a/sdrbase/maincore.cpp
+++ b/sdrbase/maincore.cpp
@@ -358,10 +358,12 @@ void MainCore::initPosition()
     if (m_positionSource)
     {
         connect(m_positionSource, &QGeoPositionInfoSource::positionUpdated, this, &MainCore::positionUpdated);
-        #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         connect(m_positionSource, &QGeoPositionInfoSource::updateTimeout, this, &MainCore::positionUpdateTimeout);
-        #endif
         connect(m_positionSource, qOverload<QGeoPositionInfoSource::Error>(&QGeoPositionInfoSource::error), this, &MainCore::positionError);
+#else
+        connect(m_positionSource, &QGeoPositionInfoSource::errorOccurred, this, &MainCore::positionError);
+#endif
         m_position = m_positionSource->lastKnownPosition();
         m_positionSource->setUpdateInterval(1000);
         m_positionSource->startUpdates();


### PR DESCRIPTION
Fix compilation with Qt 6.4 - Fixes #1625

Note using Qt 6.5.0 fails to build on Windows due to this Qt bug: https://bugreports.qt.io/browse/QTBUG-112204?jql=text%20~%20%22lconvert%20access%20is%20denied%22