### PR TITLE
aaroniartsainput: Starting with build 12830 the stream header will contain the field 'sampleFrequency' for accurate bw calculation

### DIFF
--- a/plugins/samplesource/aaroniartsainput/aaroniartsainputworker.cpp
+++ b/plugins/samplesource/aaroniartsainput/aaroniartsainputworker.cpp
@@ -311,7 +311,7 @@ void AaroniaRTSAInputWorker::onReadyRead()
                     // qDebug() << jdoc.toJson();
                     quint64 endFreq = jdoc["endFrequency"].toDouble();
                     quint64 startFreq = jdoc["startFrequency"].toDouble();
-                    int bw = endFreq - startFreq;
+                    int bw = jdoc["sampleFrequency"].toInt();
                     quint64 midFreq = (endFreq + startFreq) / 2;
 
                     if ((bw != m_sampleRate) || (midFreq != m_centerFrequency))


### PR DESCRIPTION
aaroniartsainput: Starting with build 12830 the stream header will contain the field 'sampleFrequency' for accurate bw calculation