### PR TITLE
Add separate audio bandwidth setting to AM Demod

### DIFF
--- a/plugins/channelrx/demodam/amdemod.cpp
+++ b/plugins/channelrx/demodam/amdemod.cpp
@@ -218,6 +218,7 @@ void AMDemod::applySettings(const AMDemodSettings& settings, bool force)
     qDebug() << "AMDemod::applySettings:"
             << " m_inputFrequencyOffset: " << settings.m_inputFrequencyOffset
             << " m_rfBandwidth: " << settings.m_rfBandwidth
+            << " m_afBandwidth: " << settings.m_afBandwidth
             << " m_volume: " << settings.m_volume
             << " m_squelch: " << settings.m_squelch
             << " m_audioMute: " << settings.m_audioMute
@@ -237,6 +238,9 @@ void AMDemod::applySettings(const AMDemodSettings& settings, bool force)
 
     if ((m_settings.m_rfBandwidth != settings.m_rfBandwidth) || force) {
         reverseAPIKeys.append("rfBandwidth");
+    }
+    if ((m_settings.m_afBandwidth != settings.m_afBandwidth) || force) {
+        reverseAPIKeys.append("afBandwidth");
     }
     if ((m_settings.m_bandpassEnable != settings.m_bandpassEnable) || force) {
         reverseAPIKeys.append("bandpassEnable");
@@ -411,6 +415,9 @@ void AMDemod::webapiUpdateChannelSettings(
     if (channelSettingsKeys.contains("rfBandwidth")) {
         settings.m_rfBandwidth = response.getAmDemodSettings()->getRfBandwidth();
     }
+    if (channelSettingsKeys.contains("afBandwidth")) {
+        settings.m_afBandwidth = response.getAmDemodSettings()->getAfBandwidth();
+    }
     if (channelSettingsKeys.contains("rgbColor")) {
         settings.m_rgbColor = response.getAmDemodSettings()->getRgbColor();
     }
@@ -483,6 +490,7 @@ void AMDemod::webapiFormatChannelSettings(SWGSDRangel::SWGChannelSettings& respo
     response.getAmDemodSettings()->setAudioMute(settings.m_audioMute ? 1 : 0);
     response.getAmDemodSettings()->setInputFrequencyOffset(settings.m_inputFrequencyOffset);
     response.getAmDemodSettings()->setRfBandwidth(settings.m_rfBandwidth);
+    response.getAmDemodSettings()->setAfBandwidth(settings.m_afBandwidth);
     response.getAmDemodSettings()->setRgbColor(settings.m_rgbColor);
     response.getAmDemodSettings()->setSquelch(settings.m_squelch);
     response.getAmDemodSettings()->setVolume(settings.m_volume);
@@ -633,6 +641,9 @@ void AMDemod::webapiFormatChannelSettings(
     }
     if (channelSettingsKeys.contains("rfBandwidth") || force) {
         swgAMDemodSettings->setRfBandwidth(settings.m_rfBandwidth);
+    }
+    if (channelSettingsKeys.contains("afBandwidth") || force) {
+        swgAMDemodSettings->setAfBandwidth(settings.m_afBandwidth);
     }
     if (channelSettingsKeys.contains("rgbColor") || force) {
         swgAMDemodSettings->setRgbColor(settings.m_rgbColor);

--- a/plugins/channelrx/demodam/amdemodgui.cpp
+++ b/plugins/channelrx/demodam/amdemodgui.cpp
@@ -160,10 +160,18 @@ void AMDemodGUI::on_bandpassEnable_toggled(bool checked)
 
 void AMDemodGUI::on_rfBW_valueChanged(int value)
 {
-	ui->rfBWText->setText(QString("%1 kHz").arg(value / 10.0, 0, 'f', 1));
-	m_channelMarker.setBandwidth(value * 100);
-	m_settings.m_rfBandwidth = value * 100;
-	applySettings();
+    ui->rfBWText->setText(QString("%1 kHz").arg(value / 10.0, 0, 'f', 1));
+    m_channelMarker.setBandwidth(value * 100);
+    m_settings.m_rfBandwidth = value * 100;
+    ui->afBW->setMaximum(value);
+    applySettings();
+}
+
+void AMDemodGUI::on_afBW_valueChanged(int value)
+{
+    ui->afBWText->setText(QString("%1 kHz").arg(value / 10.0, 0, 'f', 1));
+    m_settings.m_afBandwidth = value * 100;
+    applySettings();
 }
 
 void AMDemodGUI::on_volume_valueChanged(int value)
@@ -354,6 +362,10 @@ void AMDemodGUI::displaySettings()
     ui->rfBW->setValue(displayValue);
     ui->rfBWText->setText(QString("%1 kHz").arg(displayValue / 10.0, 0, 'f', 1));
 
+    displayValue = m_settings.m_afBandwidth / 100.0;
+    ui->afBW->setValue(displayValue);
+    ui->afBWText->setText(QString("%1 kHz").arg(displayValue / 10.0, 0, 'f', 1));
+
     ui->volume->setValue(m_settings.m_volume * 10.0);
     ui->volumeText->setText(QString("%1").arg(m_settings.m_volume, 0, 'f', 1));
 
@@ -503,6 +515,7 @@ void AMDemodGUI::makeUIConnections()
     QObject::connect(ui->ssb, &QToolButton::toggled, this, &AMDemodGUI::on_ssb_toggled);
     QObject::connect(ui->bandpassEnable, &ButtonSwitch::toggled, this, &AMDemodGUI::on_bandpassEnable_toggled);
     QObject::connect(ui->rfBW, &QSlider::valueChanged, this, &AMDemodGUI::on_rfBW_valueChanged);
+    QObject::connect(ui->afBW, &QSlider::valueChanged, this, &AMDemodGUI::on_afBW_valueChanged);
     QObject::connect(ui->volume, &QSlider::valueChanged, this, &AMDemodGUI::on_volume_valueChanged);
     QObject::connect(ui->squelch, &QSlider::valueChanged, this, &AMDemodGUI::on_squelch_valueChanged);
     QObject::connect(ui->audioMute, &QToolButton::toggled, this, &AMDemodGUI::on_audioMute_toggled);

--- a/plugins/channelrx/demodam/amdemodgui.h
+++ b/plugins/channelrx/demodam/amdemodgui.h
@@ -87,6 +87,7 @@ private slots:
 	void on_ssb_toggled(bool checked);
 	void on_bandpassEnable_toggled(bool checked);
 	void on_rfBW_valueChanged(int value);
+	void on_afBW_valueChanged(int value);
 	void on_volume_valueChanged(int value);
 	void on_squelch_valueChanged(int value);
 	void on_audioMute_toggled(bool checked);

--- a/plugins/channelrx/demodam/amdemodgui.ui
+++ b/plugins/channelrx/demodam/amdemodgui.ui
@@ -280,21 +280,6 @@
        </widget>
       </item>
       <item>
-       <widget class="ButtonSwitch" name="bandpassEnable">
-        <property name="toolTip">
-         <string>Toggle boxcar bandpass filter with 300 Hz low cutoff</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../../../sdrgui/resources/res.qrc">
-          <normaloff>:/filter_bandpass.png</normaloff>
-          <normalon>:/filter_bandpass.png</normalon>:/filter_bandpass.png</iconset>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QSlider" name="rfBW">
         <property name="toolTip">
          <string>Demodulator (RF) bandwidth</string>
@@ -318,6 +303,73 @@
       </item>
       <item>
        <widget class="QLabel" name="rfBWText">
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>5.0 kHz</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Line" name="line_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ButtonSwitch" name="bandpassEnable">
+        <property name="toolTip">
+         <string>Toggle boxcar bandpass filter with 300 Hz low cutoff</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../../sdrgui/resources/res.qrc">
+          <normaloff>:/filter_bandpass.png</normaloff>
+          <normalon>:/filter_bandpass.png</normalon>:/filter_bandpass.png</iconset>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="afBWLabel">
+        <property name="text">
+         <string>AF BW</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSlider" name="afBW">
+        <property name="toolTip">
+         <string>Audio bandwidth</string>
+        </property>
+        <property name="minimum">
+         <number>10</number>
+        </property>
+        <property name="maximum">
+         <number>400</number>
+        </property>
+        <property name="pageStep">
+         <number>1</number>
+        </property>
+        <property name="value">
+         <number>50</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="afBWText">
         <property name="minimumSize">
          <size>
           <width>50</width>
@@ -434,10 +486,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ValueDialZ</class>
-   <extends>QWidget</extends>
-   <header>gui/valuedialz.h</header>
-   <container>1</container>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
   </customwidget>
   <customwidget>
    <class>RollupContents</class>
@@ -446,15 +497,16 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>ValueDialZ</class>
+   <extends>QWidget</extends>
+   <header>gui/valuedialz.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>LevelMeterSignalDB</class>
    <extends>QWidget</extends>
    <header>gui/levelmeter.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ButtonSwitch</class>
-   <extends>QToolButton</extends>
-   <header>gui/buttonswitch.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/plugins/channelrx/demodam/amdemodsettings.cpp
+++ b/plugins/channelrx/demodam/amdemodsettings.cpp
@@ -38,6 +38,7 @@ void AMDemodSettings::resetToDefaults()
     m_volume = 2.0;
     m_audioMute = false;
     m_bandpassEnable = false;
+    m_afBandwidth = 5000;
     m_rgbColor = QColor(255, 255, 0).rgb();
     m_title = "AM Demodulator";
     m_audioDeviceName = AudioDeviceManager::m_defaultDeviceName;
@@ -69,6 +70,7 @@ QByteArray AMDemodSettings::serialize() const
     s.writeU32(7, m_rgbColor);
     s.writeBool(8, m_bandpassEnable);
     s.writeString(9, m_title);
+    s.writeReal(10, m_afBandwidth);
     s.writeString(11, m_audioDeviceName);
     s.writeBool(12, m_pll);
     s.writeS32(13, (int) m_syncAMOperation);
@@ -85,6 +87,7 @@ QByteArray AMDemodSettings::serialize() const
     s.writeS32(20, m_workspaceIndex);
     s.writeBlob(21, m_geometryBytes);
     s.writeBool(22, m_hidden);
+    s.writeBool(23, m_audioMute);
 
     return s.final();
 }
@@ -124,6 +127,7 @@ bool AMDemodSettings::deserialize(const QByteArray& data)
         d.readU32(7, &m_rgbColor);
         d.readBool(8, &m_bandpassEnable, false);
         d.readString(9, &m_title, "AM Demodulator");
+        d.readReal(10, &m_afBandwidth, 5000);
         d.readString(11, &m_audioDeviceName, AudioDeviceManager::m_defaultDeviceName);
         d.readBool(12, &m_pll, false);
         d.readS32(13, &tmp, 0);
@@ -152,6 +156,7 @@ bool AMDemodSettings::deserialize(const QByteArray& data)
         d.readS32(20, &m_workspaceIndex, 0);
         d.readBlob(21, &m_geometryBytes);
         d.readBool(22, &m_hidden, false);
+        d.readBool(23, &m_audioMute);
 
         return true;
     }

--- a/plugins/channelrx/demodam/amdemodsettings.h
+++ b/plugins/channelrx/demodam/amdemodsettings.h
@@ -37,6 +37,7 @@ struct AMDemodSettings
     Real m_volume;
     bool m_audioMute;
     bool m_bandpassEnable;
+    Real m_afBandwidth;  //!< High frequency for bandpass
     quint32 m_rgbColor;
     QString m_title;
     Serializable *m_channelMarker;

--- a/plugins/channelrx/demodam/amdemodsink.cpp
+++ b/plugins/channelrx/demodam/amdemodsink.cpp
@@ -273,19 +273,21 @@ void AMDemodSink::applySettings(const AMDemodSettings& settings, bool force)
             << " m_squelch: " << settings.m_squelch
             << " m_audioMute: " << settings.m_audioMute
             << " m_bandpassEnable: " << settings.m_bandpassEnable
+            << " m_afBandwidth: " << settings.m_afBandwidth
             << " m_audioDeviceName: " << settings.m_audioDeviceName
             << " m_pll: " << settings.m_pll
             << " m_syncAMOperation: " << (int) settings.m_syncAMOperation
             << " force: " << force;
 
     if((m_settings.m_rfBandwidth != settings.m_rfBandwidth) ||
-        (m_settings.m_bandpassEnable != settings.m_bandpassEnable) || force)
+        (m_settings.m_bandpassEnable != settings.m_bandpassEnable) ||
+        (m_settings.m_afBandwidth != settings.m_afBandwidth) || force)
     {
         m_interpolator.create(16, m_channelSampleRate, settings.m_rfBandwidth / 2.2f);
         m_interpolatorDistanceRemain = 0;
         m_interpolatorDistance = (Real) m_channelSampleRate / (Real) m_audioSampleRate;
-        m_bandpass.create(301, m_audioSampleRate, 300.0, settings.m_rfBandwidth / 2.0f);
-        m_lowpass.create(301, m_audioSampleRate,  settings.m_rfBandwidth / 2.0f);
+        m_bandpass.create(301, m_audioSampleRate, 300.0, settings.m_afBandwidth / 2.0f);
+        m_lowpass.create(301, m_audioSampleRate,  settings.m_afBandwidth / 2.0f);
         DSBFilter->create_dsb_filter((2.0f * settings.m_rfBandwidth) / (float) m_audioSampleRate);
     }
 
@@ -326,8 +328,8 @@ void AMDemodSink::applyAudioSampleRate(int sampleRate)
     m_interpolator.create(16, m_channelSampleRate, m_settings.m_rfBandwidth / 2.2f);
     m_interpolatorDistanceRemain = 0;
     m_interpolatorDistance = (Real) m_channelSampleRate / (Real) sampleRate;
-    m_bandpass.create(301, sampleRate, 300.0, m_settings.m_rfBandwidth / 2.0f);
-    m_lowpass.create(301, sampleRate,  m_settings.m_rfBandwidth / 2.0f);
+    m_bandpass.create(301, sampleRate, 300.0, m_settings.m_afBandwidth / 2.0f);
+    m_lowpass.create(301, sampleRate,  m_settings.m_afBandwidth / 2.0f);
     m_audioFifo.setSize(sampleRate);
     m_squelchDelayLine.resize(sampleRate/5);
     DSBFilter->create_dsb_filter((2.0f * m_settings.m_rfBandwidth) / (float) sampleRate);

--- a/plugins/channelrx/demodam/readme.md
+++ b/plugins/channelrx/demodam/readme.md
@@ -55,3 +55,10 @@ This is the volume of the audio signal from 0.0 (mute) to 10.0 (maximum). It can
 <h3>10: Squelch threshold</h3>
 
 This is the squelch threshold in dB. The average total power received in the signal bandwidth before demodulation is compared to this value and the squelch input is open above this value. It can be varied continuously in 0.1 dB steps from 0.0 to -100.0 dB using the dial button.
+
+<h3>11: Audio bandwidth</h3>
+
+Specifies cutoff frequency of low pass (or band pass if boxcar (7) enabled) filter applied to audio.
+In many use cases, this can be the same as the RF bandwidth (8). However, where offset carrier is used 
+(a.k.a CLIMAX as used by some ATC ground stations), this can reduce noise, when the RF bandwidth is set around ~20kHz
+to cope with the offset, but the audio is only ~5-6kHz wide.

--- a/swagger/sdrangel/api/swagger/include/AMDemod.yaml
+++ b/swagger/sdrangel/api/swagger/include/AMDemod.yaml
@@ -9,6 +9,10 @@ AMDemodSettings:
       description: channel RF bandwidth in Hz (floors to next 100 Hz)
       type: number
       format: float
+    afBandwidth:
+      description: AF bandwidth in Hz
+      type: number
+      format: float
     squelch:
       description: power squelch threshold in decibels
       type: number

--- a/swagger/sdrangel/code/qt5/client/SWGAMDemodSettings.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGAMDemodSettings.cpp
@@ -1,6 +1,6 @@
 /**
  * SDRangel
- * This is the web REST/JSON API of SDRangel SDR software. SDRangel is an Open Source Qt5/OpenGL 3.0+ (4.3+ in Windows) GUI and server Software Defined Radio and signal analyzer in software. It supports Airspy, BladeRF, HackRF, LimeSDR, PlutoSDR, RTL-SDR, SDRplay RSP1 and FunCube    ---   Limitations and specifcities:    * In SDRangel GUI the first Rx device set cannot be deleted. Conversely the server starts with no device sets and its number of device sets can be reduced to zero by as many calls as necessary to /sdrangel/deviceset with DELETE method.   * Preset import and export from/to file is a server only feature.   * Device set focus is a GUI only feature.   * The following channels are not implemented (status 501 is returned): ATV and DATV demodulators, Channel Analyzer NG, LoRa demodulator   * The device settings and report structures contains only the sub-structure corresponding to the device type. The DeviceSettings and DeviceReport structures documented here shows all of them but only one will be or should be present at a time   * The channel settings and report structures contains only the sub-structure corresponding to the channel type. The ChannelSettings and ChannelReport structures documented here shows all of them but only one will be or should be present at a time    --- 
+ * This is the web REST/JSON API of SDRangel SDR software. SDRangel is an Open Source Qt5/OpenGL 3.0+ (4.3+ in Windows) GUI and server Software Defined Radio and signal analyzer in software. It supports Airspy, BladeRF, HackRF, LimeSDR, PlutoSDR, RTL-SDR, SDRplay RSP1 and FunCube    ---   Limitations and specifcities:    * In SDRangel GUI the first Rx device set cannot be deleted. Conversely the server starts with no device sets and its number of device sets can be reduced to zero by as many calls as necessary to /sdrangel/deviceset with DELETE method.   * Preset import and export from/to file is a server only feature.   * Device set focus is a GUI only feature.   * The following channels are not implemented (status 501 is returned): ATV and DATV demodulators, Channel Analyzer NG, LoRa demodulator   * The device settings and report structures contains only the sub-structure corresponding to the device type. The DeviceSettings and DeviceReport structures documented here shows all of them but only one will be or should be present at a time   * The channel settings and report structures contains only the sub-structure corresponding to the channel type. The ChannelSettings and ChannelReport structures documented here shows all of them but only one will be or should be present at a time    ---
  *
  * OpenAPI spec version: 7.0.0
  * Contact: f4exb06@gmail.com
@@ -32,6 +32,8 @@ SWGAMDemodSettings::SWGAMDemodSettings() {
     m_input_frequency_offset_isSet = false;
     rf_bandwidth = 0.0f;
     m_rf_bandwidth_isSet = false;
+    af_bandwidth = 0.0f;
+    m_af_bandwidth_isSet = false;
     squelch = 0.0f;
     m_squelch_isSet = false;
     volume = 0.0f;
@@ -78,6 +80,8 @@ SWGAMDemodSettings::init() {
     m_input_frequency_offset_isSet = false;
     rf_bandwidth = 0.0f;
     m_rf_bandwidth_isSet = false;
+    af_bandwidth = 0.0f;
+    m_af_bandwidth_isSet = false;
     squelch = 0.0f;
     m_squelch_isSet = false;
     volume = 0.0f;
@@ -123,26 +127,27 @@ SWGAMDemodSettings::cleanup() {
 
 
 
-    if(title != nullptr) { 
+
+    if(title != nullptr) {
         delete title;
     }
-    if(audio_device_name != nullptr) { 
+    if(audio_device_name != nullptr) {
         delete audio_device_name;
     }
 
 
 
 
-    if(reverse_api_address != nullptr) { 
+    if(reverse_api_address != nullptr) {
         delete reverse_api_address;
     }
 
 
 
-    if(channel_marker != nullptr) { 
+    if(channel_marker != nullptr) {
         delete channel_marker;
     }
-    if(rollup_state != nullptr) { 
+    if(rollup_state != nullptr) {
         delete rollup_state;
     }
 }
@@ -159,43 +164,45 @@ SWGAMDemodSettings::fromJson(QString &json) {
 void
 SWGAMDemodSettings::fromJsonObject(QJsonObject &pJson) {
     ::SWGSDRangel::setValue(&input_frequency_offset, pJson["inputFrequencyOffset"], "qint64", "");
-    
+
     ::SWGSDRangel::setValue(&rf_bandwidth, pJson["rfBandwidth"], "float", "");
-    
+
+    ::SWGSDRangel::setValue(&af_bandwidth, pJson["afBandwidth"], "float", "");
+
     ::SWGSDRangel::setValue(&squelch, pJson["squelch"], "float", "");
-    
+
     ::SWGSDRangel::setValue(&volume, pJson["volume"], "float", "");
-    
+
     ::SWGSDRangel::setValue(&audio_mute, pJson["audioMute"], "qint32", "");
-    
+
     ::SWGSDRangel::setValue(&bandpass_enable, pJson["bandpassEnable"], "qint32", "");
-    
+
     ::SWGSDRangel::setValue(&rgb_color, pJson["rgbColor"], "qint32", "");
-    
+
     ::SWGSDRangel::setValue(&title, pJson["title"], "QString", "QString");
-    
+
     ::SWGSDRangel::setValue(&audio_device_name, pJson["audioDeviceName"], "QString", "QString");
-    
+
     ::SWGSDRangel::setValue(&pll, pJson["pll"], "qint32", "");
-    
+
     ::SWGSDRangel::setValue(&sync_am_operation, pJson["syncAMOperation"], "qint32", "");
-    
+
     ::SWGSDRangel::setValue(&stream_index, pJson["streamIndex"], "qint32", "");
-    
+
     ::SWGSDRangel::setValue(&use_reverse_api, pJson["useReverseAPI"], "qint32", "");
-    
+
     ::SWGSDRangel::setValue(&reverse_api_address, pJson["reverseAPIAddress"], "QString", "QString");
-    
+
     ::SWGSDRangel::setValue(&reverse_api_port, pJson["reverseAPIPort"], "qint32", "");
-    
+
     ::SWGSDRangel::setValue(&reverse_api_device_index, pJson["reverseAPIDeviceIndex"], "qint32", "");
-    
+
     ::SWGSDRangel::setValue(&reverse_api_channel_index, pJson["reverseAPIChannelIndex"], "qint32", "");
-    
+
     ::SWGSDRangel::setValue(&channel_marker, pJson["channelMarker"], "SWGChannelMarker", "SWGChannelMarker");
-    
+
     ::SWGSDRangel::setValue(&rollup_state, pJson["rollupState"], "SWGRollupState", "SWGRollupState");
-    
+
 }
 
 QString
@@ -217,6 +224,9 @@ SWGAMDemodSettings::asJsonObject() {
     }
     if(m_rf_bandwidth_isSet){
         obj->insert("rfBandwidth", QJsonValue(rf_bandwidth));
+    }
+    if(m_af_bandwidth_isSet){
+        obj->insert("afBandwidth", QJsonValue(af_bandwidth));
     }
     if(m_squelch_isSet){
         obj->insert("squelch", QJsonValue(squelch));
@@ -291,6 +301,16 @@ void
 SWGAMDemodSettings::setRfBandwidth(float rf_bandwidth) {
     this->rf_bandwidth = rf_bandwidth;
     this->m_rf_bandwidth_isSet = true;
+}
+
+float
+SWGAMDemodSettings::getAfBandwidth() {
+    return af_bandwidth;
+}
+void
+SWGAMDemodSettings::setAfBandwidth(float af_bandwidth) {
+    this->af_bandwidth = af_bandwidth;
+    this->m_af_bandwidth_isSet = true;
 }
 
 float
@@ -474,6 +494,9 @@ SWGAMDemodSettings::isSet(){
         if(m_rf_bandwidth_isSet){
             isObjectUpdated = true; break;
         }
+        if(m_af_bandwidth_isSet){
+            isObjectUpdated = true; break;
+        }
         if(m_squelch_isSet){
             isObjectUpdated = true; break;
         }
@@ -529,4 +552,3 @@ SWGAMDemodSettings::isSet(){
     return isObjectUpdated;
 }
 }
-

--- a/swagger/sdrangel/code/qt5/client/SWGAMDemodSettings.h
+++ b/swagger/sdrangel/code/qt5/client/SWGAMDemodSettings.h
@@ -1,6 +1,6 @@
 /**
  * SDRangel
- * This is the web REST/JSON API of SDRangel SDR software. SDRangel is an Open Source Qt5/OpenGL 3.0+ (4.3+ in Windows) GUI and server Software Defined Radio and signal analyzer in software. It supports Airspy, BladeRF, HackRF, LimeSDR, PlutoSDR, RTL-SDR, SDRplay RSP1 and FunCube    ---   Limitations and specifcities:    * In SDRangel GUI the first Rx device set cannot be deleted. Conversely the server starts with no device sets and its number of device sets can be reduced to zero by as many calls as necessary to /sdrangel/deviceset with DELETE method.   * Preset import and export from/to file is a server only feature.   * Device set focus is a GUI only feature.   * The following channels are not implemented (status 501 is returned): ATV and DATV demodulators, Channel Analyzer NG, LoRa demodulator   * The device settings and report structures contains only the sub-structure corresponding to the device type. The DeviceSettings and DeviceReport structures documented here shows all of them but only one will be or should be present at a time   * The channel settings and report structures contains only the sub-structure corresponding to the channel type. The ChannelSettings and ChannelReport structures documented here shows all of them but only one will be or should be present at a time    --- 
+ * This is the web REST/JSON API of SDRangel SDR software. SDRangel is an Open Source Qt5/OpenGL 3.0+ (4.3+ in Windows) GUI and server Software Defined Radio and signal analyzer in software. It supports Airspy, BladeRF, HackRF, LimeSDR, PlutoSDR, RTL-SDR, SDRplay RSP1 and FunCube    ---   Limitations and specifcities:    * In SDRangel GUI the first Rx device set cannot be deleted. Conversely the server starts with no device sets and its number of device sets can be reduced to zero by as many calls as necessary to /sdrangel/deviceset with DELETE method.   * Preset import and export from/to file is a server only feature.   * Device set focus is a GUI only feature.   * The following channels are not implemented (status 501 is returned): ATV and DATV demodulators, Channel Analyzer NG, LoRa demodulator   * The device settings and report structures contains only the sub-structure corresponding to the device type. The DeviceSettings and DeviceReport structures documented here shows all of them but only one will be or should be present at a time   * The channel settings and report structures contains only the sub-structure corresponding to the channel type. The ChannelSettings and ChannelReport structures documented here shows all of them but only one will be or should be present at a time    ---
  *
  * OpenAPI spec version: 7.0.0
  * Contact: f4exb06@gmail.com
@@ -49,6 +49,9 @@ public:
 
     float getRfBandwidth();
     void setRfBandwidth(float rf_bandwidth);
+
+    float getAfBandwidth();
+    void setAfBandwidth(float af_bandwidth);
 
     float getSquelch();
     void setSquelch(float squelch);
@@ -110,6 +113,9 @@ private:
 
     float rf_bandwidth;
     bool m_rf_bandwidth_isSet;
+
+    float af_bandwidth;
+    bool m_af_bandwidth_isSet;
 
     float squelch;
     bool m_squelch_isSet;


### PR DESCRIPTION
This patch adds a setting to AM Demod to allow audio bandwidth to be set independently from RF bandwidth.

This is particularly useful when listening to ATC that uses offset carrier / CLIMAX, which requires much wider RF bandwidth than audio bandwidth. E.g. spectrum looks like this:

![image](https://github.com/f4exb/sdrangel/assets/57259258/6fb27c4c-8579-4d13-9656-54838c49fc90)
