### PR TITLE
Fix/typos

### DIFF
--- a/plugins/channelrx/demodam/readme.md
+++ b/plugins/channelrx/demodam/readme.md
@@ -32,7 +32,7 @@ Average total power in dB relative to a +/- 1.0 amplitude signal received in the
 
 Left click on this button to toggle audio mute for this channel. The button will light up in green if the squelch is open. This helps identifying which channels are active in a multi-channel configuration.
 
-If you right click on it it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
+If you right click on it, it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
 
 <h3>6: Level meter in dB</h3>
 

--- a/plugins/channelrx/demoddab/readme.md
+++ b/plugins/channelrx/demoddab/readme.md
@@ -24,7 +24,7 @@ Average total power in dB relative to a +/- 1.0 amplitude signal received in the
 
 Left click on this button to toggle audio mute for this channel.
 
-If you right click on it it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
+If you right click on it, it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
 
 <h3>4: RF level meter in dB</h3>
 

--- a/plugins/channelrx/demoddsd/readme.md
+++ b/plugins/channelrx/demoddsd/readme.md
@@ -107,7 +107,7 @@ Use this switch to toggle high-pass filter on the audio
 
 Left click to mute/unmute audio. This button lights in green when the squelch opens.
 
-If you right click on it it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
+If you right click on it, it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
 
 <h3>A.12: Format specific status display</h3>
 

--- a/plugins/channelrx/demodm17/readme.md
+++ b/plugins/channelrx/demodm17/readme.md
@@ -90,7 +90,7 @@ Use this switch to toggle high-pass filter on the audio
 
 Left click to mute/unmute audio. This button lights in green when the squelch opens.
 
-If you right click on it it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
+If you right click on it, it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
 
 <h2>B: Digital common</h2>
 

--- a/plugins/channelrx/demodnfm/readme.md
+++ b/plugins/channelrx/demodnfm/readme.md
@@ -36,7 +36,7 @@ Toggle a 300 Hz cutoff high pass filter on audio to cut-off CTCSS frequencies. I
 
 Left click on this button to toggle audio mute for this channel. The button will light up in green if the squelch is open. This helps identifying which channels are active in a multi-channel configuration.
 
-If you right click on it it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
+If you right click on it, it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
 
 
 <h3>A: RF parameters</h3>

--- a/plugins/channelrx/demodvor/readme.md
+++ b/plugins/channelrx/demodvor/readme.md
@@ -40,7 +40,7 @@ Average total power in dB relative to a +/- 1.0 amplitude signal received in the
 
 Left click on this button to toggle audio mute for this channel. The button will light up in green if the squelch is open. This helps identifying which channels are active in a multi-channel configuration.
 
-If you right click on it it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
+If you right click on it, it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
 
 <h3>5: Morse ident threshold</h3>
 

--- a/plugins/channelrx/demodvormc/readme.md
+++ b/plugins/channelrx/demodvormc/readme.md
@@ -34,7 +34,7 @@ Average total power in dB relative to a +/- 1.0 amplitude signal received in the
 
 Left click on this button to toggle audio mute for this channel. The button will light up in green if the squelch is open. This helps identifying which channels are active in a multi-channel configuration.
 
-If you right click on it it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
+If you right click on it, it will open a dialog to select the audio output device. See [audio management documentation](../../../sdrgui/audio.md) for details.
 
 <h3>4: Download VOR Database</h3>
 

--- a/plugins/channelrx/demodvormc/readme.md
+++ b/plugins/channelrx/demodvormc/readme.md
@@ -10,7 +10,7 @@ VORs also transmit a Morse code ident signal at a 1020Hz offset. This is a 2 or 
 
 Some VORs also transmit an AM voice identification or information signal between 300-3kHz.
 
-This plugin can demodulate all four signals from multiple VORs simultaneously, allowing your position to be determined and plotted on a map. It can also demodulate the Morse code ident signal and and check they are correct for each VOR. The Morse code ident and any voice signal will also be heard as audio.
+This plugin can demodulate all four signals from multiple VORs simultaneously, allowing your position to be determined and plotted on a map. It can also demodulate the Morse code ident signal and check they are correct for each VOR. The Morse code ident and any voice signal will also be heard as audio.
 
 Note that for aircraft, there is typically a direct line-of-sight to the VOR. This is unlikely to be the case when using an SDR on the ground. To get good results, ideally you want to be on a nice high hill or close to the VOR.
 

