### PR TITLE
Remove extra open round brackets

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -148,7 +148,7 @@ static int runQtApplication(int argc, char* argv[], qtwebapp::LoggerWithFile *lo
 #else
     qInfo("%s %s Qt %s %db DSP Rx:%db Tx:%db PID: %lld",
             qPrintable(qApp->applicationName()),
-            qPrintable((qApp->applicationVersion()),
+            qPrintable(qApp->applicationVersion()),
             qPrintable(QString(QT_VERSION_STR)),
             QT_POINTER_SIZE*8,
             SDR_RX_SAMP_SZ,

--- a/appbench/main.cpp
+++ b/appbench/main.cpp
@@ -87,7 +87,7 @@ static int runQtApplication(int argc, char* argv[], qtwebapp::LoggerWithFile *lo
 #else
     qInfo("%s %s Qt %s %db DSP Rx:%db Tx:%db PID %lld",
           qPrintable(QCoreApplication::applicationName()),
-          qPrintable((QCoreApplication::>applicationVersion()),
+          qPrintable(QCoreApplication::>applicationVersion()),
                      qPrintable(QString(QT_VERSION_STR)),
                      QT_POINTER_SIZE*8,
                      SDR_RX_SAMP_SZ,

--- a/appsrv/main.cpp
+++ b/appsrv/main.cpp
@@ -84,7 +84,7 @@ static int runQtApplication(int argc, char* argv[], qtwebapp::LoggerWithFile *lo
 #else
     qInfo("%s %s Qt %s %db DSP Rx:%db Tx:%db PID %lld",
           qPrintable(QCoreApplication::applicationName()),
-          qPrintable((QCoreApplication::>applicationVersion()),
+          qPrintable(QCoreApplication::>applicationVersion()),
                      qPrintable(QString(QT_VERSION_STR)),
                      QT_POINTER_SIZE*8,
                      SDR_RX_SAMP_SZ,


### PR DESCRIPTION
Fixes errors found by cppcheck:
app/main.cpp:149:10: error: Unmatched '('. Configuration: ''. [syntaxError]
appsrv/main.cpp:85:10: error: Unmatched '('. Configuration: ''. [syntaxError]
appbench/main.cpp:88:10: error: Unmatched '('. Configuration: ''. [syntaxError]