### PR TITLE
Radio Astronomy: Add rotator Az/El and offset to table

### DIFF
--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -57,6 +57,7 @@
 #include "feature/featurewebapiutils.h"
 #include "feature/feature.h"
 #include "feature/featureset.h"
+#include "webapi/webapiutils.h"
 
 #include "radioastronomy.h"
 #include "radioastronomysink.h"
@@ -287,6 +288,10 @@ void RadioAstronomyGUI::resizePowerTable()
     ui->powerTable->setItem(row, POWER_COL_SENSOR_1, new QTableWidgetItem("1.0000000"));
     ui->powerTable->setItem(row, POWER_COL_SENSOR_2, new QTableWidgetItem("1.0000000"));
     ui->powerTable->setItem(row, POWER_COL_UTC, new QTableWidgetItem("15/04/2016 10:17:00"));
+    ui->powerTable->setItem(row, POWER_COL_ROT_AZ, new QTableWidgetItem("359.0"));
+    ui->powerTable->setItem(row, POWER_COL_ROT_EL, new QTableWidgetItem("-90.0"));
+    ui->powerTable->setItem(row, POWER_COL_ROT_AZ_OFF, new QTableWidgetItem("-10.0"));
+    ui->powerTable->setItem(row, POWER_COL_ROT_EL_OFF, new QTableWidgetItem("-10.0"));
     ui->powerTable->resizeColumnsToContents();
     ui->powerTable->removeRow(row);
 }
@@ -635,6 +640,10 @@ void RadioAstronomyGUI::powerMeasurementReceived(FFTMeasurement *fft, bool skipC
     QTableWidgetItem* sensor1Item = new QTableWidgetItem();
     QTableWidgetItem* sensor2Item = new QTableWidgetItem();
     QTableWidgetItem* utcItem = new QTableWidgetItem();
+    QTableWidgetItem* rotAzItem = new QTableWidgetItem();
+    QTableWidgetItem* rotElItem = new QTableWidgetItem();
+    QTableWidgetItem* rotAzOffItem = new QTableWidgetItem();
+    QTableWidgetItem* rotElOffItem = new QTableWidgetItem();
 
     ui->powerTable->setItem(row, POWER_COL_DATE, dateItem);
     ui->powerTable->setItem(row, POWER_COL_TIME, timeItem);
@@ -664,6 +673,10 @@ void RadioAstronomyGUI::powerMeasurementReceived(FFTMeasurement *fft, bool skipC
     ui->powerTable->setItem(row, POWER_COL_SENSOR_1, sensor1Item);
     ui->powerTable->setItem(row, POWER_COL_SENSOR_2, sensor2Item);
     ui->powerTable->setItem(row, POWER_COL_UTC, utcItem);
+    ui->powerTable->setItem(row, POWER_COL_ROT_AZ, rotAzItem);
+    ui->powerTable->setItem(row, POWER_COL_ROT_EL, rotElItem);
+    ui->powerTable->setItem(row, POWER_COL_ROT_AZ_OFF, rotAzOffItem);
+    ui->powerTable->setItem(row, POWER_COL_ROT_EL_OFF, rotElOffItem);
 
     ui->powerTable->setSortingEnabled(true);
 
@@ -696,6 +709,13 @@ void RadioAstronomyGUI::powerMeasurementReceived(FFTMeasurement *fft, bool skipC
     airTempItem->setData(Qt::DisplayRole, fft->m_airTemp);
     sensor1Item->setData(Qt::DisplayRole, fft->m_sensor[0]);
     sensor2Item->setData(Qt::DisplayRole, fft->m_sensor[1]);
+    if (fft->m_rotValid)
+    {
+        rotAzItem->setData(Qt::DisplayRole, fft->m_rotAz);
+        rotElItem->setData(Qt::DisplayRole, fft->m_rotEl);
+        rotAzOffItem->setData(Qt::DisplayRole, fft->m_rotAzOff);
+        rotElOffItem->setData(Qt::DisplayRole, fft->m_rotElOff);
+    }
 
     addToPowerSeries(fft, skipCalcs);
 }
@@ -2130,6 +2150,10 @@ RadioAstronomyGUI::RadioAstronomyGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUI
     ui->powerTable->setItemDelegateForColumn(POWER_COL_VBCRS, new DecimalDelegate(1));
     ui->powerTable->setItemDelegateForColumn(POWER_COL_VLSR, new DecimalDelegate(1));
     ui->powerTable->setItemDelegateForColumn(POWER_COL_AIR_TEMP, new DecimalDelegate(1));
+    ui->powerTable->setItemDelegateForColumn(POWER_COL_ROT_AZ, new DecimalDelegate(0));
+    ui->powerTable->setItemDelegateForColumn(POWER_COL_ROT_EL, new DecimalDelegate(0));
+    ui->powerTable->setItemDelegateForColumn(POWER_COL_ROT_AZ_OFF, new DecimalDelegate(0));
+    ui->powerTable->setItemDelegateForColumn(POWER_COL_ROT_EL_OFF, new DecimalDelegate(0));
 
     resizeSpectrumMarkerTable();
     ui->spectrumMarkerTable->setItemDelegateForColumn(SPECTRUM_MARKER_COL_FREQ, new DecimalDelegate(6));
@@ -2733,12 +2757,20 @@ void RadioAstronomyGUI::setColumnPrecisionFromRotator()
             ((DecimalDelegate *)ui->powerTable->itemDelegateForColumn(POWER_COL_GAL_LON))->setPrecision(precision);
             ((DecimalDelegate *)ui->powerTable->itemDelegateForColumn(POWER_COL_AZ))->setPrecision(precision);
             ((DecimalDelegate *)ui->powerTable->itemDelegateForColumn(POWER_COL_EL))->setPrecision(precision);
+            ((DecimalDelegate *)ui->powerTable->itemDelegateForColumn(POWER_COL_ROT_AZ))->setPrecision(precision);
+            ((DecimalDelegate *)ui->powerTable->itemDelegateForColumn(POWER_COL_ROT_EL))->setPrecision(precision);
+            ((DecimalDelegate *)ui->powerTable->itemDelegateForColumn(POWER_COL_ROT_AZ_OFF))->setPrecision(precision);
+            ((DecimalDelegate *)ui->powerTable->itemDelegateForColumn(POWER_COL_ROT_EL_OFF))->setPrecision(precision);
             if (precision > old)
             {
                 ui->powerTable->resizeColumnToContents(POWER_COL_GAL_LAT);
                 ui->powerTable->resizeColumnToContents(POWER_COL_GAL_LON);
                 ui->powerTable->resizeColumnToContents(POWER_COL_AZ);
                 ui->powerTable->resizeColumnToContents(POWER_COL_EL);
+                ui->powerTable->resizeColumnToContents(POWER_COL_ROT_AZ);
+                ui->powerTable->resizeColumnToContents(POWER_COL_ROT_EL);
+                ui->powerTable->resizeColumnToContents(POWER_COL_ROT_AZ_OFF);
+                ui->powerTable->resizeColumnToContents(POWER_COL_ROT_EL_OFF);
             }
             ui->powerTable->viewport()->update();
         }
@@ -3712,6 +3744,8 @@ void RadioAstronomyGUI::calCompletetReceived(const RadioAstronomy::MsgCalComplet
     }
     fft->m_tSys0 = calcTSys0();
     fft->m_baseline = m_settings.m_spectrumBaseline;
+    getRotatorData(fft);
+
 
     if (!hot) {
         ui->calTsky->setText(QString::number(m_skyTemp, 'f', 1));
@@ -4650,6 +4684,66 @@ void RadioAstronomyGUI::addFFT(FFTMeasurement *fft, bool skipCalcs)
     }
 }
 
