### PR TITLE
Fix spelling

### DIFF
--- a/plugins/channelrx/demoddab/readme.md
+++ b/plugins/channelrx/demoddab/readme.md
@@ -79,7 +79,7 @@ If you are hearing dropouts in audio, try adjusting your antenna in order to imp
 
 <h3>Transmitter</h3>
 
-Displays the TII (Transmitter Identification Information) main and sub IDs in hexidecimal, which can identify which transmitter the DAB signal is being primarily received from.
+Displays the TII (Transmitter Identification Information) main and sub IDs in hexadecimal, which can identify which transmitter the DAB signal is being primarily received from.
 Pressing the "Find Transmitter on Map" button will attempt to locate the transmitter with the same IDs and Ensemble name on the [Map](../../feature/map/readme.md) feature.
 
 <h2>Attribution</h2>

--- a/plugins/channelrx/demodft8/readme.md
+++ b/plugins/channelrx/demodft8/readme.md
@@ -149,13 +149,13 @@ Example:
 ---- 1 ------    --2---           -3-  -4- --5- --6--- --7- --8-
 </pre></code>
 
-  - **1**: Date and time of decoder slot in YYMMDD_HHmmss fomat
+  - **1**: Date and time of decoder slot in YYMMDD_HHmmss format
   - **2**: Base frequency in MHz
   - **3**: SNR in 2.5 kHz bandwidth
   - **4**: Message start delay in seconds from standard sequence start
   - **5**: Message carrier shift from base frequency in Hz
-  - **6**: First callsign area. May contain spaces (ex: "CQ DX"). Note that for messages types 0.1 and 5 it is slighlty different from the standard (See C.10)
-  - **7**: Second callsign area and is always a callsign. This might be slighlty different from the standard (see above)
+  - **6**: First callsign area. May contain spaces (ex: "CQ DX"). Note that for messages types 0.1 and 5 it is slightly different from the standard (See C.10)
+  - **7**: Second callsign area and is always a callsign. This might be slightly different from the standard (see above)
   - **8**: Locator area maybe a 4 or 6 digit locator, a report, acknowledgement (RRR) or a greetings (RR73, 73)
 
 The splitting and naming of files is different from WSJT-X scheme.
@@ -192,7 +192,7 @@ Displays the received messages in a table which columns are the following:
     - **2**: European VHF (4 char locator) minor change to standard message above
     - **3**: Russian RTTY
     - **4**: Non standard call
-    - **5**: European VHF (6 char locator). The report + QSO number is appended to first call area not to pollute the second call area which contains only a callsign, This is slightly diffrent from the standard.
+    - **5**: European VHF (6 char locator). The report + QSO number is appended to first call area not to pollute the second call area which contains only a callsign, This is slightly different from the standard.
   - **P**: LDPC decoder pass index that was successful (0 to 2) as there are 3 passes
   - **OKb**: Number of correct bits in the message before FEC correction. Maximum is 174 in which case no FEC would be needed.
   - **dt**: Message start time shift in seconds from standard FT8 time slot

--- a/plugins/channelrx/demodils/readme.md
+++ b/plugins/channelrx/demodils/readme.md
@@ -63,7 +63,7 @@ bandwidth should be set wide enough to cover all signals (E.g. ~16kHz).
 
 <h3>7: Ident</h3>
 
-Specifies the identifer for the ILS. This is typically 3 or 4 characters. The drop-down contains a number of identifiers for ILSs at
+Specifies the identifier for the ILS. This is typically 3 or 4 characters. The drop-down contains a number of identifiers for ILSs at
 airports within the South East of the UK. Selecting one of these will automatically fill in the other fields with details of the ILS.
 The ILS identifier is broadcast as Morse code at an offset of 1020Hz from the ILS carrier. This is demodulated and displayed below the CDI.
 
@@ -190,7 +190,7 @@ Full scale deviation is 2.5 degrees (centre to edge) for LOC and 0.35 degrees fo
 Pilots would fly towards the diamond. So if the diamond is left-of-center, then the aircraft should turn to the left.
 
 The decoded Morse code identifier will be displayed underneath the CDI in both Morse and letters.
-If will be displayed in white if it matches the specified identifer (7) or red if not.
+If will be displayed in white if it matches the specified identifier (7) or red if not.
 
 <h3>36: Demodulated Spectrum</h3>
 
