### PR TITLE
Remote TCP improvements

### DIFF
--- a/plugins/channelrx/demodm17/m17demod.cpp
+++ b/plugins/channelrx/demodm17/m17demod.cpp
@@ -290,13 +290,13 @@ void M17Demod::applySettings(const M17DemodSettings& settings, const QList<QStri
         m_basebandSink->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("m_useReverseAPI"))
+    if (settingsKeys.contains("useReverseAPI"))
     {
-        bool fullUpdate = ((m_settings.m_useReverseAPI != settings.m_useReverseAPI) && settings.m_useReverseAPI) ||
-                (m_settings.m_reverseAPIAddress != settings.m_reverseAPIAddress) ||
-                (m_settings.m_reverseAPIPort != settings.m_reverseAPIPort) ||
-                (m_settings.m_reverseAPIDeviceIndex != settings.m_reverseAPIDeviceIndex) ||
-                (m_settings.m_reverseAPIChannelIndex != settings.m_reverseAPIChannelIndex);
+        bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
+                settingsKeys.contains("reverseAPIAddress") ||
+                settingsKeys.contains("reverseAPIPort") ||
+                settingsKeys.contains("reverseAPIDeviceIndex") ||
+                settingsKeys.contains("reverseAPIChannelIndex");
         webapiReverseSendSettings(settingsKeys, settings, fullUpdate || force);
     }
 

--- a/plugins/channelrx/demodm17/m17demodgui.cpp
+++ b/plugins/channelrx/demodm17/m17demodgui.cpp
@@ -344,6 +344,7 @@ void M17DemodGUI::onWidgetRolled(QWidget* widget, bool rollDown)
     (void) rollDown;
 
     getRollupContents()->saveState(m_rollupState);
+    applySettings({"rollupState"});
 }
 
 void M17DemodGUI::onMenuDialogCalled(const QPoint &p)

--- a/plugins/channelrx/localsink/localsinkbaseband.cpp
+++ b/plugins/channelrx/localsink/localsinkbaseband.cpp
@@ -170,7 +170,11 @@ void LocalSinkBaseband::applySettings(const LocalSinkSettings& settings, const Q
     }
 
     m_sink.applySettings(settings, settingsKeys, force);
-    m_settings = settings;
+    if (force) {
+        m_settings = settings;
+    } else {
+        m_settings.applySettings(settingsKeys, settings);
+    }
 }
 
 int LocalSinkBaseband::getChannelSampleRate() const

--- a/plugins/channelrx/remotetcpsink/readme.md
+++ b/plugins/channelrx/remotetcpsink/readme.md
@@ -30,7 +30,7 @@ Specifies number of bits per I/Q sample transmitted via TCP/IP.
 
 <h3>5: IP address</h3>
 
-IP address of the local network interface on which the server will listen for TCP/IP connections from network clients.
+IP address of the local network interface on which the server will listen for TCP/IP connections from network clients. Use 0.0.0.0 for any interface.
 
 <h3>6: Port</h3>
 

--- a/plugins/channelrx/remotetcpsink/remotetcpsink.h
+++ b/plugins/channelrx/remotetcpsink/remotetcpsink.h
@@ -39,22 +39,25 @@ public:
 
     public:
         const RemoteTCPSinkSettings& getSettings() const { return m_settings; }
+        const QList<QString>& getSettingsKeys() const { return m_settingsKeys; }
         bool getForce() const { return m_force; }
         bool getRemoteChange() const { return m_remoteChange; }
 
-        static MsgConfigureRemoteTCPSink* create(const RemoteTCPSinkSettings& settings, bool force, bool remoteChange = false)
+        static MsgConfigureRemoteTCPSink* create(const RemoteTCPSinkSettings& settings, const QList<QString>& settingsKeys, bool force, bool remoteChange = false)
         {
-            return new MsgConfigureRemoteTCPSink(settings, force, remoteChange);
+            return new MsgConfigureRemoteTCPSink(settings, settingsKeys, force, remoteChange);
         }
 
     private:
         RemoteTCPSinkSettings m_settings;
+        QList<QString> m_settingsKeys;
         bool m_force;
         bool m_remoteChange; // This change of settings was requested by a remote client, so no need to restart server
 
-        MsgConfigureRemoteTCPSink(const RemoteTCPSinkSettings& settings, bool force, bool remoteChange) :
+        MsgConfigureRemoteTCPSink(const RemoteTCPSinkSettings& settings, const QList<QString>& settingsKeys, bool force, bool remoteChange) :
             Message(),
             m_settings(settings),
+            m_settingsKeys(settingsKeys),
             m_force(force),
             m_remoteChange(remoteChange)
         { }
@@ -180,16 +183,16 @@ private:
     QNetworkRequest m_networkRequest;
 
     virtual bool handleMessage(const Message& cmd);
