### PR TITLE
Fix spelling

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemodgui.ui
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.ui
@@ -1100,7 +1100,7 @@
             <string>OAT (C)</string>
            </property>
            <property name="toolTip">
-            <string>Outside air temperature in degrees Celsuis estimated from Mach and TAS</string>
+            <string>Outside air temperature in degrees Celsius estimated from Mach and TAS</string>
            </property>
           </column>
           <column>
@@ -1132,7 +1132,7 @@
             <string>T (C)</string>
            </property>
            <property name="toolTip">
-            <string>Static air temperature in degrees Celsuis</string>
+            <string>Static air temperature in degrees Celsius</string>
            </property>
           </column>
           <column>
@@ -1148,7 +1148,7 @@
             <string>Lat (°)</string>
            </property>
            <property name="toolTip">
-            <string extracomment="Double click to centre the map on this aircraft">Latitude in degrees postive towards the North</string>
+            <string extracomment="Double click to centre the map on this aircraft">Latitude in degrees positive towards the North</string>
            </property>
           </column>
           <column>
@@ -1180,7 +1180,7 @@
             <string>TIS-B</string>
            </property>
            <property name="toolTip">
-            <string>Number of TIS-B frames received with this aircrafts ICAO</string>
+            <string>Number of TIS-B frames received with this aircraft's ICAO</string>
            </property>
           </column>
           <column>

--- a/plugins/channelrx/demoddsc/dscdemodgui.ui
+++ b/plugins/channelrx/demoddsc/dscdemodgui.ui
@@ -865,7 +865,7 @@
         <string>RSSI</string>
        </property>
        <property name="toolTip">
-        <string>Received signal strenth indicator (Average power in dBFS)</string>
+        <string>Received signal strength indicator (Average power in dBFS)</string>
        </property>
       </column>
      </widget>

