### PR TITLE
AIS Demod: Calculate time slot used for messages.

### DIFF
--- a/plugins/channelrx/demodais/aisdemod.cpp
+++ b/plugins/channelrx/demodais/aisdemod.cpp
@@ -222,7 +222,8 @@ bool AISDemod::handleMessage(const Message& cmd)
                 << QString("%1").arg(ais->m_mmsi, 9, 10, QChar('0')) << ","
                 << ais->getType() << ","
                 << "\"" << ais->toString() << "\"" << ","
-                << "\"" << ais->toNMEA() << "\"" << "\n";
+                << "\"" << ais->toNMEA() << "\"" << ","
+                << report.getSlot() << "\n";
 
             delete ais;
         }
@@ -354,7 +355,7 @@ void AISDemod::applySettings(const AISDemodSettings& settings, bool force)
                 if (newFile)
                 {
                     // Write header
-                    m_logStream << "Date,Time,Data,MMSI,Type,Message,NMEA\n";
+                    m_logStream << "Date,Time,Data,MMSI,Type,Message,NMEA,Slot\n";
                 }
             }
             else

--- a/plugins/channelrx/demodais/aisdemod.h
+++ b/plugins/channelrx/demodais/aisdemod.h
@@ -72,20 +72,23 @@ public:
     public:
         QByteArray getMessage() const { return m_message; }
         QDateTime getDateTime() const { return m_dateTime; }
+        int getSlot() const { return m_slot; }
 
-        static MsgMessage* create(QByteArray message)
+        static MsgMessage* create(QByteArray message, QDateTime dateTime, int slot)
         {
-            return new MsgMessage(message, QDateTime::currentDateTime());
+            return new MsgMessage(message, dateTime, slot);
         }
 
     private:
         QByteArray m_message;
         QDateTime m_dateTime;
+        int m_slot;
 
-        MsgMessage(QByteArray message, QDateTime dateTime) :
+        MsgMessage(QByteArray message, QDateTime dateTime, int slot) :
             Message(),
             m_message(message),
-            m_dateTime(dateTime)
+            m_dateTime(dateTime),
+            m_slot(slot)
         {
         }
     };

--- a/plugins/channelrx/demodais/aisdemodgui.h
+++ b/plugins/channelrx/demodais/aisdemodgui.h
@@ -98,7 +98,7 @@ private:
     void blockApplySettings(bool block);
     void applySettings(bool force = false);
     void displaySettings();
-    void messageReceived(const QByteArray& message, const QDateTime& dateTime);
+    void messageReceived(const QByteArray& message, const QDateTime& dateTime, int slot);
     bool handleMessage(const Message& message);
     void makeUIConnections();
     void updateAbsoluteCenterFrequency();
@@ -116,7 +116,8 @@ private:
         MESSAGE_COL_TYPE,
         MESSAGE_COL_DATA,
         MESSAGE_COL_NMEA,
-        MESSAGE_COL_HEX
+        MESSAGE_COL_HEX,
+        MESSAGE_COL_SLOT
     };
 
 private slots:

--- a/plugins/channelrx/demodais/aisdemodgui.ui
+++ b/plugins/channelrx/demodais/aisdemodgui.ui
@@ -712,6 +712,14 @@
         <string>Packet data as hex</string>
        </property>
       </column>
+      <column>
+       <property name="text">
+        <string>Slot</string>
+       </property>
+       <property name="toolTip">
+        <string>Time slot</string>
+       </property>
+      </column>
      </widget>
     </item>
    </layout>
@@ -918,26 +926,26 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
+  </customwidget>
+  <customwidget>
    <class>RollupContents</class>
    <extends>QWidget</extends>
    <header>gui/rollupcontents.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ButtonSwitch</class>
-   <extends>QToolButton</extends>
-   <header>gui/buttonswitch.h</header>
+   <class>ValueDialZ</class>
+   <extends>QWidget</extends>
+   <header>gui/valuedialz.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>LevelMeterSignalDB</class>
    <extends>QWidget</extends>
    <header>gui/levelmeter.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ValueDialZ</class>
-   <extends>QWidget</extends>
-   <header>gui/valuedialz.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/plugins/channelrx/demodais/aisdemodsettings.h
+++ b/plugins/channelrx/demodais/aisdemodsettings.h
@@ -27,7 +27,7 @@
 class Serializable;
 
 // Number of columns in the tables
-#define AISDEMOD_MESSAGE_COLUMNS 7
+#define AISDEMOD_MESSAGE_COLUMNS 8
 
 struct AISDemodSettings
 {

--- a/plugins/channelrx/demodais/readme.md
+++ b/plugins/channelrx/demodais/readme.md
@@ -95,5 +95,6 @@ The received messages table displays information about each AIS message received
 * Data - A textual decode of the message displaying the most interesting fields.
 * NMEA - The message in NMEA format.
 * Hex - The message in hex format.
+* Slot - Time slot (0-2249). Due to SDR to SDRangel latency being unknown, this is likely to have some offset.
 
 Right clicking on the table header allows you to select which columns to show. The columns can be reorderd by left clicking and dragging the column header. Right clicking on an item in the table allows you to copy the value to the clipboard.


### PR DESCRIPTION
This PR addresses a request on the forum to display the time slot used by AIS transmissions.

Note that because SDRangel doesn't currently know the SDR to demod latency, this may not be accurate in terms of absolute slot number.