-    void applySettings(const RemoteTCPSinkSettings& settings, bool force = false, bool remoteChange = false);
-    void webapiReverseSendSettings(QList<QString>& channelSettingsKeys, const RemoteTCPSinkSettings& settings, bool force);
+    void applySettings(const RemoteTCPSinkSettings& settings, const QStringList& settingsKeys, bool force = false, bool remoteChange = false);
+    void webapiReverseSendSettings(const QStringList& channelSettingsKeys, const RemoteTCPSinkSettings& settings, bool force);
     void sendChannelSettings(
         const QList<ObjectPipe*>& pipes,
-        QList<QString>& channelSettingsKeys,
+        const QStringList& channelSettingsKeys,
         const RemoteTCPSinkSettings& settings,
         bool force
     );
     void webapiFormatChannelSettings(
-        QList<QString>& channelSettingsKeys,
+        const QStringList& channelSettingsKeys,
         SWGSDRangel::SWGChannelSettings *swgChannelSettings,
         const RemoteTCPSinkSettings& settings,
         bool force

--- a/plugins/channelrx/remotetcpsink/remotetcpsinkbaseband.h
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinkbaseband.h
@@ -63,7 +63,7 @@ private:
     QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
-    void applySettings(const RemoteTCPSinkSettings& settings, bool force = false, bool remoteChange = false);
+    void applySettings(const RemoteTCPSinkSettings& settings, const QStringList& settingsKeys, bool force = false, bool remoteChange = false);
 
 private slots:
     void handleInputMessages();

--- a/plugins/channelrx/remotetcpsink/remotetcpsinkgui.h
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinkgui.h
@@ -81,14 +81,15 @@ private:
     RemoteTCPSink* m_remoteSink;
     MessageQueue m_inputMessageQueue;
 
-    uint32_t m_tickCount;
     MovingAverageUtil<float, float, 10> m_bwAvg;
 
     explicit RemoteTCPSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSampleSink *rxChannel, QWidget* parent = 0);
     virtual ~RemoteTCPSinkGUI();
 
     void blockApplySettings(bool block);
-    void applySettings(bool force = false);
+    void applySetting(const QString& settingsKey);
+    void applySettings(const QStringList& settingsKeys, bool force = false);
+    void applyAllSettings();
     void displaySettings();
     void displayRateAndShift();
     bool handleMessage(const Message& message);
@@ -109,11 +110,11 @@ private slots:
     void on_gain_valueChanged(int value);
     void on_sampleBits_currentIndexChanged(int index);
     void on_dataAddress_editingFinished();
+    void on_dataAddress_currentIndexChanged(int index);
     void on_dataPort_editingFinished();
     void on_protocol_currentIndexChanged(int index);
     void onWidgetRolled(QWidget* widget, bool rollDown);
     void onMenuDialogCalled(const QPoint& p);
-    void tick();
 };
 
 #endif /* PLUGINS_CHANNELRX_REMOTETCPSINK_REMOTETCPSINKGUI_H_ */

--- a/plugins/channelrx/remotetcpsink/remotetcpsinkgui.ui
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinkgui.ui
@@ -308,21 +308,12 @@
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="dataAddress">
-        <property name="minimumSize">
-         <size>
-          <width>120</width>
-          <height>0</height>
-         </size>
-        </property>
+       <widget class="QComboBox" name="dataAddress">
         <property name="toolTip">
-         <string>IP address of local network interface to start TCP server on</string>
+         <string>IP address of local network interface to start TCP server on. Use 0.0.0.0 for any interface.</string>
         </property>
-        <property name="inputMask">
-         <string>000.000.000.000</string>
-        </property>
-        <property name="text">
-         <string>0...</string>
+        <property name="editable">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/plugins/channelrx/remotetcpsink/remotetcpsinksettings.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinksettings.cpp
@@ -35,7 +35,7 @@ void RemoteTCPSinkSettings::resetToDefaults()
     m_inputFrequencyOffset = 0;
     m_gain = 0;
     m_sampleBits = 8;
-    m_dataAddress = "127.0.0.1";
+    m_dataAddress = "0.0.0.0";
     m_dataPort = 1234;
     m_protocol = SDRA;
     m_rgbColor = QColor(140, 4, 4).rgb();
@@ -106,7 +106,7 @@ bool RemoteTCPSinkSettings::deserialize(const QByteArray& data)
         d.readS32(2, &m_inputFrequencyOffset, 0);
         d.readS32(3, &m_gain, 0);
         d.readU32(4, &m_sampleBits, 8);
-        d.readString(5, &m_dataAddress, "127.0.0.1");
+        d.readString(5, &m_dataAddress, "0.0.0.0");
         d.readU32(6, &tmp, 0);
 
         if ((tmp > 1023) && (tmp < 65535)) {
@@ -157,4 +157,118 @@ bool RemoteTCPSinkSettings::deserialize(const QByteArray& data)
         resetToDefaults();
         return false;
     }