--- a/plugins/channelrx/demoddsc/readme.md
+++ b/plugins/channelrx/demoddsc/readme.md
@@ -46,7 +46,7 @@ This drop down displays a list of all columns which can be used for filtering (8
 
 <h3>8: Filter Reg Exp</h3>
 
-Specifes a [regular expression](https://regexr.com/) used to filter data in the table, using data in the column specified by (7).
+Specifies a [regular expression](https://regexr.com/) used to filter data in the table, using data in the column specified by (7).
 
 <h3>9: Filter Invalid</h3>
 

--- a/plugins/channelrx/demodnfm/nfmdemodgui.ui
+++ b/plugins/channelrx/demodnfm/nfmdemodgui.ui
@@ -619,7 +619,7 @@
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>Display DCS code as postive/normal (+) or negative/inverted (-)</string>
+         <string>Display DCS code as positive/normal (+) or negative/inverted (-)</string>
         </property>
         <property name="text">
          <string/>

--- a/plugins/channelrx/demodpager/pagerdemodcharsetdialog.ui
+++ b/plugins/channelrx/demodpager/pagerdemodcharsetdialog.ui
@@ -17,7 +17,7 @@
    </font>
   </property>
   <property name="windowTitle">
-   <string>Set chararcter encoding</string>
+   <string>Set character encoding</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/plugins/channelrx/demodradiosonde/radiosondedemodgui.ui
+++ b/plugins/channelrx/demodradiosonde/radiosondedemodgui.ui
@@ -771,7 +771,7 @@
         <string>PCB (°C)</string>
        </property>
        <property name="toolTip">
-        <string>PCB temperature in degrees Celsuis</string>
+        <string>PCB temperature in degrees Celsius</string>
        </property>
       </column>
       <column>

--- a/plugins/channelrx/demodrtty/rttydemodgui.ui
+++ b/plugins/channelrx/demodrtty/rttydemodgui.ui
@@ -475,7 +475,7 @@
          </item>
          <item>
           <property name="text">
-           <string>Rasied Cosine b=1 BW=0.75</string>
+           <string>Raised Cosine b=1 BW=0.75</string>
           </property>
          </item>
          <item>

--- a/plugins/channelrx/noisefigure/noisefigurecontroldialog.ui
+++ b/plugins/channelrx/noisefigure/noisefigurecontroldialog.ui
@@ -140,7 +140,7 @@ Lines beginning with # are comments</string>
          <item>
           <widget class="QLabel" name="delayLabel">
            <property name="text">
-            <string>Delay in seconds betwen power on/off and measurement</string>
+            <string>Delay in seconds between power on/off and measurement</string>
            </property>
           </widget>
          </item>

--- a/plugins/channeltx/modais/aismodgui.ui
+++ b/plugins/channeltx/modais/aismodgui.ui
@@ -197,7 +197,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Tranmission mode</string>
+         <string>Transmission mode</string>
         </property>
         <item>
          <property name="text">
@@ -815,7 +815,7 @@
       <item>
        <widget class="QDoubleSpinBox" name="longitude">
         <property name="toolTip">
-         <string>Longitude in decimal degress (East positive)</string>
+         <string>Longitude in decimal degrees (East positive)</string>
         </property>
         <property name="decimals">
          <number>6</number>

--- a/plugins/feature/satellitetracker/satellitetrackergui.ui
+++ b/plugins/feature/satellitetracker/satellitetrackergui.ui
@@ -312,7 +312,7 @@
       <item row="2" column="4">
        <widget class="QDoubleSpinBox" name="longitude">
         <property name="toolTip">
-         <string>Longitude in decimal degress (East positive) of antenna location</string>
+         <string>Longitude in decimal degrees (East positive) of antenna location</string>
         </property>
         <property name="decimals">
          <number>6</number>

--- a/plugins/feature/satellitetracker/satellitetrackersettingsdialog.ui
+++ b/plugins/feature/satellitetracker/satellitetrackersettingsdialog.ui
@@ -388,7 +388,7 @@
           <item row="11" column="0">
            <widget class="QCheckBox" name="utc">
             <property name="toolTip">
-             <string>When checked times are dispayed using UTC rather than the local time zone</string>
+             <string>When checked times are displayed using UTC rather than the local time zone</string>
             </property>
             <property name="text">
              <string>Display times in UTC</string>

--- a/plugins/feature/startracker/startrackergui.ui
+++ b/plugins/feature/startracker/startrackergui.ui
@@ -539,7 +539,7 @@ This can be specified as a decimal (E.g. 34.23) or in degrees, minutes and secon
       <item row="2" column="3">
        <widget class="QDoubleSpinBox" name="longitude">
         <property name="toolTip">
-         <string>Longitude in decimal degress (East positive) of observation point / antenna location</string>
+         <string>Longitude in decimal degrees (East positive) of observation point / antenna location</string>
         </property>
         <property name="decimals">
          <number>6</number>

--- a/plugins/samplesink/aaroniartsaoutput/readme.md
+++ b/plugins/samplesink/aaroniartsaoutput/readme.md
@@ -4,7 +4,7 @@
 
 You can use this plugin to interface with a http server block in the Aaronia RTSA suite connected to a Spectran V6 device. It is assumed that you have prior knowledge of the Aaronia RTSA suite software and operation of the Spectran V6 RTSA (Real Time Spectrum Analyzer). However in this context there are some specificities i.e. it assumes that the "mission" (in RTSA suite terms) that is the equivalent of a "configuration" in SDRangel has a `HTTP Server` block followed by an `IQ Modulator` block.
 
-An example flow graph could be the following (Stram Debugger is optional):
+An example flow graph could be the following (Stream Debugger is optional):
 
 ![Aaronia RTSA Tx flowgraph](../../../doc/img/aaronia_http_tx.jpg)
 

--- a/plugins/samplesource/remotetcpinput/remotetcpinputgui.ui
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputgui.ui
@@ -1109,7 +1109,7 @@ When unchecked, if remote device is using SDRA protocol, local settings are upda
        </property>
        <property name="toolTip">
         <string>Output buffer.
-This should typically be empy. If full, your CPU cannot keep up and data will be lost</string>
+This should typically be empty. If full, your CPU cannot keep up and data will be lost</string>
        </property>
        <property name="minimum">
         <number>0</number>

--- a/sdrbase/resources/webapi/doc/html2/index.html
+++ b/sdrbase/resources/webapi/doc/html2/index.html
@@ -4093,7 +4093,7 @@ margin-bottom: 20px;
     },
     "decoding" : {
       "type" : "integer",
-      "description" : "Boolean - decoding status\n  * 0 - no deconding\n  * 1 - decoding\n"
+      "description" : "Boolean - decoding status\n  * 0 - no decoding\n  * 1 - decoding\n"
     }
   },
   "description" : "ChirpChatDemod"
@@ -4113,7 +4113,7 @@ margin-bottom: 20px;
     },
     "deBits" : {
       "type" : "integer",
-      "description" : "Low data rate optmize (DE) bits i.e. nb of FFT bins per effective symbol"
+      "description" : "Low data rate optimize (DE) bits i.e. nb of FFT bins per effective symbol"
     },
     "fftWindow" : {
       "type" : "integer",
@@ -4260,7 +4260,7 @@ margin-bottom: 20px;
     },
     "deBits" : {
       "type" : "integer",
-      "description" : "Low data rate optmize (DE) bits i.e. nb of FFT bins per effective symbol"
+      "description" : "Low data rate optimize (DE) bits i.e. nb of FFT bins per effective symbol"
     },
     "preambleChirps" : {
       "type" : "integer",
@@ -4945,7 +4945,7 @@ margin-bottom: 20px;
     },
     "squelchdB" : {
       "type" : "integer",
-      "description" : "Porcessing squared magnitude threshold (squelch) in dB from -140 t0 0"
+      "description" : "Processing squared magnitude threshold (squelch) in dB from -140 to 0"
     },
     "fftAveragingValue" : {
       "type" : "integer",
@@ -6979,7 +6979,7 @@ margin-bottom: 20px;
       "type" : "integer"
     }
   },
