### PR TITLE
Initialise PhaseDiscriminators state, to avoid outputting huge values.

### DIFF
--- a/plugins/channelrx/demodpager/pagerdemodgui.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodgui.cpp
@@ -819,6 +819,8 @@ void PagerDemodGUI::makeUIConnections()
     QObject::connect(ui->logEnable, &ButtonSwitch::clicked, this, &PagerDemodGUI::on_logEnable_clicked);
     QObject::connect(ui->logFilename, &QToolButton::clicked, this, &PagerDemodGUI::on_logFilename_clicked);
     QObject::connect(ui->logOpen, &QToolButton::clicked, this, &PagerDemodGUI::on_logOpen_clicked);
+    QObject::connect(ui->channel1, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &PagerDemodGUI::on_channel1_currentIndexChanged);
+    QObject::connect(ui->channel2, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &PagerDemodGUI::on_channel2_currentIndexChanged);
 }
 
 void PagerDemodGUI::updateAbsoluteCenterFrequency()

--- a/sdrbase/dsp/phasediscri.h
+++ b/sdrbase/dsp/phasediscri.h
@@ -25,13 +25,25 @@
 class PhaseDiscriminators
 {
 public:
-	/**
+
+    PhaseDiscriminators() :
+        m_fmScaling(1.0f)
+    {
+        reset();
+    }
+
+    /**
 	 * Reset stored values
 	 */
 	void reset()
 	{
 		m_m1Sample = 0;
 		m_m2Sample = 0;
+        m_fltPreviousI = 0.0f;
+        m_fltPreviousQ = 0.0f;
+        m_fltPreviousI2 = 0.0f;
+        m_fltPreviousQ2 = 0.0f;
+        m_prevArg = 0.0f;
 	}
 
 	/**


### PR DESCRIPTION
This PR initialises state in the PhaseDiscriminators class, to prevent it from randomly outputting huge values (ie. 1e+30).

(When such a large value gets in to the MovingAverageUtil, it will stay there, as it keeps a running total, rather than resumming the elements. 1e30-1=1e30)

This fixes #1794.

Patch also connects scope signals in Pager demod, noticed while debugging this issue.