### PR TITLE
Fix 2 race conditions

### DIFF
--- a/plugins/channelrx/demodais/aisdemodbaseband.cpp
+++ b/plugins/channelrx/demodais/aisdemodbaseband.cpp
@@ -32,6 +32,7 @@ AISDemodBaseband::AISDemodBaseband(AISDemod *aisDemod) :
 {
     qDebug("AISDemodBaseband::AISDemodBaseband");
 
+    m_scopeSink.setNbStreams(AISDemodSettings::m_scopeStreams);
     m_sink.setScopeSink(&m_scopeSink);
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));
     m_channelizer = new DownChannelizer(&m_sink);

--- a/plugins/channelrx/demodais/aisdemodgui.cpp
+++ b/plugins/channelrx/demodais/aisdemodgui.cpp
@@ -744,7 +744,6 @@ AISDemodGUI::AISDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
 
     m_scopeVis = m_aisDemod->getScopeSink();
     m_scopeVis->setGLScope(ui->glScope);
-    m_scopeVis->setNbStreams(AISDemodSettings::m_scopeStreams);
     ui->glScope->connectTimer(MainCore::instance()->getMasterTimer());
     ui->scopeGUI->setBuddies(m_scopeVis->getInputMessageQueue(), m_scopeVis, ui->glScope);
     ui->scopeGUI->setStreams(QStringList({"IQ", "MagSq", "FM demod", "Gaussian", "RX buf", "Correlation", "Threshold met", "DC offset", "CRC"}));

--- a/plugins/channelrx/demoddsc/dscdemodbaseband.cpp
+++ b/plugins/channelrx/demoddsc/dscdemodbaseband.cpp
@@ -26,12 +26,13 @@
 
 MESSAGE_CLASS_DEFINITION(DSCDemodBaseband::MsgConfigureDSCDemodBaseband, Message)
 
-DSCDemodBaseband::DSCDemodBaseband(DSCDemod *packetDemod) :
-    m_sink(packetDemod),
+DSCDemodBaseband::DSCDemodBaseband(DSCDemod *dscDemod) :
+    m_sink(dscDemod),
     m_running(false)
 {
     qDebug("DSCDemodBaseband::DSCDemodBaseband");
 
+    m_scopeSink.setNbStreams(DSCDemodSettings::m_scopeStreams);
     m_sink.setScopeSink(&m_scopeSink);
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));
     m_channelizer = new DownChannelizer(&m_sink);
