### PR TITLE
Fixes for Mac build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.13.0)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
 if(APPLE)
-    project(sdrangel LANGUAGES CXX OBJCXX)
+    project(sdrangel LANGUAGES C CXX OBJCXX)
 else()
     project(sdrangel)
 endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -185,9 +185,10 @@ else()
     set(USE_PRECOMPILED_LIBS TRUE)
 endif()
 
-# We don't CACHE the _DEPENDS variables, as the external project is only added when NOT _FOUND
-# and not in subsequent configures when _FOUND
-# Use PARENT_SCOPE so they can still be used in other CMakeFiles.
+# We don't CACHE the _DEPENDS variables, as some external projects are only added when NOT _FOUND
+# and not in subsequent configures when _FOUND (E.g. ffmpeg/opencv aren't added second time
+# around as it slows down the build and causes some dependencies to always be rebuilt.)
+# Use PARENT_SCOPE so they can be used in other CMakeFiles.
 macro(set_global NAME VALUE)
     set(${NAME} ${VALUE})
     set(${NAME} ${VALUE} PARENT_SCOPE)

--- a/plugins/channelrx/demoddatv/CMakeLists.txt
+++ b/plugins/channelrx/demoddatv/CMakeLists.txt
@@ -96,8 +96,8 @@ add_executable(ldpctool
 )
 install(TARGETS ldpctool DESTINATION ${INSTALL_BIN_DIR})
 
-if(FFMPEG_EXTERNAL)
-    add_dependencies(${TARGET_NAME} ffmpeg)
+if(DEFINED FFMPEG_DEPENDS)
+    add_dependencies(${TARGET_NAME} ${FFMPEG_DEPENDS})
 endif()
 
 install(TARGETS ${TARGET_NAME} DESTINATION ${INSTALL_FOLDER})

--- a/plugins/channeltx/modatv/CMakeLists.txt
+++ b/plugins/channeltx/modatv/CMakeLists.txt
@@ -62,7 +62,7 @@ target_link_libraries(${TARGET_NAME}
 )
 
 if(DEFINED OpenCV_DEPENDS)
-    add_dependencies(${TARGET_NAME} opencv)
+    add_dependencies(${TARGET_NAME} ${OpenCV_DEPENDS})
 endif()
 
 install(TARGETS ${TARGET_NAME} DESTINATION ${INSTALL_FOLDER})

--- a/plugins/channeltx/moddatv/CMakeLists.txt
+++ b/plugins/channeltx/moddatv/CMakeLists.txt
@@ -87,8 +87,8 @@ target_link_libraries(${TARGET_NAME}
     ${SWRESAMPLE_LIBRARIES}
 )
 
-if(FFMPEG_EXTERNAL)
-    add_dependencies(${TARGET_NAME} ffmpeg)
+if(DEFINED FFMPEG_DEPENDS)
+    add_dependencies(${TARGET_NAME} ${FFMPEG_DEPENDS})
 endif()
 
 install(TARGETS ${TARGET_NAME} DESTINATION ${INSTALL_FOLDER})


### PR DESCRIPTION
Enable C language, as needed for some external projects.

Fix ffmpeg/opencv dependencies, to avoid error when cmake is run for a second time.