-  "description" : "A band of frequencies given its boudaries in Hertz (Hz)"
+  "description" : "A band of frequencies given its boundaries in Hertz (Hz)"
 };
             defs.FrequencyRange = {
   "properties" : {
@@ -8301,7 +8301,7 @@ margin-bottom: 20px;
   "properties" : {
     "success" : {
       "type" : "integer",
-      "description" : "1 if info was successfullt retrieved else 0"
+      "description" : "1 if info was successfully retrieved else 0"
     },
     "streamActive" : {
       "type" : "integer",
@@ -8462,7 +8462,7 @@ margin-bottom: 20px;
     },
     "successRx" : {
       "type" : "integer",
-      "description" : "1 if Rx info was successfullt retrieved else 0"
+      "description" : "1 if Rx info was successfully retrieved else 0"
     },
     "streamActiveRx" : {
       "type" : "integer",
@@ -8489,7 +8489,7 @@ margin-bottom: 20px;
     },
     "successTx" : {
       "type" : "integer",
-      "description" : "1 if Tx info was successfullt retrieved else 0"
+      "description" : "1 if Tx info was successfully retrieved else 0"
     },
     "streamActiveTx" : {
       "type" : "integer",
@@ -8744,7 +8744,7 @@ margin-bottom: 20px;
   "properties" : {
     "success" : {
       "type" : "integer",
-      "description" : "1 if info was successfullt retrieved else 0"
+      "description" : "1 if info was successfully retrieved else 0"
     },
     "streamActive" : {
       "type" : "integer",
@@ -8960,7 +8960,7 @@ margin-bottom: 20px;
     },
     "fftOn" : {
       "type" : "integer",
-      "description" : "Activate FFT multiband filter\n  * 0 - do not run flter\n  * 1 - run filter\n"
+      "description" : "Activate FFT multiband filter\n  * 0 - do not run filter\n  * 1 - run filter\n"
     },
     "log2FFT" : {
       "type" : "integer",
@@ -9519,7 +9519,7 @@ margin-bottom: 20px;
     "labelAltitudeOffset" : {
       "type" : "number",
       "format" : "float",
-      "description" : "Veritical offset to position label at"
+      "description" : "Vertical offset to position label at"
     },
     "modelAltitudeOffset" : {
       "type" : "number",
@@ -9678,7 +9678,7 @@ margin-bottom: 20px;
     "labelAltitudeOffset" : {
       "type" : "number",
       "format" : "float",
-      "description" : "Veritical offset to position label at"
+      "description" : "Vertical offset to position label at"
     },
     "modelAltitudeOffset" : {
       "type" : "number",
@@ -11409,7 +11409,7 @@ margin-bottom: 20px;
       "description" : "See QtMsgType"
     }
   },
-  "description" : "Repreents a Prefernce object"
+  "description" : "Represents a Preference object"
 };
             defs.Preset = {
   "properties" : {
@@ -12250,7 +12250,7 @@ margin-bottom: 20px;
     },
     "nbTxBytes" : {
       "type" : "integer",
-      "description" : "Number of bytes in a transmited I or Q sample\n  * 1\n  * 2\n  * 4\n"
+      "description" : "Number of bytes in a transmitted I or Q sample\n  * 1\n  * 2\n  * 4\n"
     },
     "apiAddress" : {
       "type" : "string"
@@ -12294,7 +12294,7 @@ margin-bottom: 20px;
     },
     "nbTxBytes" : {
       "type" : "integer",
-      "description" : "Number of bytes in a transmited I or Q sample\n  * 1\n  * 2\n  * 4\n"
+      "description" : "Number of bytes in a transmitted I or Q sample\n  * 1\n  * 2\n  * 4\n"
     },
     "deviceCenterFrequency" : {
       "type" : "integer",
@@ -14327,7 +14327,7 @@ margin-bottom: 20px;
     },
     "markerColor" : {
       "type" : "integer",
-      "description" : "Color in 8 bit BGR serie"
+      "description" : "Color in 8 bit BGR series"
     },
     "show" : {
       "type" : "integer",
@@ -14370,7 +14370,7 @@ margin-bottom: 20px;
     },
     "markerColor" : {
       "type" : "integer",
-      "description" : "Color in 8 bit BGR serie"
+      "description" : "Color in 8 bit BGR series"
     },
     "show" : {
       "type" : "integer",
@@ -14424,7 +14424,7 @@ margin-bottom: 20px;
     },
     "markerColor" : {
       "type" : "integer",
-      "description" : "Color in 8 bit BGR serie"
+      "description" : "Color in 8 bit BGR series"
     },
     "show" : {
       "type" : "integer",
@@ -14595,7 +14595,7 @@ margin-bottom: 20px;
     "temperature" : {
       "type" : "number",
       "format" : "float",
-      "description" : "Air temperature in Celsuis, for refraction"
+      "description" : "Air temperature in Celsius, for refraction"
     },
     "humidity" : {
       "type" : "number",
@@ -22563,7 +22563,7 @@ $(document).ready(function() {
 
 
                           <h2>Responses</h2>
-                            <h3> Status: 202 - On successful semding of the message it returns the details of the device being set </h3>
+                            <h3> Status: 202 - On successful sending of the message it returns the details of the device being set </h3>
 
                             <ul class="nav nav-tabs nav-tabs-examples" >
                                 <li class="active">
@@ -22578,7 +22578,7 @@ $(document).ready(function() {
                                     <script>
                                       $(document).ready(function() {
                                         var schemaWrapper = {
-  "description" : "On successful semding of the message it returns the details of the device being set",
+  "description" : "On successful sending of the message it returns the details of the device being set",
   "schema" : {
     "$ref" : "#/definitions/DeviceListItem"
   }
@@ -31220,7 +31220,7 @@ $(document).ready(function() {
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Apply main spectrun settings unconditionnaly (force)</p>
+                        <p class="marked">Apply main spectrun settings unconditionally (force)</p>
                         <p></p>
                         <br />
                         <pre class="prettyprint language-html prettyprinted" data-type="put"><code><span class="pln">/sdrangel/deviceset/{deviceSetIndex}/spectrum/settings</span></code></pre>
@@ -41339,7 +41339,7 @@ except ApiException as e:
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Delete audio input device paramaters and return to defaults</p>
+                        <p class="marked">Delete audio input device parameters and return to defaults</p>
                         <p></p>
                         <br />
                         <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/sdrangel/audio/input/parameters</span></code></pre>
@@ -41769,7 +41769,7 @@ $(document).ready(function() {
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Set audio input device paramaters</p>
+                        <p class="marked">Set audio input device parameters</p>
                         <p></p>
                         <br />
                         <pre class="prettyprint language-html prettyprinted" data-type="patch"><code><span class="pln">/sdrangel/audio/input/parameters</span></code></pre>
@@ -42534,7 +42534,7 @@ except ApiException as e:
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Delete audio output device paramaters and return to defaults</p>
+                        <p class="marked">Delete audio output device parameters and return to defaults</p>
                         <p></p>
                         <br />
                         <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/sdrangel/audio/output/parameters</span></code></pre>
@@ -52246,7 +52246,7 @@ except ApiException as e:
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Change logging parmeters for this instance</p>
+                        <p class="marked">Change logging parameters for this instance</p>
                         <p></p>
                         <br />
                         <pre class="prettyprint language-html prettyprinted" data-type="put"><code><span class="pln">/sdrangel/logging</span></code></pre>

--- a/sdrgui/gui/basicchannelsettingsdialog.ui
+++ b/sdrgui/gui/basicchannelsettingsdialog.ui
@@ -157,7 +157,7 @@
      <item>
       <widget class="QCheckBox" name="reverseAPI">
        <property name="toolTip">
-        <string>Sychronize with reverse API </string>
+        <string>Synchronize with reverse API </string>
        </property>
        <property name="text">
         <string>reverse API</string>

--- a/sdrgui/gui/basicdevicesettingsdialog.ui
+++ b/sdrgui/gui/basicdevicesettingsdialog.ui
@@ -25,7 +25,7 @@
      <item>
       <widget class="QCheckBox" name="reverseAPI">
        <property name="toolTip">
-        <string>Sychronize with reverse API </string>
+        <string>Synchronize with reverse API </string>
        </property>
        <property name="text">
         <string>reverse API</string>

--- a/sdrgui/gui/basicfeaturesettingsdialog.ui
+++ b/sdrgui/gui/basicfeaturesettingsdialog.ui
@@ -75,7 +75,7 @@
      <item>
       <widget class="QCheckBox" name="reverseAPI">
        <property name="toolTip">
-        <string>Sychronize with reverse API </string>
+        <string>Synchronize with reverse API </string>
        </property>
        <property name="text">
         <string>reverse API</string>

--- a/sdrgui/gui/devicestreamselectiondialog.ui
+++ b/sdrgui/gui/devicestreamselectiondialog.ui
@@ -32,7 +32,7 @@
      <item>
       <widget class="QComboBox" name="deviceStream">
        <property name="toolTip">
-        <string>Devcie stream index</string>
+        <string>Device stream index</string>
        </property>
       </widget>
      </item>

--- a/sdrgui/gui/fftwisdomdialog.ui
+++ b/sdrgui/gui/fftwisdomdialog.ui
@@ -134,7 +134,7 @@
      <item>
       <widget class="QCheckBox" name="fftwReverse">
        <property name="toolTip">
-        <string>Sychronize with reverse API </string>
+        <string>Synchronize with reverse API </string>
        </property>
        <property name="text">
         <string>reverse FFT</string>

--- a/swagger/sdrangel/code/html2/index.html
+++ b/swagger/sdrangel/code/html2/index.html
@@ -4093,7 +4093,7 @@ margin-bottom: 20px;
     },
     "decoding" : {
       "type" : "integer",
-      "description" : "Boolean - decoding status\n  * 0 - no deconding\n  * 1 - decoding\n"
+      "description" : "Boolean - decoding status\n  * 0 - no decoding\n  * 1 - decoding\n"
     }
   },
   "description" : "ChirpChatDemod"
@@ -4113,7 +4113,7 @@ margin-bottom: 20px;
     },
     "deBits" : {
       "type" : "integer",
-      "description" : "Low data rate optmize (DE) bits i.e. nb of FFT bins per effective symbol"
+      "description" : "Low data rate optimize (DE) bits i.e. nb of FFT bins per effective symbol"
     },
     "fftWindow" : {
       "type" : "integer",
@@ -4260,7 +4260,7 @@ margin-bottom: 20px;
     },
     "deBits" : {
       "type" : "integer",
-      "description" : "Low data rate optmize (DE) bits i.e. nb of FFT bins per effective symbol"
+      "description" : "Low data rate optimize (DE) bits i.e. nb of FFT bins per effective symbol"
     },
     "preambleChirps" : {
       "type" : "integer",
@@ -4945,7 +4945,7 @@ margin-bottom: 20px;
     },
     "squelchdB" : {
       "type" : "integer",
-      "description" : "Porcessing squared magnitude threshold (squelch) in dB from -140 t0 0"
+      "description" : "Processing squared magnitude threshold (squelch) in dB from -140 to 0"
     },
     "fftAveragingValue" : {
       "type" : "integer",
@@ -6979,7 +6979,7 @@ margin-bottom: 20px;
       "type" : "integer"
     }
   },
-  "description" : "A band of frequencies given its boudaries in Hertz (Hz)"
+  "description" : "A band of frequencies given its boundaries in Hertz (Hz)"
 };
             defs.FrequencyRange = {
   "properties" : {
@@ -8301,7 +8301,7 @@ margin-bottom: 20px;
   "properties" : {
     "success" : {
       "type" : "integer",
-      "description" : "1 if info was successfullt retrieved else 0"
+      "description" : "1 if info was successfully retrieved else 0"
     },
     "streamActive" : {
       "type" : "integer",
@@ -8462,7 +8462,7 @@ margin-bottom: 20px;
     },
     "successRx" : {
       "type" : "integer",
-      "description" : "1 if Rx info was successfullt retrieved else 0"
+      "description" : "1 if Rx info was successfully retrieved else 0"
     },
     "streamActiveRx" : {
       "type" : "integer",
@@ -8489,7 +8489,7 @@ margin-bottom: 20px;
     },
     "successTx" : {
       "type" : "integer",
-      "description" : "1 if Tx info was successfullt retrieved else 0"
+      "description" : "1 if Tx info was successfully retrieved else 0"
     },
     "streamActiveTx" : {
       "type" : "integer",
@@ -8744,7 +8744,7 @@ margin-bottom: 20px;
   "properties" : {
     "success" : {
       "type" : "integer",
-      "description" : "1 if info was successfullt retrieved else 0"
+      "description" : "1 if info was successfully retrieved else 0"
     },
     "streamActive" : {
       "type" : "integer",
@@ -8960,7 +8960,7 @@ margin-bottom: 20px;
     },
     "fftOn" : {
       "type" : "integer",
-      "description" : "Activate FFT multiband filter\n  * 0 - do not run flter\n  * 1 - run filter\n"
+      "description" : "Activate FFT multiband filter\n  * 0 - do not run filter\n  * 1 - run filter\n"
     },
     "log2FFT" : {
       "type" : "integer",
@@ -9519,7 +9519,7 @@ margin-bottom: 20px;
     "labelAltitudeOffset" : {
       "type" : "number",
       "format" : "float",
-      "description" : "Veritical offset to position label at"
+      "description" : "Vertical offset to position label at"
     },
     "modelAltitudeOffset" : {
       "type" : "number",
@@ -9678,7 +9678,7 @@ margin-bottom: 20px;
     "labelAltitudeOffset" : {
       "type" : "number",
       "format" : "float",
-      "description" : "Veritical offset to position label at"
+      "description" : "Vertical offset to position label at"
     },
     "modelAltitudeOffset" : {
       "type" : "number",
@@ -11409,7 +11409,7 @@ margin-bottom: 20px;
       "description" : "See QtMsgType"
     }
   },
-  "description" : "Repreents a Prefernce object"
+  "description" : "Represents a Preference object"
 };
             defs.Preset = {
   "properties" : {
@@ -12250,7 +12250,7 @@ margin-bottom: 20px;
     },
     "nbTxBytes" : {
       "type" : "integer",
-      "description" : "Number of bytes in a transmited I or Q sample\n  * 1\n  * 2\n  * 4\n"
+      "description" : "Number of bytes in a transmitted I or Q sample\n  * 1\n  * 2\n  * 4\n"
     },
     "apiAddress" : {
       "type" : "string"
@@ -12294,7 +12294,7 @@ margin-bottom: 20px;
     },
     "nbTxBytes" : {
       "type" : "integer",
-      "description" : "Number of bytes in a transmited I or Q sample\n  * 1\n  * 2\n  * 4\n"
+      "description" : "Number of bytes in a transmitted I or Q sample\n  * 1\n  * 2\n  * 4\n"
     },
     "deviceCenterFrequency" : {
       "type" : "integer",
@@ -14327,7 +14327,7 @@ margin-bottom: 20px;
     },
     "markerColor" : {
       "type" : "integer",
-      "description" : "Color in 8 bit BGR serie"
+      "description" : "Color in 8 bit BGR series"
     },
     "show" : {
       "type" : "integer",
@@ -14370,7 +14370,7 @@ margin-bottom: 20px;
     },
     "markerColor" : {
       "type" : "integer",
-      "description" : "Color in 8 bit BGR serie"
+      "description" : "Color in 8 bit BGR series"
     },
     "show" : {
       "type" : "integer",
@@ -14424,7 +14424,7 @@ margin-bottom: 20px;
     },
     "markerColor" : {
       "type" : "integer",
-      "description" : "Color in 8 bit BGR serie"
+      "description" : "Color in 8 bit BGR series"
     },
     "show" : {
       "type" : "integer",
@@ -14595,7 +14595,7 @@ margin-bottom: 20px;
     "temperature" : {
       "type" : "number",
       "format" : "float",
-      "description" : "Air temperature in Celsuis, for refraction"
+      "description" : "Air temperature in Celsius, for refraction"
     },
     "humidity" : {
       "type" : "number",
@@ -22563,7 +22563,7 @@ $(document).ready(function() {
 
 
                           <h2>Responses</h2>
-                            <h3> Status: 202 - On successful semding of the message it returns the details of the device being set </h3>
+                            <h3> Status: 202 - On successful sending of the message it returns the details of the device being set </h3>
 
                             <ul class="nav nav-tabs nav-tabs-examples" >
                                 <li class="active">
@@ -22578,7 +22578,7 @@ $(document).ready(function() {
                                     <script>
                                       $(document).ready(function() {
                                         var schemaWrapper = {
-  "description" : "On successful semding of the message it returns the details of the device being set",
+  "description" : "On successful sending of the message it returns the details of the device being set",
   "schema" : {
     "$ref" : "#/definitions/DeviceListItem"
   }
@@ -31220,7 +31220,7 @@ $(document).ready(function() {
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Apply main spectrun settings unconditionnaly (force)</p>
+                        <p class="marked">Apply main spectrun settings unconditionally (force)</p>
                         <p></p>
                         <br />
                         <pre class="prettyprint language-html prettyprinted" data-type="put"><code><span class="pln">/sdrangel/deviceset/{deviceSetIndex}/spectrum/settings</span></code></pre>
@@ -41339,7 +41339,7 @@ except ApiException as e:
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Delete audio input device paramaters and return to defaults</p>
+                        <p class="marked">Delete audio input device parameters and return to defaults</p>
                         <p></p>
                         <br />
                         <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/sdrangel/audio/input/parameters</span></code></pre>
@@ -41769,7 +41769,7 @@ $(document).ready(function() {
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Set audio input device paramaters</p>
+                        <p class="marked">Set audio input device parameters</p>
                         <p></p>
                         <br />
                         <pre class="prettyprint language-html prettyprinted" data-type="patch"><code><span class="pln">/sdrangel/audio/input/parameters</span></code></pre>
@@ -42534,7 +42534,7 @@ except ApiException as e:
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Delete audio output device paramaters and return to defaults</p>
+                        <p class="marked">Delete audio output device parameters and return to defaults</p>
                         <p></p>
                         <br />
                         <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/sdrangel/audio/output/parameters</span></code></pre>
@@ -52246,7 +52246,7 @@ except ApiException as e:
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Change logging parmeters for this instance</p>
+                        <p class="marked">Change logging parameters for this instance</p>
                         <p></p>
                         <br />
                         <pre class="prettyprint language-html prettyprinted" data-type="put"><code><span class="pln">/sdrangel/logging</span></code></pre>


### PR DESCRIPTION
This PR fixes the spelling in some *.md and *.ui files running the command:
> find . \( -name '*.md' -o -name '*.ui' \) -exec codespell --ignore-words-list=cach,doas,ehr,inout,lits,nd,verry --summary --write-changes {} \+

and then manually ignoring some changes made by the tool.