### PR TITLE
Fix cppcheck error and compiler warning

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -2165,7 +2165,7 @@ void ADSBDemodGUI::decodeCommB(const QByteArray data, const QDateTime dateTime, 
         float longitude = longitudeFix * (360.0f / 1048576.0f);
 
         bool positionInconsistent = !aircraft->m_positionValid
-                                || (positionValid && aircraft->m_positionValid && ((abs(latitude - aircraft->m_latitude > 2.0f)) || (abs(longitude - aircraft->m_longitude) > 2.0f)))
+                                || (positionValid && aircraft->m_positionValid && ((abs(latitude - aircraft->m_latitude) > 2.0f) || (abs(longitude - aircraft->m_longitude) > 2.0f)))
                                 || (!positionValid && ((latitudeFix != 0) || (longitudeFix != 0)));
 
         int pressureAltFix = ((data[9] & 0x7f) << 8) | (data[10] & 0xff);

--- a/plugins/channelrx/demodam/amdemodsink.cpp
+++ b/plugins/channelrx/demodam/amdemodsink.cpp
@@ -203,7 +203,7 @@ void AMDemodSink::processOneSample(Complex &ci)
 
     if (m_audioBufferFill >= m_audioBuffer.size())
     {
-        std:;size_t res = m_audioFifo.write((const quint8*)&m_audioBuffer[0], std::min(m_audioBufferFill, m_audioBuffer.size()));
+        std::size_t res = m_audioFifo.write((const quint8*)&m_audioBuffer[0], std::min(m_audioBufferFill, m_audioBuffer.size()));
 
         if (res != m_audioBufferFill)
         {


### PR DESCRIPTION
This PR:
moves the check `> 2.0f` outside of the round brackets to fix an error found with cppcheck:
> Invalid abs() argument nr 1. A non-boolean value is required. [invalidFunctionArgBool]

replace a stray semicolon with a colon to fix a compiler warning:
> warning: label ‘std’ defined but not used [-Wunused-label]