+}
+
+void RemoteTCPSinkSettings::applySettings(const QStringList& settingsKeys, const RemoteTCPSinkSettings& settings)
+{
+    if (settingsKeys.contains("channelSampleRate")) {
+        m_channelSampleRate = settings.m_channelSampleRate;
+    }
+    if (settingsKeys.contains("inputFrequencyOffset")) {
+        m_inputFrequencyOffset = settings.m_inputFrequencyOffset;
+    }
+    if (settingsKeys.contains("gain")) {
+        m_gain = settings.m_gain;
+    }
+    if (settingsKeys.contains("sampleBits")) {
+        m_sampleBits = settings.m_sampleBits;
+    }
+    if (settingsKeys.contains("dataAddress")) {
+        m_dataAddress = settings.m_dataAddress;
+    }
+    if (settingsKeys.contains("dataPort")) {
+        m_dataPort = settings.m_dataPort;
+    }
+    if (settingsKeys.contains("protocol")) {
+        m_protocol = settings.m_protocol;
+    }
+    if (settingsKeys.contains("rgbColor")) {
+        m_rgbColor = settings.m_rgbColor;
+    }
+    if (settingsKeys.contains("title")) {
+        m_title = settings.m_title;
+    }
+    if (settingsKeys.contains("streamIndex")) {
+        m_streamIndex = settings.m_streamIndex;
+    }
+    if (settingsKeys.contains("useReverseAPI")) {
+        m_useReverseAPI = settings.m_useReverseAPI;
+    }
+    if (settingsKeys.contains("reverseAPIAddress")) {
+        m_reverseAPIAddress = settings.m_reverseAPIAddress;
+    }
+    if (settingsKeys.contains("reverseAPIPort")) {
+        m_reverseAPIPort = settings.m_reverseAPIPort;
+    }
+    if (settingsKeys.contains("reverseAPIDeviceIndex")) {
+        m_reverseAPIDeviceIndex = settings.m_reverseAPIDeviceIndex;
+    }
+    if (settingsKeys.contains("reverseAPIChannelIndex")) {
+        m_reverseAPIChannelIndex = settings.m_reverseAPIChannelIndex;
+    }
+    if (settingsKeys.contains("workspaceIndex")) {
+        m_workspaceIndex = settings.m_workspaceIndex;
+    }
+    if (settingsKeys.contains("hidden")) {
+        m_hidden = settings.m_hidden;
+    }
+}
+
+QString RemoteTCPSinkSettings::getDebugString(const QStringList& settingsKeys, bool force) const
+{
+    std::ostringstream ostr;
+
+    if (settingsKeys.contains("channelSampleRate") || force) {
+        ostr << " m_channelSampleRate: " << m_channelSampleRate;
+    }
+    if (settingsKeys.contains("inputFrequencyOffset") || force) {
+        ostr << " m_inputFrequencyOffset: " << m_inputFrequencyOffset;
+    }
+    if (settingsKeys.contains("gain") || force) {
+        ostr << " m_gain: " << m_gain;
+    }
+    if (settingsKeys.contains("sampleBits") || force) {
+        ostr << " m_sampleBits: " << m_sampleBits;
+    }
+    if (settingsKeys.contains("dataAddress") || force) {
+        ostr << " m_dataAddress: " << m_dataAddress.toStdString();
+    }
+    if (settingsKeys.contains("dataPort") || force) {
+        ostr << " m_dataPort: " << m_dataPort;
+    }
+    if (settingsKeys.contains("protocol") || force) {
+        ostr << " m_protocol: " << m_protocol;
+    }
+    if (settingsKeys.contains("rgbColor") || force) {
+        ostr << " m_rgbColor: " << m_rgbColor;
+    }
+    if (settingsKeys.contains("title") || force) {
+        ostr << " m_title: " << m_title.toStdString();
+    }
+    if (settingsKeys.contains("streamIndex") || force) {
+        ostr << " m_streamIndex: " << m_streamIndex;
+    }
+    if (settingsKeys.contains("useReverseAPI") || force) {
+        ostr << " m_useReverseAPI: " << m_useReverseAPI;
+    }
+    if (settingsKeys.contains("reverseAPIAddress") || force) {
+        ostr << " m_reverseAPIAddress: " << m_reverseAPIAddress.toStdString();
+    }
+    if (settingsKeys.contains("reverseAPIPort") || force) {
+        ostr << " m_reverseAPIPort: " << m_reverseAPIPort;
+    }
+    if (settingsKeys.contains("reverseAPIDeviceIndex") || force) {
+        ostr << " m_reverseAPIDeviceIndex: " << m_reverseAPIDeviceIndex;
+    }
+    if (settingsKeys.contains("reverseAPIChannelIndex") || force) {
+        ostr << " m_reverseAPIChannelIndex: " << m_reverseAPIChannelIndex;
+    }
+    if (settingsKeys.contains("workspaceIndex") || force) {
+        ostr << " m_workspaceIndex: " << m_workspaceIndex;
+    }
+    if (settingsKeys.contains("hidden") || force) {
+        ostr << " m_hidden: " << m_hidden;
+    }
+
+    return QString(ostr.str().c_str());
 }

