### PR TITLE
Pager: Flush log stream after write, so data is available immediately

### DIFF
--- a/plugins/channelrx/demodpager/pagerdemod.cpp
+++ b/plugins/channelrx/demodpager/pagerdemod.cpp
@@ -199,6 +199,7 @@ bool PagerDemod::handleMessage(const Message& cmd)
                 << report.getNumericMessage() << ","
                 << QString::number(report.getEvenParityErrors()) << ","
                 << QString::number(report.getBCHParityErrors()) << "\n";
+            m_logStream.flush();
         }
 
         return true;


### PR DESCRIPTION
In Pager demod, flush log stream so data is available immediately. For #1833.