--- a/plugins/feature/gs232controller/readme.md
+++ b/plugins/feature/gs232controller/readme.md
@@ -34,7 +34,7 @@ For example, this allows an aircraft to be tracked, by setting the Source to the
 
 <h3>5: Source</h3>
 
-Specify the SDRangel Channel or Feature that that will control the target azimuth and elevation values, when Track (4) is checked.
+Specify the SDRangel Channel or Feature that will control the target azimuth and elevation values, when Track (4) is checked.
 
 <h3>6: Target</h3>
 

--- a/plugins/samplemimo/bladerf2mimo/readme.md
+++ b/plugins/samplemimo/bladerf2mimo/readme.md
@@ -87,7 +87,7 @@ Use this toggle button to switch the sample rate input next (15) between device 
 
 This controls the sample rate between Host and Device in both directions. Effectively ADC and DAC run on the same sample rate.
 
-<h3>16. Baseband center frequency position relative the the BladeRF center frequency</h3>
+<h3>16. Baseband center frequency position relative to the BladeRF center frequency</h3>
 
 Possible values are:
 

--- a/plugins/samplemimo/limesdrmimo/readme.md
+++ b/plugins/samplemimo/limesdrmimo/readme.md
@@ -222,7 +222,7 @@ This label turns green when status can be obtained from the current stream. Usua
 
 <h3>13. Stream global (all Rx or all Tx) throughput in MB/s</h3>
 
-This is the stream throughput in MB/s and is about 6 times the sample rate for a for a dual Rx or Tx stream. This is due to the fact that 12 bits samples are used and although they are represented as 16 bit values only 12 bits travel on the USB link.
+This is the stream throughput in MB/s and is about 6 times the sample rate for a dual Rx or Tx stream. This is due to the fact that 12 bits samples are used and although they are represented as 16 bit values only 12 bits travel on the USB link.
 
 The Rx or Tx stream is displayed depending on the side display selection (3)
 

--- a/plugins/samplemimo/metismiso/readme.md
+++ b/plugins/samplemimo/metismiso/readme.md
@@ -79,7 +79,7 @@ Note that there is no interpolation on the Tx side.
 
 <h4>8.3: Subsampling index</h4>
 
-The Red Pitaya has a LTC2185 ADC specified for a bandwidth up to 550 MHz. This lets you use the Red Pitaya receivers in subsampling mode with appropriate filtering and LNA chain as a front end. In this mode the received frequency may extend above 61.44 MHz in successive 61.44 MHz wide bands. This index corresponds to the frequency band index from 0 to 7 and let you input the frequency directly corresponding the the subsampling scheme. The band limits appear in the tooltip and are the following:
+The Red Pitaya has a LTC2185 ADC specified for a bandwidth up to 550 MHz. This lets you use the Red Pitaya receivers in subsampling mode with appropriate filtering and LNA chain as a front end. In this mode the received frequency may extend above 61.44 MHz in successive 61.44 MHz wide bands. This index corresponds to the frequency band index from 0 to 7 and let you input the frequency directly corresponding to the subsampling scheme. The band limits appear in the tooltip and are the following:
 
   - **0**: 0 to 61.44 MHz - fundamental no subsampling
   - **1**: 61.44 to 122.88 MHz

--- a/plugins/samplemimo/plutosdrmimo/readme.md
+++ b/plugins/samplemimo/plutosdrmimo/readme.md
@@ -126,7 +126,7 @@ Hardware AD9363 DC and I/Q compensation: I/Q imbalance correction.
 
 The I/Q stream from the PlutoSDR is downsampled by a power of two by software inside the plugin before being sent to the passband. Possible values are increasing powers of two: 1 (no decimation), 2, 4, 8, 16, 32, 64.
 
-<h3>14: Decimated bandpass center frequency position relative the the PlutoSDR Rx center frequency</h3>
+<h3>14: Decimated bandpass center frequency position relative to the PlutoSDR Rx center frequency</h3>
 
   - **Cen**: the decimation operation takes place around the PlutoSDR Rx center frequency Fs
   - **Inf**: the decimation operation takes place around Fs - Fc.

--- a/plugins/samplemimo/testmi/readme.md
+++ b/plugins/samplemimo/testmi/readme.md
@@ -57,7 +57,7 @@ The I/Q stream from the generator is downsampled by a power of two before being 
 
 This exercises the decimation chain.
 
