### PR TITLE
Update github action to use MacOS 12

### DIFF
--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -100,7 +100,7 @@ jobs:
           files: ${{ github.workspace }}/build/sdrangel-${{ steps.get_version.outputs.version }}-win64.exe
 
   build_mac:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
As brew complains about 11 being unsupported and fails