### PR TITLE
Fix/typos

### DIFF
--- a/plugins/channelmimo/doa2/doa2gui.cpp
+++ b/plugins/channelmimo/doa2/doa2gui.cpp
@@ -82,7 +82,7 @@ bool DOA2GUI::handleMessage(const Message& message)
         m_centerFrequency = notif.getCenterFrequency();
         displayRateAndShift();
         updateAbsoluteCenterFrequency();
-        setFFTAveragingToolitp();
+        setFFTAveragingTooltip();
         return true;
     }
     else if (DOA2::MsgConfigureDOA2::match(message))
@@ -211,7 +211,7 @@ void DOA2GUI::displaySettings()
     ui->squelch->setValue(m_settings.m_squelchdB);
     ui->squelchText->setText(tr("%1").arg(m_settings.m_squelchdB, 3));
     ui->fftAveraging->setCurrentIndex(m_settings.m_fftAveragingIndex);
-    setFFTAveragingToolitp();
+    setFFTAveragingTooltip();
     getRollupContents()->restoreState(m_rollupState);
     updateAbsoluteCenterFrequency();
     blockApplySettings(false);
@@ -229,7 +229,7 @@ void DOA2GUI::displayRateAndShift()
     m_scopeVis->setLiveRate(channelSampleRate);
 }
 
-void DOA2GUI::setFFTAveragingToolitp()
+void DOA2GUI::setFFTAveragingTooltip()
 {
     float channelSampleRate = ((float) m_sampleRate) / (1<<m_settings.m_log2Decim);
     float averagingTime = (DOA2::m_fftSize * DOA2Settings::getAveragingValue(m_settings.m_fftAveragingIndex)) /
@@ -378,7 +378,7 @@ void DOA2GUI::on_fftAveraging_currentIndexChanged(int index)
     qDebug("DOA2GUI::on_averaging_currentIndexChanged: %d", index);
     m_settings.m_fftAveragingIndex = index;
     applySettings();
-    setFFTAveragingToolitp();
+    setFFTAveragingTooltip();
 }
 
 void DOA2GUI::on_centerPosition_clicked()

--- a/plugins/channelmimo/doa2/doa2gui.h
+++ b/plugins/channelmimo/doa2/doa2gui.h
@@ -85,7 +85,7 @@ private:
     void applyPosition();
 	void displaySettings();
     void displayRateAndShift();
-    void setFFTAveragingToolitp();
+    void setFFTAveragingTooltip();
     static void setNumberStr(float v, int decimalPlaces, QString& s);
     bool handleMessage(const Message& message);
     void makeUIConnections();

--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -3439,7 +3439,7 @@ void ADSBDemodGUI::adsbData_customContextMenuRequested(QPoint pos)
         });
         tableContextMenu->addAction(planeSpottersAction);
 
-        QAction* adsbExchangeAction = new QAction("View aircraft on adsbexchange.net...", tableContextMenu);
+        QAction* adsbExchangeAction = new QAction("View aircraft on adsbexchange.com...", tableContextMenu);
         connect(adsbExchangeAction, &QAction::triggered, this, [icaoHex]()->void {
             QDesktopServices::openUrl(QUrl(QString("https://globe.adsbexchange.com/?icao=%1").arg(icaoHex)));
         });
@@ -3453,7 +3453,7 @@ void ADSBDemodGUI::adsbData_customContextMenuRequested(QPoint pos)
 
         if (!aircraft->m_callsign.isEmpty())
         {
-            QAction* flightRadarAction = new QAction("View flight on flightradar24.net...", tableContextMenu);
+            QAction* flightRadarAction = new QAction("View flight on flightradar24.com...", tableContextMenu);
             connect(flightRadarAction, &QAction::triggered, this, [aircraft]()->void {
                 QDesktopServices::openUrl(QUrl(QString("https://www.flightradar24.com/%1").arg(aircraft->m_callsign)));
             });

--- a/plugins/feature/map/ibpbeacon.h
+++ b/plugins/feature/map/ibpbeacon.h
@@ -49,7 +49,7 @@ struct IBPBeacon {
         QStringList list;
         list.append("IBP Beacon");
         list.append(QString("Callsign: %1").arg(m_callsign));
-        list.append(QString("Frequency: 14.1, 18.11, 21.15, 24.92, 28.2MHz"));
+        list.append(QString("Frequency: 14.1, 18.11, 21.15, 24.93, 28.2 MHz"));
         list.append(QString("Power: 100 Watts ERP"));
         list.append(QString("Polarization: V"));
         list.append(QString("Pattern: Omni"));


### PR DESCRIPTION
This PR fixes a typo in the name of a private method and the TLDs in two context menus.