### PR TITLE
Fix Sat Tracker crash

### DIFF
--- a/plugins/channelrx/radioastronomy/radioastronomygui.h
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.h
@@ -449,6 +449,7 @@ private:
     void calcPowerChartTickCount(int width);
     void calcSpectrumChartTickCount(QValueAxis *axis, int width);
     int powerYUnitsToIndex(RadioAstronomySettings::PowerYUnits units);
+    void setColumnPrecisionFromRotator();
 
     void leaveEvent(QEvent*);
     void enterEvent(EnterEventType*);

--- a/plugins/feature/gs232controller/gs232controllergui.ui
+++ b/plugins/feature/gs232controller/gs232controllergui.ui
@@ -339,6 +339,9 @@
       </item>
       <item row="4" column="1">
        <widget class="QSpinBox" name="azimuthMin">
+        <property name="minimum">
+         <number>-180</number>
+        </property>
         <property name="maximum">
          <number>450</number>
         </property>

--- a/plugins/feature/gs232controller/rotctrldprotocol.cpp
+++ b/plugins/feature/gs232controller/rotctrldprotocol.cpp
@@ -75,7 +75,7 @@ void RotCtrlDProtocol::readData()
                 int rprt = matchRprt.captured(1).toInt();
                 if (rprt != 0)
                 {
-                    qWarning() << "GS232ControllerWorker::readData - rotctld error: " << errors[-rprt];
+                    qWarning() << "RotCtrlDProtocol::readData - rotctld error: " << errors[-rprt];
                     // Seem to get a lot of EPROTO errors from rotctld due to extra 00 char in response to GS232 C2 command
                     // E.g: ./rotctld.exe -m 603 -r com7 -vvvvv
                     // read_string(): RX 16 characters
@@ -97,12 +97,12 @@ void RotCtrlDProtocol::readData()
                 QString az = m_rotCtlDAz;
                 QString el = response;
                 m_rotCtlDReadAz = false;
-                //qDebug() << "GS232ControllerWorker::readData read Az " << az << " El " << el;
+                //qDebug() << "RotCtrlDProtocol::readData read Az " << az << " El " << el;
                 reportAzEl(az.toFloat(), el.toFloat());
             }
             else
             {
-                qWarning() << "GS232ControllerWorker::readData - Unexpected rotctld response \"" << response << "\"";
+                qWarning() << "RotCtrlDProtocol::readData - Unexpected rotctld response \"" << response << "\"";
                 reportError(QString("Unexpected rotctld response: %1").arg(response));
             }
         }

