### PR TITLE
Fix RTLSDR E4000 gain and bandwidth settings and add RTLSDRBlog V4 support

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -22,7 +22,7 @@ set(MIRISDR_TAG "v2.0.0")
 set(LIBSIGMF_TAG "new-namespaces")
 
 set(PTHREADS4W_TAG "Version-2-11-0-release")
-set(RTLSDR_TAG 5e73f90f1d85d8db2e583f3dbf1cff052d71d59b)
+set(RTLSDR_TAG 1261fbb285297da08f4620b18871b6d6d9ec2a7b)
 set(RTLSDR_UDEV OFF)
 set(SOAPYSDR_TAG "soapy-sdr-0.7.1")
 set(SOAPYSDR_SDRPLAY_TAG "soapy-sdrplay-0.2.0")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1091,7 +1091,11 @@ if (WIN32 OR APPLE)
         endif ()
         # Disable pkg-config to allow LIBUSB_INCLUDE_DIRS to be used
         set(DISABLE_PKGCONFIG "-DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON")
-        # needs libusb
+        # If we want to use https://github.com/librtlsdr/librtlsdr instead of https://github.com/osmocom/rtl-sdr.git
+        #  - Don't use DISABLE_PKGCONFIG
+        #  - Use -DLIBUSB_INCLUDE_DIR instead of -DLIBUSB_INCLUDE_DIRS
+        #  - Build target is rtl_sdr rather than rtlsdr
+        #  - Use tag development otherwise it will not build with MSVC
         ExternalProject_Add(rtlsdr
                 GIT_REPOSITORY https://github.com/osmocom/rtl-sdr.git
                 GIT_TAG ${RTLSDR_TAG}

--- a/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
@@ -208,7 +208,7 @@ void RTLSDRGui::updateFrequencyLimits()
 {
     // values in kHz
     qint64 deltaFrequency = m_settings.m_transverterMode ? m_settings.m_transverterDeltaFrequency/1000 : 0;
-    qint64 minLimit = (m_settings.m_noModMode ? RTLSDRInput::frequencyLowRangeMin : RTLSDRInput::frequencyHighRangeMin) + deltaFrequency;
+    qint64 minLimit = (m_settings.m_noModMode ? RTLSDRInput::frequencyLowRangeMin : m_sampleSource->m_frequencyHighRangeMin) + deltaFrequency;
     qint64 maxLimit = (m_settings.m_noModMode ? RTLSDRInput::frequencyLowRangeMax : RTLSDRInput::frequencyHighRangeMax) + deltaFrequency;
 
     if (m_settings.m_transverterMode)

--- a/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
@@ -68,6 +68,14 @@ RTLSDRGui::RTLSDRGui(DeviceUISet *deviceUISet, QWidget* parent) :
 	m_gains = m_sampleSource->getGains();
 	displayGains();
 
+    rtlsdr_tuner tunerType = m_sampleSource->getTunerType();
+    // Disable widgets not relevent for this tuner
+    bool offsetTuningEnabled = (tunerType != RTLSDR_TUNER_R820T) && (tunerType != RTLSDR_TUNER_R828D);
+    if (!offsetTuningEnabled) {
+        ui->offsetTuning->setEnabled(false);
+    }
+    ui->tunerType->setText("Tuner: " + m_sampleSource->getTunerName());
+
 	connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     m_sampleSource->setMessageQueueToGUI(&m_inputMessageQueue);
 }
@@ -474,6 +482,7 @@ void RTLSDRGui::on_checkBox_stateChanged(int state)
 	if (state == Qt::Checked)
 	{
 		ui->gain->setEnabled(false);
+        ui->offsetTuning->setEnabled(false);
         m_settings.m_noModMode = true;
 	    updateFrequencyLimits();
 		ui->centerFrequency->setValue(7000);
@@ -482,6 +491,7 @@ void RTLSDRGui::on_checkBox_stateChanged(int state)
 	else
 	{
 		ui->gain->setEnabled(true);
+        ui->offsetTuning->setEnabled(true);
         m_settings.m_noModMode = false;
 	    updateFrequencyLimits();
 		ui->centerFrequency->setValue(434000);

--- a/plugins/samplesource/rtlsdr/rtlsdrgui.ui
+++ b/plugins/samplesource/rtlsdr/rtlsdrgui.ui
@@ -500,12 +500,12 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_direct">
      <item>
-      <widget class="QCheckBox" name="checkBox">
+      <widget class="QLabel" name="tunerType">
        <property name="toolTip">
-        <string>RTLSDR special direct sampling mode (HF Bands)</string>
+        <string>Tuner type</string>
        </property>
        <property name="text">
-        <string>No-mod DS</string>
+        <string>Tuner: Unknown</string>
        </property>
       </widget>
      </item>
@@ -521,6 +521,16 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBox">
+       <property name="toolTip">
+        <string>RTLSDR special direct sampling mode (HF Bands)</string>
+       </property>
+       <property name="text">
+        <string>DS</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QCheckBox" name="offsetTuning">

--- a/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
@@ -44,7 +44,6 @@ MESSAGE_CLASS_DEFINITION(RTLSDRInput::MsgStartStop, Message)
 
 const quint64 RTLSDRInput::frequencyLowRangeMin = 0UL;
 const quint64 RTLSDRInput::frequencyLowRangeMax = 275000UL;
-const quint64 RTLSDRInput::frequencyHighRangeMin = 24000UL;
 const quint64 RTLSDRInput::frequencyHighRangeMax = 2400000UL;
 const int RTLSDRInput::sampleRateLowRangeMin = 225001;
 const int RTLSDRInput::sampleRateLowRangeMax = 300000;
@@ -158,8 +157,14 @@ bool RTLSDRInput::openDevice()
 
     m_tunerType = rtlsdr_get_tuner_type(m_dev);
 
-    qInfo("RTLSDRInput::openDevice: open: %s %s, SN: %s Tuner: %s", vendor, product, serial, getTunerName());
+    qInfo("RTLSDRInput::openDevice: open: %s %s, SN: %s Tuner: %s", vendor, product, serial, qPrintable(getTunerName()));
     m_deviceDescription = QString("%1 (SN %2)").arg(product).arg(serial);
+
+    if ((vendor == QStringLiteral("RTLSDRBlog")) && (product == QStringLiteral("Blog V4"))) {
+        m_frequencyHighRangeMin = 0;
+    } else {
+        m_frequencyHighRangeMin = 24000UL;
+    }
 
     if ((res = rtlsdr_set_sample_rate(m_dev, 1152000)) < 0)
     {

--- a/plugins/samplesource/rtlsdr/rtlsdrinput.h
+++ b/plugins/samplesource/rtlsdr/rtlsdrinput.h
@@ -133,6 +133,8 @@ public:
             SWGSDRangel::SWGDeviceSettings& response);
 
 	const std::vector<int>& getGains() const { return m_gains; }
+    rtlsdr_tuner getTunerType() const { return m_tunerType; }
+    QString getTunerName() const;
 	void set_ds_mode(int on);
 
 	static const quint64 frequencyLowRangeMin;
@@ -152,6 +154,7 @@ private:
 	RTLSDRThread* m_rtlSDRThread;
 	QString m_deviceDescription;
 	std::vector<int> m_gains;
+    rtlsdr_tuner m_tunerType;
 	bool m_running;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/samplesource/rtlsdr/rtlsdrinput.h
+++ b/plugins/samplesource/rtlsdr/rtlsdrinput.h
@@ -139,7 +139,7 @@ public:
 
 	static const quint64 frequencyLowRangeMin;
 	static const quint64 frequencyLowRangeMax;
-    static const quint64 frequencyHighRangeMin;
+    quint64 m_frequencyHighRangeMin;
     static const quint64 frequencyHighRangeMax;
 	static const int sampleRateLowRangeMin;
     static const int sampleRateLowRangeMax;


### PR DESCRIPTION
I noticed two problems with Nooelec RTLSDR with E4000 tuner:

- Gain setting was not working. After adjusting the gain, it would re-adjust itself as though AGC had been reenabled. It appears we need to call rtlsdr_set_tuner_gain_mode before each call to rtlsdr_set_tuner_gain.
- Adjusting RFBW would result in a bizarre frequency response.

Also, added a change to the GUI that displays the tuner type and disables Ofs checkbox if not supported for the given tuner.
