### PR TITLE
Fix syntax error in cmake/ci/build_sdrangel.sh and remote external files from .deb

### DIFF
--- a/cmake/ci/build_sdrangel.sh
+++ b/cmake/ci/build_sdrangel.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-if [ "${TRAVIS_OS_NAME}" == "linux" ] || [ ${CI_LINUX} = true ]; then
+if [ "${TRAVIS_OS_NAME}" == "linux" ] || [ ${CI_LINUX} == true ]; then
   debuild -i -us -uc -b
 else
   mkdir -p build;  cd build

--- a/cmake/ci/build_sdrangel.sh
+++ b/cmake/ci/build_sdrangel.sh
@@ -1,6 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
-if [ "${TRAVIS_OS_NAME}" == "linux" ] || [ ${CI_LINUX} == true ]; then
+if [ "${TRAVIS_OS_NAME}" == "linux" ] || [ "${CI_LINUX}" == true ]; then
   debuild -i -us -uc -b
 else
   mkdir -p build;  cd build

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,12 @@
 override_dh_auto_configure:
 	dh_auto_configure -- -DARCH_OPT=nehalem -DENABLE_EXTERNAL_LIBRARIES=AUTO -DDEBUG_OUTPUT=ON -DBUILD_SERVER=OFF
 
+# delete any external projects (such as libsigmf) that are installed
+# would be better if we could prevent them from being installed in CMakeLists.txt
+override_dh_install:
+	-find debian/sdrangel -type d -name external -exec rm -r {} \; -exec mkdir {} \; -exec rmdir -p {} \;
+	dh_install
+
 override_dh_auto_test:
 	echo "Skipping test step"
 


### PR DESCRIPTION
Use == instead of = for comparison in cmake/ci/build_sdrangel.sh 

Remove external projects (libsigmf) from .deb.