### PR TITLE
Initialize values before use

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -4250,6 +4250,7 @@ void ADSBDemodGUI::updateAirports()
         ++i;
     }
     // Save settings we've just used so we know if they've changed
+    m_currentAirportRange = m_settings.m_airportRange;
     m_currentAirportMinimumSize = m_settings.m_airportMinimumSize;
     m_currentDisplayHeliports = m_settings.m_displayHeliports;
 }

--- a/plugins/feature/map/mapibpbeacondialog.cpp
+++ b/plugins/feature/map/mapibpbeacondialog.cpp
@@ -31,7 +31,6 @@ MapIBPBeaconDialog::MapIBPBeaconDialog(MapGUI *gui, QWidget* parent) :
     ui->setupUi(this);
     connect(&m_timer, &QTimer::timeout, this, &MapIBPBeaconDialog::updateTime);
     m_timer.setInterval(1000);
-    m_timer.start();
     ui->beacons->setRowCount(IBPBeacon::m_frequencies.size());
     for (int row = 0; row < IBPBeacon::m_frequencies.size(); row++)
     {
@@ -124,4 +123,18 @@ void MapIBPBeaconDialog::updateTime()
     if ((t.second() % IBPBeacon::m_period) == 0) {
         updateTable(t);
     }
+}
+
+void MapIBPBeaconDialog::showEvent(QShowEvent *event)
+{
+    (void) event;
+    updateTable(QTime::currentTime());
+    updateTime();
+    m_timer.start();
+}
+
+void MapIBPBeaconDialog::hideEvent(QHideEvent *event)
+{
+    (void) event;
+    m_timer.stop();
 }

--- a/plugins/feature/map/mapibpbeacondialog.h
+++ b/plugins/feature/map/mapibpbeacondialog.h
@@ -39,6 +39,8 @@ private slots:
     void accept();
     void on_beacons_cellDoubleClicked(int row, int column);
     void updateTime();
+    void showEvent(QShowEvent *event);
+    void hideEvent(QHideEvent *event);
 
 private:
     MapGUI *m_gui;

--- a/plugins/samplesource/audioinput/audioinputgui.cpp
+++ b/plugins/samplesource/audioinput/audioinputgui.cpp
@@ -38,6 +38,7 @@ AudioInputGui::AudioInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
     m_forceSettings(true),
     m_settings(),
     m_sampleSource(nullptr),
+    m_sampleRate(0),
     m_centerFrequency(0)
 {
     m_deviceUISet = deviceUISet;

--- a/plugins/samplesource/localinput/localinput.cpp
+++ b/plugins/samplesource/localinput/localinput.cpp
@@ -42,6 +42,7 @@ LocalInput::LocalInput(DeviceAPI *deviceAPI) :
     m_deviceAPI(deviceAPI),
     m_settings(),
     m_centerFrequency(0),
+    m_sampleRate(0),
 	m_deviceDescription("LocalInput")
 {
     m_sampleFifo.setLabel(m_deviceDescription);


### PR DESCRIPTION
This PR fixes some warnings found with valgrind.

I think that the commit [Update the beacons only when the dialog is visible](https://github.com/f4exb/sdrangel/commit/59a25ed72f75729de71f780982a1c6a4d36ca478) is needed only when using valgrind because the initialization takes more than a second (on my system) and so the first timer is triggered before the initialization is complete. In retrospect, probably moving `m_timer.start();` at the end of the constructor would be enough, but there is no need to update the table of beacons when it is not visible.