--- a/plugins/channelrx/remotetcpsink/remotetcpsinksettings.h
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinksettings.h
@@ -59,6 +59,8 @@ struct RemoteTCPSinkSettings
     void setRollupState(Serializable *rollupState) { m_rollupState = rollupState; }
     QByteArray serialize() const;
     bool deserialize(const QByteArray& data);
+    void applySettings(const QStringList& settingsKeys, const RemoteTCPSinkSettings& settings);
+    QString getDebugString(const QStringList& settingsKeys, bool force=false) const;
 };
 
 #endif /* INCLUDE_REMOTECHANNELSINKSETTINGS_H_ */

--- a/plugins/channelrx/remotetcpsink/remotetcpsinksink.h
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinksink.h
@@ -48,7 +48,7 @@ public:
     void stop();
     void init();
 
-    void applySettings(const RemoteTCPSinkSettings& settings, bool force = false, bool remoteChange = false);
+    void applySettings(const RemoteTCPSinkSettings& settings, const QStringList& settingsKeys, bool force = false, bool remoteChange = false);
     void applyChannelSettings(int channelSampleRate, int channelFrequencyOffset, bool force = false);
     void setDeviceIndex(uint32_t deviceIndex) { m_deviceIndex = deviceIndex; }
     void setChannelIndex(uint32_t channelIndex) { m_channelIndex = channelIndex; }

--- a/plugins/samplesource/remotetcpinput/remotetcpinputgui.h
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputgui.h
@@ -86,6 +86,11 @@ class RemoteTCPInputGui : public DeviceGUI {
         bool m_biasTee;
     };
 
+    struct SampleRateRange {
+        int m_min;
+        int m_max;
+    };
+
 public:
     explicit RemoteTCPInputGui(DeviceUISet *deviceUISet, QWidget* parent = 0);
     virtual ~RemoteTCPInputGui();
@@ -151,6 +156,19 @@ private:
     static const DeviceGains m_xtrxGains;
     static const QHash<RemoteTCPProtocol::Device, const DeviceGains *> m_gains;
 
+    static const SampleRateRange m_rtlSDRSampleRateRange;
+    static const SampleRateRange m_sdrPlaySampleRateRange;
+    static const SampleRateRange m_bladeRF1SampleRateRange;
+    static const SampleRateRange m_hackRFSampleRateRange;
+    static const SampleRateRange m_limeSampleRateRange;
+    static const SampleRateRange m_plutoSampleRateRange;
+    static const SampleRateRange m_usrpSampleRateRange;
+    static const QHash<RemoteTCPProtocol::Device, const SampleRateRange *> m_sampleRateRanges;
+
+    static const QList<int> m_airspySampleRateList;
+    static const QList<int> m_airspyHFSampleRateList;
+    static const QHash<RemoteTCPProtocol::Device, const QList<int> *> m_sampleRateLists;
+
     void blockApplySettings(bool block);
     void displaySettings();
     QString gainText(int stage);
@@ -186,6 +204,7 @@ private slots:
     void on_decimation_toggled(bool checked);
     void on_sampleBits_currentIndexChanged(int index);
     void on_dataAddress_editingFinished();
+    void on_dataAddress_currentIndexChanged(int index);
     void on_dataPort_editingFinished();
     void on_overrideRemoteSettings_toggled(bool checked);
     void on_preFill_valueChanged(int value);

--- a/plugins/samplesource/remotetcpinput/remotetcpinputgui.ui
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputgui.ui
@@ -876,7 +876,7 @@ Use to ensure full dynamic range of 8-bit data is used.</string>
       <widget class="QLabel" name="dataAddressLabel">
        <property name="minimumSize">
         <size>
-         <width>50</width>
+         <width>0</width>
          <height>0</height>
         </size>
        </property>
@@ -886,28 +886,24 @@ Use to ensure full dynamic range of 8-bit data is used.</string>
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="dataAddress">
+      <widget class="QComboBox" name="dataAddress">
        <property name="minimumSize">
         <size>
          <width>120</width>
          <height>0</height>
         </size>
        </property>
-       <property name="maximumSize">
-        <size>
-         <width>120</width>
-         <height>16777215</height>
-        </size>
-       </property>
        <property name="toolTip">
         <string>Remote IPv4 address or hostname to connect to</string>
        </property>
-       <property name="inputMask">
-        <string/>
+       <property name="editable">
+        <bool>true</bool>
        </property>
-       <property name="text">
-        <string/>
-       </property>
+       <item>
+        <property name="text">
+         <string>127.0.0.1</string>
+        </property>
+       </item>
       </widget>
      </item>
      <item>
