### PR TITLE
Fix misspelling of FFMPEG_FOUND

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -402,7 +402,7 @@ else()
     endif()
 endif()
 
-if (NOT FFMEG_FOUND AND NOT USE_PRECOMPILED_LIBS)
+if (NOT FFMPEG_FOUND AND NOT USE_PRECOMPILED_LIBS)
 
     # Libs only used by ffmpeg
 


### PR DESCRIPTION
Fix misspelling of FFMPEG_FOUND in external/CMakeLists.txt, noticed while reviewing the logs for #1740