### PR TITLE
Fix QFileDialog filters to work with non-native file dialog.

### DIFF
--- a/plugins/channelrx/demodapt/aptdemodgui.cpp
+++ b/plugins/channelrx/demodapt/aptdemodgui.cpp
@@ -505,7 +505,7 @@ void APTDemodGUI::on_showSettings_clicked()
 // Save image to disk
 void APTDemodGUI::on_saveImage_clicked()
 {
-    QFileDialog fileDialog(nullptr, "Select file to save image to", "", "*.png;*.jpg;*.jpeg;*.bmp;*.ppm;*.xbm;*.xpm");
+    QFileDialog fileDialog(nullptr, "Select file to save image to", "", "*.png *.jpg *.jpeg *.bmp *.ppm *.xbm *.xpm");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/demodapt/aptdemodsettingsdialog.cpp
+++ b/plugins/channelrx/demodapt/aptdemodsettingsdialog.cpp
@@ -100,7 +100,7 @@ void APTDemodSettingsDialog::on_autoSave_clicked(bool checked)
 
 void APTDemodSettingsDialog::on_addPalette_clicked()
 {
-    QFileDialog fileDialog(nullptr, "Select palette files", "", "*.png;*.bmp");
+    QFileDialog fileDialog(nullptr, "Select palette files", "", "*.png *.bmp");
     fileDialog.setFileMode(QFileDialog::ExistingFiles);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/heatmap/heatmapgui.cpp
+++ b/plugins/channelrx/heatmap/heatmapgui.cpp
@@ -390,7 +390,7 @@ void HeatMapGUI::on_readCSV_clicked()
 void HeatMapGUI::on_writeImage_clicked()
 {
     m_imageFileDialog.setAcceptMode(QFileDialog::AcceptSave);
-    m_imageFileDialog.setNameFilter("*.png;*.jpg;*.jpeg;*.bmp;*.ppm;*.xbm;*.xpm");
+    m_imageFileDialog.setNameFilter("*.png *.jpg *.jpeg *.bmp *.ppm *.xbm *.xpm");
     if (m_imageFileDialog.exec())
     {
         QStringList fileNames = m_imageFileDialog.selectedFiles();

--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -5038,7 +5038,7 @@ void RadioAstronomyGUI::on_sunOrbitalVelocity_valueChanged(double value)
 
 void RadioAstronomyGUI::on_savePowerChartImage_clicked()
 {
-    QFileDialog fileDialog(nullptr, "Select file to save image to", "", "*.png;*.jpg;*.jpeg;*.bmp;*.ppm;*.xbm;*.xpm");
+    QFileDialog fileDialog(nullptr, "Select file to save image to", "", "*.png *.jpg *.jpeg *.bmp *.ppm *.xbm *.xpm");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {
@@ -5058,7 +5058,7 @@ void RadioAstronomyGUI::on_savePowerChartImage_clicked()
 
 void RadioAstronomyGUI::on_saveSpectrumChartImage_clicked()
 {
-    QFileDialog fileDialog(nullptr, "Select file to save image to", "", "*.png;*.jpg;*.jpeg;*.bmp;*.ppm;*.xbm;*.xpm");
+    QFileDialog fileDialog(nullptr, "Select file to save image to", "", "*.png *.jpg *.jpeg *.bmp *.ppm *.xbm *.xpm");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {


### PR DESCRIPTION
Filter needs to be space separated, not semicolon separated.

Fixes #1681.