@@ -222,7 +222,7 @@ adjust the setting until the centre of the localizer (the course line) lines up 
 
 The ILS Reference Datum Height (RDH) to be set in (15) can often be found in the AIP, and is typically 15m (50ft).
 
-The course width (16) is ocassionaly specified in the AIP.
+The course width (16) is occasionally specified in the AIP.
 
 If not in the AIP, it may be possible to calculate it from an SBAS FAS Data Block if available:
 * Calculate the distance between LTP (Landing Threshold Point) and FPAP (Fight Path Alignment Point) from

--- a/plugins/channelrx/demodnavtex/readme.md
+++ b/plugins/channelrx/demodnavtex/readme.md
@@ -34,7 +34,7 @@ Average total power in dB relative to a +/- 1.0 amplitude signal received in the
 <h3>4: Navarea</h3>
 
 Specifies the geographical area in which the receiver is in. This enables the plugin to decode transmitter station identifiers, and display which transmitter the current transmission timeslot is assigned to (5).
-Note that with good propagation conditions, it is possible to receive messages from another area, so the station indicated in the message table (17) should be checked against the location given in the recevied message text.
+Note that with good propagation conditions, it is possible to receive messages from another area, so the station indicated in the message table (17) should be checked against the location given in the received message text.
 
 <h3>5: TX</h3>
 
@@ -90,7 +90,7 @@ The received messages table displays the contents of the messages that have been
 
 * Date - Date the message was received.
 * Time - Time the message was received.
-* SID - Station identifer of the transmitting station.
+* SID - Station identifier of the transmitting station.
 * Station - SID decoded according to the currently selected navarea (4).
 * TID - Message type identifier.
 * MID - Message identifier.

--- a/plugins/channelrx/heatmap/readme.md
+++ b/plugins/channelrx/heatmap/readme.md
@@ -9,11 +9,11 @@ To view the Heat Map visually, the [Map Feature](../../feature/map/readme.md) sh
 To record data for a heat map, a GPS is required, and Preferences > My Position should have "Auto-update from GPS" enabled.
 
 On Windows/Linux/Mac, a GPS supporting NMEA via a serial port at 4800 baud is required.
-The COM port / serial device should be specfied via the QT_NMEA_SERIAL_PORT environment variable before SDRangel is started.
+The COM port / serial device should be specified via the QT_NMEA_SERIAL_PORT environment variable before SDRangel is started.
 (E.g. on Linux: export QT_NMEA_SERIAL_PORT=/dev/ttyACM0 or /dev/ttyUSB0 on Windows: Set QT_NMEA_SERIAL_PORT=COM5 via Control Panel)
 This requires the Qt serialnmea plugin, which is not available in the libqt5positioning5-plugins package on Debian / Ubuntu.
 It can be downloaded for Ubuntu/x64 from http://sdrangel.org/downloads/libqtposition_serialnmea.so and should be installed in usr/lib/x86_64-linux-gnu/qt5/plugins/position/.
-This custom build of the pluging also allows setting the baud rate via the QT_NMEA_SERIAL_BAUD_RATE option (which is not supported on Windows nor Mac).
+This custom build of the plugin also allows setting the baud rate via the QT_NMEA_SERIAL_BAUD_RATE option (which is not supported on Windows nor Mac).
 
 On Android, GPS setup should be automatic. GPS position updates may stop on Android when the screen is off. To keep the screen on, press the View > Keep Screen On menu.
 
@@ -69,7 +69,7 @@ Specifies the latitude of the transmitter in decimal degrees, North positive.
 
 <h3>11: Transmitter Longitude</h3>
 
-Specifies the longitude of the transmitter in decimal degrees, East postive.
+Specifies the longitude of the transmitter in decimal degrees, East positive.
 
 <h3>12: Transmitter Power</h3>
 


### PR DESCRIPTION
Fixed with:
find . -name '*.md' -exec codespell --ignore-words-list=cach,doas,ehr,inout,lits,nd,verry --summary --write-changes {} \+

and then running the same command with --interactive=2: find . -name '*.md' -exec codespell --ignore-words-list=cach,doas,ehr,inout,lits,nd,verry --summary --write-changes --interactive=2 {} \+