@@ -92,7 +93,7 @@ void DSCDemodBaseband::handleData()
 {
     QMutexLocker mutexLocker(&m_mutex);
 
-    while ((m_sampleFifo.fill() > 0) && (m_inputMessageQueue.size() == 0))
+    while ((m_sampleFifo.fill() > 0) && (m_inputMessageQueue.size() == 0) && m_channelizer->getBasebandSampleRate())
     {
         SampleVector::iterator part1begin;
         SampleVector::iterator part1end;

--- a/plugins/channelrx/demoddsc/dscdemodbaseband.h
+++ b/plugins/channelrx/demoddsc/dscdemodbaseband.h
@@ -61,7 +61,7 @@ public:
         { }
     };
 
-    DSCDemodBaseband(DSCDemod *packetDemod);
+    DSCDemodBaseband(DSCDemod *dscDemod);
     ~DSCDemodBaseband();
     void reset();
     void startWork();

--- a/plugins/channelrx/demoddsc/dscdemodgui.cpp
+++ b/plugins/channelrx/demoddsc/dscdemodgui.cpp
@@ -576,7 +576,6 @@ DSCDemodGUI::DSCDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
 
     m_scopeVis = m_dscDemod->getScopeSink();
     m_scopeVis->setGLScope(ui->glScope);
-    m_scopeVis->setNbStreams(DSCDemodSettings::m_scopeStreams);
     ui->glScope->connectTimer(MainCore::instance()->getMasterTimer());
     ui->scopeGUI->setBuddies(m_scopeVis->getInputMessageQueue(), m_scopeVis, ui->glScope);
     ui->scopeGUI->setStreams(QStringList({"IQ", "MagSq", "abs1", "abs2", "Unbiased", "Biased", "Data", "Clock", "Bit", "GotSOP"}));

--- a/plugins/channelrx/demoddsc/dscdemodsink.cpp
+++ b/plugins/channelrx/demoddsc/dscdemodsink.cpp
@@ -29,8 +29,9 @@
 #include "dscdemod.h"
 #include "dscdemodsink.h"
 
-DSCDemodSink::DSCDemodSink(DSCDemod *packetDemod) :
-        m_dscDemod(packetDemod),
+DSCDemodSink::DSCDemodSink(DSCDemod *dscDemod) :
+        m_scopeSink(nullptr),
+        m_dscDemod(dscDemod),
         m_channelSampleRate(DSCDemodSettings::DSCDEMOD_CHANNEL_SAMPLE_RATE),
         m_channelFrequencyOffset(0),
         m_magsqSum(0.0f),

--- a/plugins/channelrx/demoddsc/dscdemodsink.h
+++ b/plugins/channelrx/demoddsc/dscdemodsink.h
@@ -41,7 +41,7 @@ class ScopeVis;
 
 class DSCDemodSink : public ChannelSampleSink {
 public:
-    DSCDemodSink(DSCDemod *packetDemod);
+    DSCDemodSink(DSCDemod *dscDemod);
     ~DSCDemodSink();
 
     virtual void feed(const SampleVector::const_iterator& begin, const SampleVector::const_iterator& end);

--- a/plugins/channelrx/demodnavtex/navtexdemodbaseband.cpp
+++ b/plugins/channelrx/demodnavtex/navtexdemodbaseband.cpp
@@ -26,8 +26,8 @@
 
 MESSAGE_CLASS_DEFINITION(NavtexDemodBaseband::MsgConfigureNavtexDemodBaseband, Message)
 
-NavtexDemodBaseband::NavtexDemodBaseband(NavtexDemod *packetDemod) :
-    m_sink(packetDemod),
+NavtexDemodBaseband::NavtexDemodBaseband(NavtexDemod *navtexDemod) :
+    m_sink(navtexDemod),
     m_running(false)
 {
     qDebug("NavtexDemodBaseband::NavtexDemodBaseband");
@@ -92,7 +92,7 @@ void NavtexDemodBaseband::handleData()
 {
     QMutexLocker mutexLocker(&m_mutex);
 
-    while ((m_sampleFifo.fill() > 0) && (m_inputMessageQueue.size() == 0))
+    while ((m_sampleFifo.fill() > 0) && (m_inputMessageQueue.size() == 0) && m_channelizer->getBasebandSampleRate())
     {
         SampleVector::iterator part1begin;
         SampleVector::iterator part1end;

--- a/plugins/channelrx/demodnavtex/navtexdemodbaseband.h
+++ b/plugins/channelrx/demodnavtex/navtexdemodbaseband.h
@@ -61,7 +61,7 @@ public:
         { }
     };
 
-    NavtexDemodBaseband(NavtexDemod *packetDemod);
+    NavtexDemodBaseband(NavtexDemod *navtexDemod);
     ~NavtexDemodBaseband();
     void reset();
     void startWork();

--- a/plugins/channelrx/demodrtty/rttydemodbaseband.cpp
+++ b/plugins/channelrx/demodrtty/rttydemodbaseband.cpp
@@ -26,8 +26,8 @@
 
 MESSAGE_CLASS_DEFINITION(RttyDemodBaseband::MsgConfigureRttyDemodBaseband, Message)
 
-RttyDemodBaseband::RttyDemodBaseband(RttyDemod *packetDemod) :
-    m_sink(packetDemod),
+RttyDemodBaseband::RttyDemodBaseband(RttyDemod *rttyDemod) :
+    m_sink(rttyDemod),
     m_running(false)
 {
     qDebug("RttyDemodBaseband::RttyDemodBaseband");
@@ -92,7 +92,7 @@ void RttyDemodBaseband::handleData()
 {
     QMutexLocker mutexLocker(&m_mutex);
 
-    while ((m_sampleFifo.fill() > 0) && (m_inputMessageQueue.size() == 0))
+    while ((m_sampleFifo.fill() > 0) && (m_inputMessageQueue.size() == 0) && m_channelizer->getBasebandSampleRate())
     {
         SampleVector::iterator part1begin;
         SampleVector::iterator part1end;

--- a/plugins/channelrx/demodrtty/rttydemodbaseband.h
+++ b/plugins/channelrx/demodrtty/rttydemodbaseband.h
@@ -61,7 +61,7 @@ public:
         { }
     };
 
-    RttyDemodBaseband(RttyDemod *packetDemod);
+    RttyDemodBaseband(RttyDemod *rttyDemod);
     ~RttyDemodBaseband();
     void reset();
     void startWork();

--- a/plugins/channelrx/radioclock/radioclockbaseband.cpp
+++ b/plugins/channelrx/radioclock/radioclockbaseband.cpp
@@ -33,6 +33,7 @@ RadioClockBaseband::RadioClockBaseband(RadioClock *radioClock) :
 {
     qDebug("RadioClockBaseband::RadioClockBaseband");
 
+    m_scopeSink.setNbStreams(RadioClockSettings::m_scopeStreams);
     m_sink.setScopeSink(&m_scopeSink);
     m_sampleFifo.setSize(SampleSinkFifo::getSizePolicy(48000));
     m_channelizer = new DownChannelizer(&m_sink);

--- a/plugins/channelrx/radioclock/radioclockgui.cpp
+++ b/plugins/channelrx/radioclock/radioclockgui.cpp
@@ -292,7 +292,6 @@ RadioClockGUI::RadioClockGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Bas
 
     m_scopeVis = m_radioClock->getScopeSink();
     m_scopeVis->setGLScope(ui->glScope);
-    m_scopeVis->setNbStreams(RadioClockSettings::m_scopeStreams);
     m_scopeVis->setLiveRate(RadioClockSettings::RADIOCLOCK_CHANNEL_SAMPLE_RATE);
     ui->glScope->connectTimer(MainCore::instance()->getMasterTimer());
     ui->scopeGUI->setBuddies(m_scopeVis->getInputMessageQueue(), m_scopeVis, ui->glScope);


### PR DESCRIPTION
This PR fixes 2 race conditions in some RX demods.

The first is the initialisation of the number of streams used by a scope. Currently this is performed in the GUI, but this can be too slow, if the sink gets samples before the GUI initialisation code has run, resulting in a crash. So I've moved the init code to the baseband, where the scope is created. 

The next problem appears if a channel is added to a device set that is already running. When this happens, the baseband class initially receives a DSP signal notification with a baseband sample rate of 0. This results in the DownChannelizer not being initialised properly. For some demods with low sample rates, it seems Baseband::handleData() can be called before the correct baseband sample rate is received and used to correctly initialise the DownChannelizer. When this happens, the channels will hang (somewhere in m_channelizer->feed), the log will show samples being dropped and if you try to stop the device, SDRangel will hang completely.

This patch has a little workaround for the demods I've noticed have this problem (on my computer, at least). In the handleData() method, I've added a check to make sure a valid baseband sample rate has been set in the channelizer, preventing m_channelizer->feed from being called, if not. E.g:

Old:
    while ((m_sampleFifo.fill() > 0) && (m_inputMessageQueue.size() == 0))
New:
    while ((m_sampleFifo.fill() > 0) && (m_inputMessageQueue.size() == 0) && m_channelizer->getBasebandSampleRate())

Is there a better way? (Perhaps DownConverter could have a isValid() method, to also check channelSampleRate is correct etc)

Should this code be added to all demod basebands? I guess the problem potentially applies everywhere.