-<h4>2.3: Baseband center frequency position relative the center frequency</h4>
+<h4>2.3: Baseband center frequency position relative to the center frequency</h4>
 
   - **Cen**: the decimation operation takes place around the center frequency Fs
   - **Inf**: the decimation operation takes place around Fs - Fc.

--- a/plugins/samplesink/hackrfoutput/readme.md
+++ b/plugins/samplesink/hackrfoutput/readme.md
@@ -74,7 +74,7 @@ The limits are adjusted automatically. In baseband input mode the limits are dri
 
 Use the wheels to adjust the sample rate. Left click on a digit sets the cursor position at this digit. Right click on a digit sets all digits on the right to zero. This effectively floors value at the digit position. Wheels are moved with the mousewheel while pointing at the wheel or by selecting the wheel with the left mouse click and using the keyboard arrows. Pressing shift simultaneously moves digit by 5 and pressing control moves it by 2.
 
-<h3>9: Baseband center frequency position relative the the HackRF Tx center frequency</h3>
+<h3>9: Baseband center frequency position relative to the HackRF Tx center frequency</h3>
 
   - **Cen**: the decimation operation takes place around the HackRF Tx center frequency Fs
   - **Inf**: the decimation operation takes place around Fs - Fc.

--- a/plugins/samplesink/soapysdroutput/readme.md
+++ b/plugins/samplesink/soapysdroutput/readme.md
@@ -93,7 +93,7 @@ Use the wheels to adjust the value. Left click on a digit sets the cursor positi
 
 <h3>4: Interpolation factor</h3>
 
-The I/Q stream from the application is upsampled by a power of two before being sent to the the SoapySDR controlled device. Possible values are increasing powers of two: 1 (no interpolation), 2, 4, 8, 16, 32, 64.
+The I/Q stream from the application is upsampled by a power of two before being sent to the SoapySDR controlled device. Possible values are increasing powers of two: 1 (no interpolation), 2, 4, 8, 16, 32, 64.
 
 <h3>5: Transverter mode open dialog</h3>
 

--- a/plugins/samplesource/aaroniartsainput/readme.md
+++ b/plugins/samplesource/aaroniartsainput/readme.md
@@ -39,11 +39,11 @@ This is the stream sample rate in S/s with multiplier. It should be equal to wha
 
 <h3>3: Frequency</h3>
 
-This is the center frequency received in he stream meta data. When setting it it will try to set the center frequency of the `IQ Demodulator` in RTSA suite the closest to the `HTTP server`.
+This is the center frequency received in he stream meta data. When setting it, it will try to set the center frequency of the `IQ Demodulator` in RTSA suite the closest to the `HTTP server`.
 
 <h3>4: Stream sample rate</h3>
 
-This is sample rate (actually the frequency span) received in the stream meta data. When setting it it will try to set the sample rate and frequency span of the IQ Demodulator` in RTSA suite the closest to the `HTTP server`.
+This is sample rate (actually the frequency span) received in the stream meta data. When setting it, it will try to set the sample rate and frequency span of the IQ Demodulator` in RTSA suite the closest to the `HTTP server`.
 
 <h3>5: Remote address and port</h3>
 

--- a/plugins/samplesource/audioinput/readme.md
+++ b/plugins/samplesource/audioinput/readme.md
@@ -42,7 +42,7 @@ Audio sample rate in Hz (Sa/s).
 
 A decimation factor to apply to the audio data. The baseband sample rate will be the audio sample, divided by this decimation factor.
 
-<h3>8: Decimated bandpass center frequency position relative the device center frequency</h3>
+<h3>8: Decimated bandpass center frequency position relative to the device center frequency</h3>
 
 This will work in I/Q mode (stereo I/Q) only.
 

--- a/plugins/samplesource/bladerf1input/readme.md
+++ b/plugins/samplesource/bladerf1input/readme.md
@@ -84,7 +84,7 @@ Use the wheels to adjust the sample rate. Left click on a digit sets the cursor 
 
 The I/Q stream from the BladeRF ADC is downsampled by a power of two before being sent to the baseband. Possible values are increasing powers of two: 1 (no decimation), 2, 4, 8, 16, 32, 64.
 
-<h3>6: Baseband center frequency position relative the the BladeRF Rx center frequency</h3>
+<h3>6: Baseband center frequency position relative to the BladeRF Rx center frequency</h3>
 
 Possible values are:
 