+void RadioAstronomyGUI::getRotatorData(FFTMeasurement *fft)
+{
+    const QRegExp re("F([0-9]+):([0-9]+)");
+    if (re.indexIn(m_settings.m_rotator) >= 0)
+    {
+        int rotatorFeatureSetIndex = re.capturedTexts()[1].toInt();
+        int rotatorFeatureIndex = re.capturedTexts()[2].toInt();
+
+        SWGSDRangel::SWGFeatureReport featureReport;
+        double value;
+        qDebug() << m_settings.m_rotator << rotatorFeatureSetIndex << rotatorFeatureIndex;
+
+        if (ChannelWebAPIUtils::getFeatureReport(rotatorFeatureSetIndex, rotatorFeatureIndex, featureReport))
+        {
+            QJsonObject *jsonObj = featureReport.asJsonObject();
+            qDebug() << *jsonObj;
+            if (WebAPIUtils::getSubObjectDouble(*jsonObj, "currentAzimuth", value)) {
+                fft->m_rotAz = value;
+            } else {
+                qDebug() << "RadioAstronomyGUI::getRotatorData: getSubObjectDouble currentAzimuth failed";
+            }
+            if (WebAPIUtils::getSubObjectDouble(*jsonObj, "currentElevation", value)) {
+                fft->m_rotEl = value;
+            } else {
+                qDebug() << "RadioAstronomyGUI::getRotatorData: getSubObjectDouble currentElevation failed";
+            }
+        }
+        else
+        {
+            qDebug() << "RadioAstronomyGUI::getRotatorData: getFeatureReport failed";
+        }
+
+        SWGSDRangel::SWGFeatureSettings featureSettingsResponse;
+        Feature *feature;
+        if (ChannelWebAPIUtils::getFeatureSettings(rotatorFeatureSetIndex, rotatorFeatureIndex, featureSettingsResponse, feature))
+        {
+            QJsonObject *jsonObj = featureSettingsResponse.asJsonObject();
+            qDebug() << *jsonObj;
+            if (WebAPIUtils::getSubObjectDouble(*jsonObj, "azimuthOffset", value)) {
+                fft->m_rotAzOff = value;
+            } else {
+                qDebug() << "RadioAstronomyGUI::getRotatorData: getSubObjectDouble azimuthOffset failed";
+            }
+            if (WebAPIUtils::getSubObjectDouble(*jsonObj, "elevationOffset", value)) {
+                fft->m_rotElOff = value;
+            } else {
+                qDebug() << "RadioAstronomyGUI::getRotatorData: getSubObjectDouble elevationOffset ";
+            }
+        }
+        else
+        {
+            qDebug() << "RadioAstronomyGUI::getRotatorData: getFeatureSettings failed";
+        }
+
+        fft->m_rotValid = true;
+    }
+    else
+        qDebug() << "Couldn't parse rotator feature " << m_settings.m_rotator;
+}
+
 void RadioAstronomyGUI::fftMeasurementReceived(const RadioAstronomy::MsgFFTMeasurement& measurement)
 {
     FFTMeasurement *fft = new FFTMeasurement();
@@ -4681,6 +4775,7 @@ void RadioAstronomyGUI::fftMeasurementReceived(const RadioAstronomy::MsgFFTMeasu
     fft->m_sweepIndex = m_sweepIndex++;
     fft->m_tSys0 = calcTSys0();
     fft->m_baseline = m_settings.m_spectrumBaseline;
+    getRotatorData(fft);
 
     calcFFTPower(fft);
     calcFFTTotalPower(fft);

--- a/plugins/channelrx/radioastronomy/radioastronomygui.h
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.h
@@ -98,6 +98,12 @@ class RadioAstronomyGUI : public ChannelGUI {
         float m_skyTemp;
         float m_sensor[RADIOASTRONOMY_SENSORS];
 
+        bool m_rotValid;
+        float m_rotAz;
+        float m_rotEl;
+        float m_rotAzOff;
+        float m_rotElOff;
+
         int m_sweepIndex;
 
         FFTMeasurement() :
@@ -121,6 +127,11 @@ class RadioAstronomyGUI : public ChannelGUI {
             m_coordsValid(false),
             m_airTemp(0.0),
             m_skyTemp(0.0),
+            m_rotValid(false),
+            m_rotAz(0.0),
+            m_rotEl(0.0),
+            m_rotAzOff(0.0),
+            m_rotElOff(0.0),
             m_sweepIndex(0)
         {
         }
@@ -450,6 +461,7 @@ private:
     void calcSpectrumChartTickCount(QValueAxis *axis, int width);
     int powerYUnitsToIndex(RadioAstronomySettings::PowerYUnits units);
     void setColumnPrecisionFromRotator();
+    void getRotatorData(FFTMeasurement *fft);
 
     void leaveEvent(QEvent*);
     void enterEvent(EnterEventType*);
@@ -487,7 +499,11 @@ private:
         POWER_COL_AIR_TEMP,
         POWER_COL_SENSOR_1,
         POWER_COL_SENSOR_2,
-        POWER_COL_UTC
+        POWER_COL_UTC,
+        POWER_COL_ROT_AZ,
+        POWER_COL_ROT_EL,
+        POWER_COL_ROT_AZ_OFF,
+        POWER_COL_ROT_EL_OFF
     };
 
     enum PowerMarkerTable {

--- a/plugins/channelrx/radioastronomy/radioastronomygui.ui
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.ui
@@ -5147,6 +5147,38 @@ This should be close to the expected difference in power between hot and cold ca
         <string>UTC date and time measurement finished</string>
        </property>
       </column>
+      <column>
+       <property name="text">
+        <string>Az (Rot)</string>
+       </property>
+       <property name="toolTip">
+        <string>Azimuth of rotator controller in degrees</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>El (Rot)</string>
+       </property>
+       <property name="toolTip">
+        <string>Elevation of rotator controller in degrees</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Az Off (Rot)</string>
+       </property>
+       <property name="toolTip">
+        <string>Azimuth offset of rotator controller in degrees</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>El Off (Rot)</string>
+       </property>
+       <property name="toolTip">
+        <string>Elevation offset of rotator controller in degrees</string>
+       </property>
+      </column>
      </widget>
     </item>
    </layout>

--- a/plugins/channelrx/radioastronomy/radioastronomysettings.h
+++ b/plugins/channelrx/radioastronomy/radioastronomysettings.h
@@ -28,7 +28,7 @@
 class Serializable;
 
 // Number of columns in the tables
-#define RADIOASTRONOMY_POWERTABLE_COLUMNS 28
+#define RADIOASTRONOMY_POWERTABLE_COLUMNS 32
 
 // Number of sensors
 #define RADIOASTRONOMY_SENSORS 2

--- a/plugins/channelrx/radioastronomy/readme.md
+++ b/plugins/channelrx/radioastronomy/readme.md
@@ -793,7 +793,7 @@ The columns in the table include:
 - Sensor 2 - Data recorded for Sensor 2.
 - UTC - UTC date and time at the end of the measurement.
 - Az (Rot) - Azimuth of rotator controller in degrees at the end of measurement.
-- El (Rot) - Elevation of rotator controller in degrees at then end of measurement.
+- El (Rot) - Elevation of rotator controller in degrees at the end of measurement.
 - Az Off (Rot) - Azimimuth offset of rotator controller in degrees at the end of measurement.
 - El Off (Rot) - Elevation offset of rotator controller in degrees at the end of measurement.
 

--- a/plugins/channelrx/radioastronomy/readme.md
+++ b/plugins/channelrx/radioastronomy/readme.md
@@ -792,6 +792,10 @@ The columns in the table include:
 - Sensor 1 - Data recorded for Sensor 1.
 - Sensor 2 - Data recorded for Sensor 2.
 - UTC - UTC date and time at the end of the measurement.
+- Az (Rot) - Azimuth of rotator controller in degrees at the end of measurement.
+- El (Rot) - Elevation of rotator controller in degrees at then end of measurement.
+- Az Off (Rot) - Azimimuth offset of rotator controller in degrees at the end of measurement.
+- El Off (Rot) - Elevation offset of rotator controller in degrees at the end of measurement.
 
 Right clicking on the table shows a popup menu that supports:
 

--- a/plugins/feature/startracker/startrackergui.h
+++ b/plugins/feature/startracker/startrackergui.h
@@ -81,6 +81,7 @@ private:
     QList<QString> m_settingsKeys;
     RollupState m_rollupState;
     bool m_doApplySettings;
+    bool m_doPlotChart;
 
     StarTracker* m_starTracker;
     MessageQueue m_inputMessageQueue;
@@ -135,6 +136,8 @@ private:
     virtual ~StarTrackerGUI();
 
     void blockApplySettings(bool block);
+    void blockPlotChart();
+    void unblockPlotChartAndPlot();
     void applySettings(bool force = false);
     void displaySettings();
     void updateForTarget();

--- a/plugins/feature/startracker/startrackerworker.cpp
+++ b/plugins/feature/startracker/startrackerworker.cpp
@@ -519,8 +519,6 @@ void StarTrackerWorker::update()
         else
             qDebug() << "StarTrackerWorker::update - Failed to parse feature name " << m_settings.m_target;
     }
-    else
-        qDebug() << "TARGET IS NOT SAT TRACKER!! " << m_settings.m_target;
 
     if (m_settings.m_target == "Sun")
     {

--- a/sdrbase/channel/channelwebapiutils.h
+++ b/sdrbase/channel/channelwebapiutils.h
@@ -81,13 +81,13 @@ public:
     static bool getChannelReportValue(unsigned int deviceIndex, unsigned int channelIndex, const QString &key, int &value);
     static bool getChannelReportValue(unsigned int deviceIndex, unsigned int channelIndex, const QString &key, double &value);
     static bool getChannelReportValue(unsigned int deviceIndex, unsigned int channelIndex, const QString &key, QString &value);
-protected:
     static bool getDeviceSettings(unsigned int deviceIndex, SWGSDRangel::SWGDeviceSettings &deviceSettingsResponse, DeviceSet *&deviceSet);
     static bool getDeviceReport(unsigned int deviceIndex, SWGSDRangel::SWGDeviceReport &deviceReport);
     static bool getFeatureSettings(unsigned int featureSetIndex, unsigned int featureIndex, SWGSDRangel::SWGFeatureSettings &featureSettingsResponse, Feature *&feature);
     static bool getFeatureReport(unsigned int featureSetIndex, unsigned int featureIndex, SWGSDRangel::SWGFeatureReport &featureReport);
     static bool getChannelSettings(unsigned int deviceIndex, unsigned int channelIndex, SWGSDRangel::SWGChannelSettings &channelSettingsResponse, ChannelAPI *&channel);
     static bool getChannelReport(unsigned int deviceIndex, unsigned int channelIndex, SWGSDRangel::SWGChannelReport &channelReport);
+protected:
     static QString getDeviceHardwareId(unsigned int deviceIndex);
 };
 


### PR DESCRIPTION
In the Radio Astronomy, add rotator Az/El and az/el offset to table.

Also optimizes redrawing of charts in the Star Tracker, as was being redrawn unnecessarily and unnecessary refraction calculation was very slow.