### PR TITLE
Add windows-default CMake preset for building with Visual Studio

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,56 +1,98 @@
 {
-    "version": 3,
-    "configurePresets": [
-        {
-            "name": "default",
-            "binaryDir": "build-default",
-            "cacheVariables": {
-                "DEBUG_OUTPUT": "ON",
-                "AIRSPYHF_DIR": "/opt/install/libairspyhf",
-                "AIRSPY_DIR": "/opt/install/libairspy",
-                "APT_DIR": "/opt/install/aptdec",
-                "BLADERF_DIR": "/opt/install/libbladeRF",
-                "CM256CC_DIR": "/opt/install/cm256cc",
-                "CODEC2_DIR": "/opt/install/codec2",
-                "DAB_DIR": "/opt/install/libdab",
-                "DSDCC_DIR": "/opt/install/dsdcc",
-                "HACKRF_DIR": "/opt/install/libhackrf",
-                "HAMLIB_DIR": "/opt/build/hamlib-prefix",
-                "IIO_DIR": "/opt/install/libiio",
-                "LIBSIGMF_DIR": "/opt/install/libsigmf",
-                "LIMESUITE_DIR": "/opt/install/LimeSuite",
-                "MBE_DIR": "/opt/install/mbelib",
-                "MIRISDR_DIR": "/opt/install/libmirisdr",
-                "PERSEUS_DIR": "/opt/install/libperseus",
-                "RTLSDR_DIR": "/opt/install/librtlsdr",
-                "SERIALDV_DIR": "/opt/install/serialdv",
-                "SGP4_DIR": "/opt/install/sgp4",
-                "SOAPYSDR_DIR": "/opt/install/SoapySDR",
-                "UHD_DIR": "/opt/install/uhd",
-                "XTRX_DIR": "/opt/install/xtrx-images",
-                "CMAKE_INSTALL_PREFIX": "/opt/install/sdrangel"
-            },
-            "warnings": {
-                "dev": false
-            }
-        },
-        {
-            "name": "default-qt6",
-            "inherits": "default",
-            "binaryDir": "build-qt6",
-            "cacheVariables": {
-                "ENABLE_QT6": "ON"
-            }
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "default",
+      "binaryDir": "build-default",
+      "cacheVariables": {
+        "DEBUG_OUTPUT": "ON",
+        "AIRSPYHF_DIR": "/opt/install/libairspyhf",
+        "AIRSPY_DIR": "/opt/install/libairspy",
+        "APT_DIR": "/opt/install/aptdec",
+        "BLADERF_DIR": "/opt/install/libbladeRF",
+        "CM256CC_DIR": "/opt/install/cm256cc",
+        "CODEC2_DIR": "/opt/install/codec2",
+        "DAB_DIR": "/opt/install/libdab",
+        "DSDCC_DIR": "/opt/install/dsdcc",
+        "HACKRF_DIR": "/opt/install/libhackrf",
+        "HAMLIB_DIR": "/opt/build/hamlib-prefix",
+        "IIO_DIR": "/opt/install/libiio",
+        "LIBSIGMF_DIR": "/opt/install/libsigmf",
+        "LIMESUITE_DIR": "/opt/install/LimeSuite",
+        "MBE_DIR": "/opt/install/mbelib",
+        "MIRISDR_DIR": "/opt/install/libmirisdr",
+        "PERSEUS_DIR": "/opt/install/libperseus",
+        "RTLSDR_DIR": "/opt/install/librtlsdr",
+        "SERIALDV_DIR": "/opt/install/serialdv",
+        "SGP4_DIR": "/opt/install/sgp4",
+        "SOAPYSDR_DIR": "/opt/install/SoapySDR",
+        "UHD_DIR": "/opt/install/uhd",
+        "XTRX_DIR": "/opt/install/xtrx-images",
+        "CMAKE_INSTALL_PREFIX": "/opt/install/sdrangel"
+      },
+      "warnings": {
+        "dev": false
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [ "Linux" ]
         }
-    ],
-    "buildPresets": [
-        {
-          "name": "default",
-          "configurePreset": "default"
-        },
-        {
-            "name": "default-qt6",
-            "configurePreset": "default-qt6"
+      }
+    },
+    {
+      "name": "default-windows",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "DEBUG_OUTPUT": "ON",
+        "RX_SAMPLE_24BIT": "ON",
+        "ARCH_OPT": "SSE4_2",
+        "HIDE_CONSOLE": "OFF",
+        "ENABLE_AIRSPY": "ON",
+        "ENABLE_AIRSPYHF": "ON",
+        "ENABLE_BLADERF": "ON",
+        "ENABLE_HACKRF": "ON",
+        "ENABLE_IIO": "ON",
+        "ENABLE_MIRISDR": "OFF",
+        "ENABLE_PERSEUS": "ON",
+        "ENABLE_RTLSDR": "ON",
+        "ENABLE_SDRPLAY": "ON",
+        "ENABLE_SOAPYSDR": "ON",
+        "ENABLE_XTRX": "ON",
+        "ENABLE_USRP": "ON",
+        "BUILD_SERVER": "OFF",
+        "CMAKE_PREFIX_PATH": "C:/Qt/5.15.2/msvc2019_64;C:/Applications/boost_1_81_0"
+      },
+      "warnings": {
+        "dev": false
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [ "Windows" ]
         }
-    ]
+      }
+    },
+    {
+      "name": "default-qt6",
+      "inherits": "default",
+      "binaryDir": "build-qt6",
+      "cacheVariables": {
+        "ENABLE_QT6": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
+    {
+      "name": "default-windows",
+      "configurePreset": "default-windows"
+    },
+    {
+      "name": "default-qt6",
+      "configurePreset": "default-qt6"
+    }
+  ]
 }


### PR DESCRIPTION
This PR updates CMakePresets.json to add a windows-default preset, that can be used to configure and build SDRangel easily from within Visual Studio (Just need to open the folder and hit build).

Hopefully Linux presets should remain the same. Have just added an option that indicates they are for Linux, so VS doesn't try to build them.
