### PR TITLE
Add missing settings keys for Pluto Output. 

### DIFF
--- a/plugins/samplesink/plutosdroutput/plutosdroutput.cpp
+++ b/plugins/samplesink/plutosdroutput/plutosdroutput.cpp
@@ -217,7 +217,7 @@ bool PlutoSDROutput::handleMessage(const Message& message)
         PlutoSDROutputSettings newSettings = m_settings;
         newSettings.m_lpfFIREnable = conf.isLpfFirEnable();
 
-        applySettings(newSettings, QList<QString>{"lpfFIREnable"});
+        applySettings(newSettings, QList<QString>{"devSampleRate", "lpfFIRlog2Interp", "lpfFIRBW", "LOppmTenths", "lpfFIREnable"});
 
         return true;
     }


### PR DESCRIPTION
For #1690, this adds a few additional settings keys that look like they are missing (they are in the Pluto Input which supposedly works - you need to see a little more context that what the github diff shows).

I don't have a Pluto, so can't test( but this PR should create a build other people can try).