--- a/plugins/feature/satellitetracker/satellitetrackerworker.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackerworker.cpp
@@ -811,28 +811,30 @@ void SatelliteTrackerWorker::applyDeviceAOSSettings(const QString& name)
 void SatelliteTrackerWorker::enableDoppler(SatWorkerState *satWorkerState)
 {
     QList<SatelliteTrackerSettings::SatelliteDeviceSettings *> *m_deviceSettingsList = m_settings.m_deviceSettings.value(satWorkerState->m_name);
-
-    satWorkerState->m_doppler.clear();
-    bool requiresDoppler = false;
-    for (int i = 0; i < m_deviceSettingsList->size(); i++)
+    if (m_deviceSettingsList)
     {
-        SatelliteTrackerSettings::SatelliteDeviceSettings *devSettings = m_deviceSettingsList->at(i);
-        if (devSettings->m_doppler.size() > 0)
+        satWorkerState->m_doppler.clear();
+        bool requiresDoppler = false;
+        for (int i = 0; i < m_deviceSettingsList->size(); i++)
         {
-            requiresDoppler = true;
-            for (int j = 0; j < devSettings->m_doppler.size(); j++) {
-                satWorkerState->m_doppler.append(0);
+            SatelliteTrackerSettings::SatelliteDeviceSettings *devSettings = m_deviceSettingsList->at(i);
+            if (devSettings->m_doppler.size() > 0)
+            {
+                requiresDoppler = true;
+                for (int j = 0; j < devSettings->m_doppler.size(); j++) {
+                    satWorkerState->m_doppler.append(0);
+                }
             }
         }
-    }
-    if (requiresDoppler)
-    {
-        qDebug() << "SatelliteTrackerWorker::applyDeviceAOSSettings: Enabling doppler for " << satWorkerState->m_name;
-        satWorkerState->m_dopplerTimer.setInterval(m_settings.m_dopplerPeriod * 1000);
-        satWorkerState->m_dopplerTimer.start();
-        connect(&satWorkerState->m_dopplerTimer, &QTimer::timeout, [this, satWorkerState]() {
-            doppler(satWorkerState);
-        });
+        if (requiresDoppler)
+        {
+            qDebug() << "SatelliteTrackerWorker::applyDeviceAOSSettings: Enabling doppler for " << satWorkerState->m_name;
+            satWorkerState->m_dopplerTimer.setInterval(m_settings.m_dopplerPeriod * 1000);
+            satWorkerState->m_dopplerTimer.start();
+            connect(&satWorkerState->m_dopplerTimer, &QTimer::timeout, [this, satWorkerState]() {
+                doppler(satWorkerState);
+            });
+        }
     }
 }
 
@@ -874,7 +876,7 @@ void SatelliteTrackerWorker::doppler(SatWorkerState *satWorkerState)
     qDebug() << "SatelliteTrackerWorker::doppler " << satWorkerState->m_name;
 
     QList<SatelliteTrackerSettings::SatelliteDeviceSettings *> *m_deviceSettingsList = m_settings.m_deviceSettings.value(satWorkerState->m_name);
-    if (m_deviceSettingsList != nullptr)
+    if (m_deviceSettingsList)
     {
         for (int i = 0; i < m_deviceSettingsList->size(); i++)
         {

--- a/plugins/feature/startracker/readme.md
+++ b/plugins/feature/startracker/readme.md
@@ -99,6 +99,7 @@ To allow Stellarium to set the RA and Dec, select Custom RA/Dec, and ensure the 
 | S7               | HI                | IAU secondary calibration region (l=132,b=-1)  | Tb=100 peak                                |
 | S8               | HI                | IAU primary calibration region (l=207,b=-15)   | Tb=72 peak                                 |
 | S9               | HI                | IAU secondary calibration region (l=356,b=-4)  | Tb=85 peak                                 |
+| SatelliteTracker |                   | Gets target Az/El from Satellite Tracker       |                                            |
 
 References:
 
@@ -172,6 +173,9 @@ Click on this icon ![Star Tracker Chart theme](../../../doc/img/StarTracker_char
 In order to assist in determining whether and when observations of the target object may be possible, an elevation vs time plot is drawn for the 24 hours encompassing the selected date and time.
 This can be plotted on Cartesian or polar axis.
 Some objects may not be visible from a particular latitude for the specified time, in which case, the graph title will indicate the object is not visible on that particular date.
+
+When the target is set to a Satellite Tracker, this chart is plotted based on the Satellite's current position only. It does not take in to consideration the satellite's movement. For that,
+use the chart in the Satellite Tracker.
 
 <h3>Solar flux vs frequency</h3>
 

--- a/plugins/feature/startracker/startracker.cpp
+++ b/plugins/feature/startracker/startracker.cpp
@@ -29,6 +29,7 @@
 
 #include "device/deviceset.h"
 #include "dsp/dspengine.h"
+#include "feature/featureset.h"
 #include "util/weather.h"
 #include "util/units.h"
 #include "settings/serializable.h"
@@ -41,6 +42,7 @@
 MESSAGE_CLASS_DEFINITION(StarTracker::MsgConfigureStarTracker, Message)
 MESSAGE_CLASS_DEFINITION(StarTracker::MsgStartStop, Message)
 MESSAGE_CLASS_DEFINITION(StarTracker::MsgSetSolarFlux, Message)
+MESSAGE_CLASS_DEFINITION(StarTracker::MsgReportAvailableSatelliteTrackers, Message)
 
 const char* const StarTracker::m_featureIdURI = "sdrangel.feature.startracker";
 const char* const StarTracker::m_featureId = "StarTracker";
@@ -69,11 +71,24 @@ StarTracker::StarTracker(WebAPIAdapterInterface *webAPIAdapterInterface) :
     m_temps.append(new FITS(":/startracker/startracker/1420mhz_ra_dec.fits"));
     m_spectralIndex = new FITS(":/startracker/startracker/408mhz_ra_dec_spectral_index.fits");
     scanAvailableChannels();
+    scanAvailableFeatures();
     QObject::connect(
         MainCore::instance(),
         &MainCore::channelAdded,
         this,
         &StarTracker::handleChannelAdded
+    );
+    QObject::connect(
+        MainCore::instance(),
+        &MainCore::featureAdded,
+        this,
+        &StarTracker::handleFeatureAdded
+    );
+    QObject::connect(
+        MainCore::instance(),
+        &MainCore::featureRemoved,
+        this,
+        &StarTracker::handleFeatureRemoved
     );
 }
 
@@ -905,6 +920,52 @@ void StarTracker::handleMessagePipeToBeDeleted(int reason, QObject* object)
     {
         qDebug("StarTracker::handleMessagePipeToBeDeleted: removing channel at (%p)", object);
         m_availableChannels.remove((ChannelAPI*) object);
+    }
+}
+
+void StarTracker::scanAvailableFeatures()
+{
+    qDebug("StarTracker::scanAvailableFeatures");
+    MainCore *mainCore = MainCore::instance();
+    MessagePipes& messagePipes = mainCore->getMessagePipes();
+    std::vector<FeatureSet*>& featureSets = mainCore->getFeatureeSets();
+    m_satelliteTrackers.clear();
+
+    for (const auto& featureSet : featureSets)
+    {
+        for (int fei = 0; fei < featureSet->getNumberOfFeatures(); fei++)
+        {
+            Feature *feature = featureSet->getFeatureAt(fei);
+
+            if (feature->getURI() == "sdrangel.feature.satellitetracker")
+            {
+                StarTrackerSettings::AvailableFeature satelliteTracker =
+                    StarTrackerSettings::AvailableFeature{featureSet->getIndex(), fei, feature->getIdentifier()};
+                m_satelliteTrackers[feature] = satelliteTracker;
+            }
+        }
+    }
+
+    notifyUpdateSatelliteTrackers();
+}
+
+void StarTracker::handleFeatureAdded(int featureSetIndex, Feature *feature)
+{
+    scanAvailableFeatures();
+}
+
+void StarTracker::handleFeatureRemoved(int featureSetIndex, Feature *feature)
+{
+    scanAvailableFeatures();
+}
+
+void StarTracker::notifyUpdateSatelliteTrackers()
+{
+    if (getMessageQueueToGUI())
+    {
+        MsgReportAvailableSatelliteTrackers *msg = MsgReportAvailableSatelliteTrackers::create();
+        msg->getFeatures() = m_satelliteTrackers.values();
+        getMessageQueueToGUI()->push(msg);
     }
 }
 

--- a/plugins/feature/startracker/startracker.cpp
+++ b/plugins/feature/startracker/startracker.cpp
@@ -927,7 +927,6 @@ void StarTracker::scanAvailableFeatures()
 {
     qDebug("StarTracker::scanAvailableFeatures");
     MainCore *mainCore = MainCore::instance();
-    MessagePipes& messagePipes = mainCore->getMessagePipes();
     std::vector<FeatureSet*>& featureSets = mainCore->getFeatureeSets();
     m_satelliteTrackers.clear();
 
@@ -951,11 +950,17 @@ void StarTracker::scanAvailableFeatures()
 
 void StarTracker::handleFeatureAdded(int featureSetIndex, Feature *feature)
 {
+    (void) featureSetIndex;
+    (void) feature;
+
     scanAvailableFeatures();
 }
 
 void StarTracker::handleFeatureRemoved(int featureSetIndex, Feature *feature)
 {
+    (void) featureSetIndex;
+    (void) feature;
+
     scanAvailableFeatures();
 }
 

--- a/plugins/feature/startracker/startracker.h
+++ b/plugins/feature/startracker/startracker.h
@@ -106,6 +106,24 @@ public:
         { }
     };
 
+    class MsgReportAvailableSatelliteTrackers : public Message {
+        MESSAGE_CLASS_DECLARATION
+
+    public:
+        QList<StarTrackerSettings::AvailableFeature>& getFeatures() { return m_availableFeatures; }
+
+        static MsgReportAvailableSatelliteTrackers* create() {
+            return new MsgReportAvailableSatelliteTrackers();
+        }
+
+    private:
+        QList<StarTrackerSettings::AvailableFeature> m_availableFeatures;
+
+        MsgReportAvailableSatelliteTrackers() :
+            Message()
+        {}
+    };
+
     StarTracker(WebAPIAdapterInterface *webAPIAdapterInterface);
     virtual ~StarTracker();
     virtual void destroy() { delete this; }
@@ -165,6 +183,7 @@ private:
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;
     QSet<ChannelAPI*> m_availableChannels;
+    QHash<Feature*, StarTrackerSettings::AvailableFeature> m_satelliteTrackers;
     Weather *m_weather;
     float m_solarFlux;
 
@@ -178,12 +197,16 @@ private:
     void webapiFormatFeatureReport(SWGSDRangel::SWGFeatureReport& response);
     double applyBeam(const FITS *fits, double beamwidth, double ra, double dec, int& imgX, int& imgY) const;
     void scanAvailableChannels();
+    void scanAvailableFeatures();
+    void notifyUpdateSatelliteTrackers();
 
 private slots:
     void networkManagerFinished(QNetworkReply *reply);
     void weatherUpdated(float temperature, float pressure, float humidity);
     void handleChannelAdded(int deviceSetIndex, ChannelAPI *channel);
     void handleMessagePipeToBeDeleted(int reason, QObject* object);
+    void handleFeatureAdded(int featureSetIndex, Feature *feature);
+    void handleFeatureRemoved(int featureSetIndex, Feature *feature);
     void handleChannelMessageQueue(MessageQueue* messageQueue);
 };
 

--- a/plugins/feature/startracker/startrackergui.h
+++ b/plugins/feature/startracker/startrackergui.h
@@ -163,6 +163,7 @@ private:
     void updateSolarFlux(bool all);
     void makeUIConnections();
     void limitAzElRange(double& azimuth, double& elevation) const;
+    void updateSatelliteTrackerList(const QList<StarTrackerSettings::AvailableFeature>& satelliteTrackers);
 
 private slots:
     void onMenuDialogCalled(const QPoint &p);

--- a/plugins/feature/startracker/startrackergui.ui
+++ b/plugins/feature/startracker/startrackergui.ui
@@ -101,7 +101,7 @@
          <string>Offset in degrees to add to calculated target elevation</string>
         </property>
         <property name="decimals">
-         <number>1</number>
+         <number>3</number>
         </property>
         <property name="minimum">
          <double>-180.000000000000000</double>
@@ -167,7 +167,7 @@
          <widget class="QComboBox" name="target">
           <property name="minimumSize">
            <size>
-            <width>110</width>
+            <width>150</width>
             <height>0</height>
            </size>
           </property>
@@ -460,7 +460,7 @@ This can be specified as a decimal (E.g. 34.23) or in degrees, minutes and secon
          <string>Offset in degrees to added to calculated target azimuth</string>
         </property>
         <property name="decimals">
-         <number>1</number>
+         <number>3</number>
         </property>
         <property name="minimum">
          <double>-360.000000000000000</double>

--- a/plugins/feature/startracker/startrackersettings.cpp
+++ b/plugins/feature/startracker/startrackersettings.cpp
@@ -341,10 +341,10 @@ void StarTrackerSettings::applySettings(const QStringList& settingsKeys, const S
     if (settingsKeys.contains("reverseAPIFeatureIndex")) {
         m_reverseAPIFeatureIndex = settings.m_reverseAPIFeatureIndex;
     }
-    if (settingsKeys.contains("az")) {
+    if (settingsKeys.contains("azimuth")) {
         m_az = settings.m_az;
     }
-    if (settingsKeys.contains("el")) {
+    if (settingsKeys.contains("elevation")) {
         m_el = settings.m_el;
     }
     if (settingsKeys.contains("l")) {
@@ -482,10 +482,10 @@ QString StarTrackerSettings::getDebugString(const QStringList& settingsKeys, boo
     if (settingsKeys.contains("reverseAPIFeatureIndex") || force) {
         ostr << " m_reverseAPIFeatureIndex: " << m_reverseAPIFeatureIndex;
     }
-    if (settingsKeys.contains("az") || force) {
+    if (settingsKeys.contains("azimuth") || force) {
         ostr << " m_az: " << m_az;
     }
-    if (settingsKeys.contains("el") || force) {
+    if (settingsKeys.contains("elevation") || force) {
         ostr << " m_el: " << m_el;
     }
     if (settingsKeys.contains("l") || force) {

--- a/plugins/feature/startracker/startrackersettings.h
+++ b/plugins/feature/startracker/startrackersettings.h
@@ -28,6 +28,23 @@ class Serializable;
 
 struct StarTrackerSettings
 {
+    struct AvailableFeature
+    {
+        int m_featureSetIndex;
+        int m_featureIndex;
+        QString m_type;
+
+        AvailableFeature() = default;
+        AvailableFeature(const AvailableFeature&) = default;
+        AvailableFeature& operator=(const AvailableFeature&) = default;
+        bool operator==(const AvailableFeature& a) const {
+            return (m_featureSetIndex == a.m_featureSetIndex) && (m_featureIndex == a.m_featureIndex) && (m_type == a.m_type);
+        }
+        QString getName() const {
+            return QString("F%1:%2 %3").arg(m_featureSetIndex).arg(m_featureIndex).arg(m_type);
+        }
+    };
+
     QString m_ra;
     QString m_dec;
     double m_latitude;

--- a/sdrgui/gui/decimaldelegate.h
+++ b/sdrgui/gui/decimaldelegate.h
@@ -29,6 +29,8 @@ public:
     DecimalDelegate(int precision = 2);
 
     virtual QString displayText(const QVariant &value, const QLocale &locale) const override;
+    int getPrecision() const { return m_precision; }
+    void setPrecision(int precision) { m_precision = precision; }
 
 private:
     int m_precision;


### PR DESCRIPTION
Just a bit too late... Fix Sat Tracker crash introduced by last patch for #1682.

Add support for tracking Satellites in the Star Tracker, to enable satellites to be used as calibration signals in Radio Astronomy plugin.