--- a/plugins/samplesource/bladerf2input/readme.md
+++ b/plugins/samplesource/bladerf2input/readme.md
@@ -76,7 +76,7 @@ Use the wheels to adjust the sample rate. Left click on a digit sets the cursor 
 
 The ADC sample rate is the same for all Rx channels. The GUI of the sibling channel if present is adjusted automatically.
 
-<h3>7: Baseband center frequency position relative the the BladeRF Rx center frequency</h3>
+<h3>7: Baseband center frequency position relative to the BladeRF Rx center frequency</h3>
 
 Possible values are:
 

--- a/plugins/samplesource/fcdpro/readme.md
+++ b/plugins/samplesource/fcdpro/readme.md
@@ -41,7 +41,7 @@ These buttons control the local DSP auto correction options:
   - **DC**: auto remove DC component
   - **IQ**: auto make I/Q balance. The DC correction must be enabled for this to be effective.
 
-<h3>4: Decimated bandpass center frequency position relative the FCD Pro center frequency</h3>
+<h3>4: Decimated bandpass center frequency position relative to the FCD Pro center frequency</h3>
 
   - **Cen**: the decimation operation takes place around the FCD Pro center frequency Fs
   - **Inf**: the decimation operation takes place around Fs - Fc.

--- a/plugins/samplesource/fcdproplus/readme.md
+++ b/plugins/samplesource/fcdproplus/readme.md
@@ -41,7 +41,7 @@ These buttons control the local DSP auto correction options:
   - **DC**: auto remove DC component
   - **IQ**: auto make I/Q balance. The DC correction must be enabled for this to be effective.
 
-<h3>4: Decimated bandpass center frequency position relative the FCD Pro+ center frequency</h3>
+<h3>4: Decimated bandpass center frequency position relative to the FCD Pro+ center frequency</h3>
 
   - **Cen**: the decimation operation takes place around the FCD Pro+ center frequency Fs
   - **Inf**: the decimation operation takes place around Fs - Fc.

--- a/plugins/samplesource/hackrfinput/readme.md
+++ b/plugins/samplesource/hackrfinput/readme.md
@@ -82,7 +82,7 @@ The device stream from the HackRF is decimated to obtain the baseband stream. Po
   - **16**: divide device stream sample rate by 16
   - **32**: divide device stream sample rate by 32
 
-<h3>8: Baseband center frequency position relative the the HackRF Rx center frequency</h3>
+<h3>8: Baseband center frequency position relative to the HackRF Rx center frequency</h3>
 
   - **Cen**: the decimation operation takes place around the HackRF Rx center frequency Fs
   - **Inf**: the decimation operation takes place around Fs - Fc.

--- a/plugins/samplesource/plutosdrinput/readme.md
+++ b/plugins/samplesource/plutosdrinput/readme.md
@@ -84,7 +84,7 @@ This button opens a dialog to set the transverter mode frequency translation opt
 
 The I/Q stream from the PlutoSDR is downsampled by a power of two by software inside the plugin before being sent to the passband. Possible values are increasing powers of two: 1 (no decimation), 2, 4, 8, 16, 32, 64.
 
-<h3>6: Decimated bandpass center frequency position relative the the PlutoSDR Rx center frequency</h3>
+<h3>6: Decimated bandpass center frequency position relative to the PlutoSDR Rx center frequency</h3>
 
   - **Cen**: the decimation operation takes place around the PlutoSDR Rx center frequency Fs
   - **Inf**: the decimation operation takes place around Fs - Fc.

--- a/plugins/samplesource/rtlsdr/readme.md
+++ b/plugins/samplesource/rtlsdr/readme.md
@@ -53,7 +53,7 @@ These buttons control the local DSP auto correction options:
 
 Activates or de-activates the antenna bias tee. Works with v3 dongles only it will be simply ignored by others. It actually activates or de-activates GPIO pin 0 that commands bias tee on v3 dongles.
 
-<h3>4: Decimated bandpass center frequency position relative the RTL-SDR center frequency</h3>
+<h3>4: Decimated bandpass center frequency position relative to the RTL-SDR center frequency</h3>
 
   - **Cen**: the decimation operation takes place around the RTL-SDR center frequency Fs
   - **Inf**: the decimation operation takes place around Fs - Fc.

--- a/plugins/samplesource/sdrplay/readme.md
+++ b/plugins/samplesource/sdrplay/readme.md
@@ -77,7 +77,7 @@ You have the choice between various sample rates from 1536 to 8192 kHz. Some val
 
 Decimation in powers of two from 1 (no decimation) to 64.
 