@@ -1185,15 +1181,15 @@ This should typically be empty. If full, your CPU cannot keep up and data will b
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ButtonSwitch</class>
-   <extends>QToolButton</extends>
-   <header>gui/buttonswitch.h</header>
-  </customwidget>
-  <customwidget>
    <class>ValueDial</class>
    <extends>QWidget</extends>
    <header>gui/valuedial.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -1213,7 +1209,6 @@ This should typically be empty. If full, your CPU cannot keep up and data will b
   <tabstop>channelGain</tabstop>
   <tabstop>decimation</tabstop>
   <tabstop>sampleBits</tabstop>
-  <tabstop>dataAddress</tabstop>
   <tabstop>dataPort</tabstop>
   <tabstop>overrideRemoteSettings</tabstop>
   <tabstop>preFill</tabstop>

--- a/plugins/samplesource/remotetcpinput/remotetcpinputsettings.cpp
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputsettings.cpp
@@ -80,6 +80,7 @@ QByteArray RemoteTCPInputSettings::serialize() const
     s.writeString(21, m_reverseAPIAddress);
     s.writeU32(22, m_reverseAPIPort);
     s.writeU32(23, m_reverseAPIDeviceIndex);
+    s.writeList(24, m_addressList);
 
     for (int i = 0; i < m_maxGains; i++) {
         s.writeS32(30+i, m_gain[i]);
@@ -133,6 +134,8 @@ bool RemoteTCPInputSettings::deserialize(const QByteArray& data)
 
         d.readU32(23, &uintval, 0);
         m_reverseAPIDeviceIndex = uintval > 99 ? 99 : uintval;
+
+        d.readList(24, &m_addressList);
 
         for (int i = 0; i < m_maxGains; i++) {
             d.readS32(30+i, &m_gain[i], 0);
@@ -218,6 +221,9 @@ void RemoteTCPInputSettings::applySettings(const QStringList& settingsKeys, cons
     if (settingsKeys.contains("reverseAPIDeviceIndex")) {
         m_reverseAPIDeviceIndex = settings.m_reverseAPIDeviceIndex;
     }
+    if (settingsKeys.contains("addressList")) {
+        m_addressList = settings.m_addressList;
+    }
 
     for (int i = 0; i < m_maxGains; i++)
     {
@@ -299,6 +305,9 @@ QString RemoteTCPInputSettings::getDebugString(const QStringList& settingsKeys, 
     }
     if (settingsKeys.contains("reverseAPIDeviceIndex") || force) {
         ostr << " m_reverseAPIDeviceIndex: " << m_reverseAPIDeviceIndex;
+    }
+    if (settingsKeys.contains("addressList") || force) {
+        ostr << " m_addressList: " << m_addressList.join(",").toStdString();
     }
 
     for (int i = 0; i < m_maxGains; i++)

--- a/plugins/samplesource/remotetcpinput/remotetcpinputsettings.h
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputsettings.h
@@ -50,6 +50,7 @@ struct RemoteTCPInputSettings
     QString  m_reverseAPIAddress;
     uint16_t m_reverseAPIPort;
     uint16_t m_reverseAPIDeviceIndex;
+    QStringList m_addressList;          // List of dataAddresses that have been used in the past
 
     RemoteTCPInputSettings();
     void resetToDefaults();

--- a/plugins/samplesource/remotetcpinput/remotetcpinputtcphandler.cpp
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputtcphandler.cpp
@@ -495,11 +495,6 @@ void RemoteTCPInputTCPHandler::connected()
 {
     QMutexLocker mutexLocker(&m_mutex);
     qDebug() << "RemoteTCPInputTCPHandler::connected";
-    if (m_settings.m_overrideRemoteSettings)
-    {
-        // Force settings to be sent to remote device
-        applySettings(m_settings, QList<QString>(), true);
-    }
     if (m_messageQueueToGUI)
     {
         MsgReportConnection *msg = MsgReportConnection::create(true);
@@ -648,6 +643,11 @@ void RemoteTCPInputTCPHandler::dataReadyRead()
                 else
                 {
                     qDebug() << "RemoteTCPInputTCPHandler::dataReadyRead: Unknown protocol: " << protocol;
+                }
+                if (m_settings.m_overrideRemoteSettings)
+                {
+                    // Force settings to be sent to remote device (this needs to be after m_sdra is determined above)
+                    applySettings(m_settings, QList<QString>(), true);
                 }
             }
             m_readMetaData = true;

--- a/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
@@ -780,6 +780,8 @@ void RTLSDRInput::webapiFormatDeviceReport(SWGSDRangel::SWGDeviceReport& respons
         response.getRtlSdrReport()->getGains()->append(new SWGSDRangel::SWGGain);
         response.getRtlSdrReport()->getGains()->back()->setGainCb(*it);
     }
+
+    response.getRtlSdrReport()->setTunerType(new QString(getTunerName()));
 }
 
 void RTLSDRInput::webapiReverseSendSettings(const QList<QString>& deviceSettingsKeys, const RTLSDRSettings& settings, bool force)

--- a/plugins/samplesource/sdrplayv3/sdrplayv3gui.cpp
+++ b/plugins/samplesource/sdrplayv3/sdrplayv3gui.cpp
@@ -171,6 +171,7 @@ bool SDRPlayV3Gui::handleMessage(const Message& message)
     if (SDRPlayV3Input::MsgConfigureSDRPlayV3::match(message))
     {
         const SDRPlayV3Input::MsgConfigureSDRPlayV3& cfg = (SDRPlayV3Input::MsgConfigureSDRPlayV3&) message;
+        qDebug() << "SDRPlayV3Gui::handleMessage: MsgConfigureSDRPlayV3: " << cfg.getSettings().getDebugString(cfg.getSettingsKeys(), cfg.getForce());
 
         if (cfg.getForce()) {
             m_settings = cfg.getSettings();
@@ -313,6 +314,7 @@ void SDRPlayV3Gui::updateLNAValues()
 
     const int *attenuations = SDRPlayV3LNA::getAttenuations(m_sdrPlayV3Input->getDeviceId(), m_settings.m_centerFrequency);
     int len = attenuations[0];
+    ui->gainLNA->blockSignals(true);
     ui->gainLNA->clear();
     for (int i = 1; i <= len; i++)
     {
@@ -328,6 +330,7 @@ void SDRPlayV3Gui::updateLNAValues()
             found = true;
         }
     }
+    ui->gainLNA->blockSignals(false);
 }
 
 void SDRPlayV3Gui::sendSettings()

--- a/plugins/samplesource/sdrplayv3/sdrplayv3input.h
+++ b/plugins/samplesource/sdrplayv3/sdrplayv3input.h
@@ -134,7 +134,7 @@ public:
             const QStringList& deviceSettingsKeys,
             SWGSDRangel::SWGDeviceSettings& response);
 
-    int getDeviceId();
+    int getDeviceId() const;
 
 private:
     DeviceAPI *m_deviceAPI;
@@ -157,6 +157,8 @@ private:
     void webapiFormatDeviceReport(SWGSDRangel::SWGDeviceReport& response);
     void webapiReverseSendSettings(const QList<QString>& deviceSettingsKeys, const SDRPlayV3Settings& settings, bool force);
     void webapiReverseSendStartStop(bool start);
+    int mapLNAGainDBToLNAIndex(int gainDB, qint64 frequency) const;
+    int mapLNAIndexToLNAGainDB(int lnaIndex, qint64 frequency) const;
 
 private slots:
     void networkManagerFinished(QNetworkReply *reply);

--- a/sdrbase/channel/channelwebapiutils.cpp
+++ b/sdrbase/channel/channelwebapiutils.cpp
@@ -502,10 +502,9 @@ bool ChannelWebAPIUtils::getGain(unsigned int deviceIndex, int stage, int &gain)
     }
     else if ((devId == "SDRplayV3"))
     {
-        QStringList sdrplayStages = {"lnaIndex", "ifGain"};
+        QStringList sdrplayStages = {"lnaGain", "ifGain"};
         if (stage < sdrplayStages.size())
         {
-            // FIXME: How to map to lnaIndex - gain can vary by SDR
             error = ChannelWebAPIUtils::getDeviceSetting(deviceIndex, sdrplayStages[stage], gain);
             gain *= 10;
         }
@@ -561,10 +560,8 @@ bool ChannelWebAPIUtils::setGain(unsigned int deviceIndex, int stage, int gain)
     }
     else if (devId == "SDRplayV3")
     {
-        QStringList sdrplayStages = {"lnaIndex", "ifGain"};
-        if (stage < sdrplayStages.size())
-        {
-            // FIXME: How to map to lnaIndex - gain can vary by SDR
+        QStringList sdrplayStages = {"lnaGain", "ifGain"};
+        if (stage < sdrplayStages.size()) {
             return ChannelWebAPIUtils::patchDeviceSetting(deviceIndex, sdrplayStages[stage], gain / 10);
         }
     }
@@ -1120,7 +1117,7 @@ bool ChannelWebAPIUtils::patchDeviceSetting(unsigned int deviceIndex, const QStr
 
     if (getDeviceSettings(deviceIndex, deviceSettingsResponse, deviceSet))
     {
-        // Patch centerFrequency
+        // Patch setting
         QJsonObject *jsonObj = deviceSettingsResponse.asJsonObject();
         int oldValue;
         if (WebAPIUtils::getSubObjectInt(*jsonObj, setting, oldValue))

--- a/sdrbase/mainparser.cpp
+++ b/sdrbase/mainparser.cpp
@@ -38,7 +38,7 @@ MainParser::MainParser() :
     m_scratchOption("scratch", "Start from scratch (no current config)."),
     m_soapyOption("soapy", "Activate Soapy SDR support."),
     m_remoteTCPSinkOption("remote-tcp", "Start Remote TCP Sink"),
-    m_remoteTCPSinkAddressOption("remote-tcp-address", "Remote TCP Sink interface IP address (Default 127.0.0.1).", "address", "127.0.0.1"),
+    m_remoteTCPSinkAddressOption("remote-tcp-address", "Remote TCP Sink interface IP address (Default any).", "address", "0.0.0.0"),
     m_remoteTCPSinkPortOption("remote-tcp-port", "Remote TCP Sink port (Default 1234).", "port", "1234"),
     m_remoteTCPSinkHWTypeOption("remote-tcp-hwtype", "Remote TCP Sink device hardware type (Optional. E.g. RTLSDR/SDRplayV3/AirspyHF).", "hwtype"),
     m_remoteTCPSinkSerialOption("remote-tcp-serial", "Remote TCP Sink device serial (Optional).", "serial"),
@@ -51,7 +51,7 @@ MainParser::MainParser() :
     m_soapy = false;
     m_fftwfWindowFileName = "";
     m_remoteTCPSink = false;
-    m_remoteTCPSinkAddress = "127.0.0.1";
+    m_remoteTCPSinkAddress = "0.0.0.0";
     m_remoteTCPSinkPort = 1234;
     m_remoteTCPSinkHWType = "";
     m_remoteTCPSinkSerial = "";

--- a/swagger/sdrangel/api/swagger/include/RtlSdr.yaml
+++ b/swagger/sdrangel/api/swagger/include/RtlSdr.yaml
@@ -62,3 +62,5 @@ RtlSdrReport:
       type: array
       items:
         $ref: "http://swgserver:8081/api/swagger/include/Structs.yaml#/Gain"
+    tunerType:
+      type: string

--- a/swagger/sdrangel/api/swagger/include/SDRPlayV3.yaml
+++ b/swagger/sdrangel/api/swagger/include/SDRPlayV3.yaml
@@ -22,6 +22,9 @@ SDRPlayV3Settings:
       type: integer
     lnaIndex:
       type: integer
+    lnaGain:
+      description: Gain in dB, as an alternative to lnaIndex setting
+      type: integer
     ifAGC:
       type: integer
     ifGain:

--- a/swagger/sdrangel/code/qt5/client/SWGRtlSdrReport.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGRtlSdrReport.cpp
@@ -30,6 +30,8 @@ SWGRtlSdrReport::SWGRtlSdrReport(QString* json) {
 SWGRtlSdrReport::SWGRtlSdrReport() {
     gains = nullptr;
     m_gains_isSet = false;
+    tuner_type = nullptr;
+    m_tuner_type_isSet = false;
 }
 
 SWGRtlSdrReport::~SWGRtlSdrReport() {
@@ -40,6 +42,8 @@ void
 SWGRtlSdrReport::init() {
     gains = new QList<SWGGain*>();
     m_gains_isSet = false;
+    tuner_type = new QString("");
+    m_tuner_type_isSet = false;
 }
 
 void
@@ -50,6 +54,9 @@ SWGRtlSdrReport::cleanup() {
             delete o;
         }
         delete gains;
+    }
+    if(tuner_type != nullptr) { 
+        delete tuner_type;
     }
 }
 
@@ -66,6 +73,8 @@ void
 SWGRtlSdrReport::fromJsonObject(QJsonObject &pJson) {
     
     ::SWGSDRangel::setValue(&gains, pJson["gains"], "QList", "SWGGain");
+    ::SWGSDRangel::setValue(&tuner_type, pJson["tunerType"], "QString", "QString");
+    
 }
 
 QString
@@ -85,6 +94,9 @@ SWGRtlSdrReport::asJsonObject() {
     if(gains && gains->size() > 0){
         toJsonArray((QList<void*>*)gains, obj, "gains", "SWGGain");
     }
+    if(tuner_type != nullptr && *tuner_type != QString("")){
+        toJsonValue(QString("tunerType"), tuner_type, obj, QString("QString"));
+    }
 
     return obj;
 }
@@ -99,12 +111,25 @@ SWGRtlSdrReport::setGains(QList<SWGGain*>* gains) {
     this->m_gains_isSet = true;
 }
 
+QString*
+SWGRtlSdrReport::getTunerType() {
+    return tuner_type;
+}
+void
+SWGRtlSdrReport::setTunerType(QString* tuner_type) {
+    this->tuner_type = tuner_type;
+    this->m_tuner_type_isSet = true;
+}
+
 
 bool
 SWGRtlSdrReport::isSet(){
     bool isObjectUpdated = false;
     do{
         if(gains && (gains->size() > 0)){
+            isObjectUpdated = true; break;
+        }
+        if(tuner_type && *tuner_type != QString("")){
             isObjectUpdated = true; break;
         }
     }while(false);

--- a/swagger/sdrangel/code/qt5/client/SWGRtlSdrReport.h
+++ b/swagger/sdrangel/code/qt5/client/SWGRtlSdrReport.h
@@ -24,6 +24,7 @@
 
 #include "SWGGain.h"
 #include <QList>
+#include <QString>
 
 #include "SWGObject.h"
 #include "export.h"
@@ -46,12 +47,18 @@ public:
     QList<SWGGain*>* getGains();
     void setGains(QList<SWGGain*>* gains);
 
+    QString* getTunerType();
+    void setTunerType(QString* tuner_type);
+
 
     virtual bool isSet() override;
 
 private:
     QList<SWGGain*>* gains;
     bool m_gains_isSet;
+
+    QString* tuner_type;
+    bool m_tuner_type_isSet;
 
 };
 

--- a/swagger/sdrangel/code/qt5/client/SWGSDRPlayV3Settings.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGSDRPlayV3Settings.cpp
@@ -48,6 +48,8 @@ SWGSDRPlayV3Settings::SWGSDRPlayV3Settings() {
     m_iq_correction_isSet = false;
     lna_index = 0;
     m_lna_index_isSet = false;
+    lna_gain = 0;
+    m_lna_gain_isSet = false;
     if_agc = 0;
     m_if_agc_isSet = false;
     if_gain = 0;
@@ -108,6 +110,8 @@ SWGSDRPlayV3Settings::init() {
     m_iq_correction_isSet = false;
     lna_index = 0;
     m_lna_index_isSet = false;
+    lna_gain = 0;
+    m_lna_gain_isSet = false;
     if_agc = 0;
     m_if_agc_isSet = false;
     if_gain = 0;
@@ -144,6 +148,7 @@ SWGSDRPlayV3Settings::init() {
 
 void
 SWGSDRPlayV3Settings::cleanup() {
+
 
 
 
@@ -204,6 +209,8 @@ SWGSDRPlayV3Settings::fromJsonObject(QJsonObject &pJson) {
     ::SWGSDRangel::setValue(&iq_correction, pJson["iqCorrection"], "qint32", "");
     
     ::SWGSDRangel::setValue(&lna_index, pJson["lnaIndex"], "qint32", "");
+    
+    ::SWGSDRangel::setValue(&lna_gain, pJson["lnaGain"], "qint32", "");
     
     ::SWGSDRangel::setValue(&if_agc, pJson["ifAGC"], "qint32", "");
     
@@ -282,6 +289,9 @@ SWGSDRPlayV3Settings::asJsonObject() {
     }
     if(m_lna_index_isSet){
         obj->insert("lnaIndex", QJsonValue(lna_index));
+    }
+    if(m_lna_gain_isSet){
+        obj->insert("lnaGain", QJsonValue(lna_gain));
     }
     if(m_if_agc_isSet){
         obj->insert("ifAGC", QJsonValue(if_agc));
@@ -433,6 +443,16 @@ void
 SWGSDRPlayV3Settings::setLnaIndex(qint32 lna_index) {
     this->lna_index = lna_index;
     this->m_lna_index_isSet = true;
+}
+
+qint32
+SWGSDRPlayV3Settings::getLnaGain() {
+    return lna_gain;
+}
+void
+SWGSDRPlayV3Settings::setLnaGain(qint32 lna_gain) {
+    this->lna_gain = lna_gain;
+    this->m_lna_gain_isSet = true;
 }
 
 qint32
@@ -628,6 +648,9 @@ SWGSDRPlayV3Settings::isSet(){
             isObjectUpdated = true; break;
         }
         if(m_lna_index_isSet){
+            isObjectUpdated = true; break;
+        }
+        if(m_lna_gain_isSet){
             isObjectUpdated = true; break;
         }
         if(m_if_agc_isSet){

--- a/swagger/sdrangel/code/qt5/client/SWGSDRPlayV3Settings.h
+++ b/swagger/sdrangel/code/qt5/client/SWGSDRPlayV3Settings.h
@@ -72,6 +72,9 @@ public:
     qint32 getLnaIndex();
     void setLnaIndex(qint32 lna_index);
 
+    qint32 getLnaGain();
+    void setLnaGain(qint32 lna_gain);
+
     qint32 getIfAgc();
     void setIfAgc(qint32 if_agc);
 
@@ -153,6 +156,9 @@ private:
 
     qint32 lna_index;
     bool m_lna_index_isSet;
+
+    qint32 lna_gain;
+    bool m_lna_gain_isSet;
 
     qint32 if_agc;
     bool m_if_agc_isSet;


### PR DESCRIPTION
This PR contains some fixes/improvements to Remote TCP Sink and Device to help with #1827 

RemoteTCPInput:

- Add basic remote device sample rate range checking.
- Add IP address history.
- Add SDRPlay LNA gain support.

RemoteTCPSink:

- Add support for settings keys.
- Bind to requested interface.
- Set RTLSDR device ID according to tuner type.

SDRPlayV3:

- Add support for lnaGain API setting, to allow gain to be set more easily.

RTLSDR:

- Add tuner type to Web API report.

mainparser:

- Default to 0.0.0.0 instead of 127.0.0.1 for --remote-tcp-address


Also, while adding settings keys to RemoteTCPSink, I noticed a few small problems in localsink and m17demod's settings keys this patch should fix.