-<h3>9: Decimated bandpass center frequency position relative the SDRplay center frequency</h3>
+<h3>9: Decimated bandpass center frequency position relative to the SDRplay center frequency</h3>
 
   - **Cen**: the decimation operation takes place around the SDRplay center frequency Fs
   - **Inf**: the decimation operation takes place around Fs - Fc.

--- a/plugins/samplesource/sdrplayv3/readme.md
+++ b/plugins/samplesource/sdrplayv3/readme.md
@@ -129,7 +129,7 @@ Sets the ADC IQ sample rats from 2M to 10.66M Hz.
 
 Decimation in powers of two from 1 (no decimation) to 64.
 
-<h3>19: Decimated bandpass center frequency position relative the SDRplay center frequency</h3>
+<h3>19: Decimated bandpass center frequency position relative to the SDRplay center frequency</h3>
 
   - **Cen**: the decimation operation takes place around the SDRplay center frequency Fs.
   - **Inf**: the decimation operation takes place around Fs - Fc.

--- a/plugins/samplesource/soapysdrinput/readme.md
+++ b/plugins/samplesource/soapysdrinput/readme.md
@@ -110,7 +110,7 @@ These buttons control the SDRangel internal DSP auto correction options:
   - **DC**: auto remove DC component
   - **IQ**: auto make I/Q balance. The DC correction must be enabled for this to be effective.
 
-<h3>3: Baseband center frequency position relative the LO center frequency</h3>
+<h3>3: Baseband center frequency position relative to the LO center frequency</h3>
 
 Possible values are:
 

--- a/plugins/samplesource/testsource/readme.md
+++ b/plugins/samplesource/testsource/readme.md
@@ -50,7 +50,7 @@ The I/Q stream from the generator is downsampled by a power of two before being 
 
 This exercises the decimation chain.
 
-<h4>2.3: Baseband center frequency position relative the center frequency</h4>
+<h4>2.3: Baseband center frequency position relative to the center frequency</h4>
 
   - **Cen**: the decimation operation takes place around the center frequency Fs
   - **Inf**: the decimation operation takes place around Fs - Fc.

--- a/sdrgui/audio.md
+++ b/sdrgui/audio.md
@@ -17,7 +17,7 @@ Each device is represented by a row in the list. Move the cursor with the mouse 
 In this column there are two indicators:
 
   - `S`: for system default device. This is the device that is defined as system default. You may configure it directly or via the ` System default device` entry. <br/>&#9758; Note that (at least in Linux) you may affect different parameters to one or the other.
-  - `D`: the device is unregistered so if you associate an output stream to it it will be registered with default values. Default values are:
+  - `D`: the device is unregistered so if you associate an output stream to it, it will be registered with default values. Default values are:
     - Sample rate: 48000 S/s
     - UDP address: 127.0.0.1
     - UDP port: 9998
@@ -199,7 +199,7 @@ Each device is represented by a row in the list. Move the cursor with the mouse 
 In this column there are two indicators:
 
   - `S`: for system default device. This is the device that is defined as system default. You may configure it directly or via the ` System default device` entry. <br/>&#9758; Note that (at least in Linux) you may affect different parameters to one or the other.
-  - `D`: the device is unregistered so if you associate an input stream to it it will be registered with default values. Default values are:
+  - `D`: the device is unregistered so if you associate an input stream to it, it will be registered with default values. Default values are:
     - Sample rate: 48000 S/s
     - Volume: 0.15
 
@@ -259,7 +259,7 @@ The dialog for input or output is similar. The screenshot below is taken from an
 In this column there are two indicators:
 
   - `S`: for system default device. This is the device that is defined as system default. You may configure it directly or via the ` System default device` entry. <br/>&#9758; Note that (at least in Linux) you may affect different parameters to one or the other.
-  - `D`: the device is unregistered so if you associate an input stream to it it will be registered with default values. Default values depend on the input or output nature and are listed in the 2.1 and 1.1 sections respectively.
+  - `D`: the device is unregistered so if you associate an input stream to it, it will be registered with default values. Default values depend on the input or output nature and are listed in the 2.1 and 1.1 sections respectively.
 
 A unset indicator is marked with an underscore character: `_`
 


### PR DESCRIPTION
Some fixes for words found with the regex ([[:alpha:]]+) \1