### PR TITLE
Add explicit typecasting that was missing

### DIFF
--- a/sdrgui/gui/glspectrumgui.cpp
+++ b/sdrgui/gui/glspectrumgui.cpp
@@ -864,7 +864,7 @@ void GLSpectrumGUI::setAveragingToolitp()
     {
         QString s;
         int averagingIndex = m_settings.m_averagingMode == SpectrumSettings::AvgModeNone ? 0 : m_settings.m_averagingIndex;
-        float overlapFactor = (m_settings.m_fftSize - m_settings.m_fftOverlap) / m_settings.m_fftSize;
+        float overlapFactor = (m_settings.m_fftSize - m_settings.m_fftOverlap) / (float)m_settings.m_fftSize;
         float averagingTime = (m_settings.m_fftSize * (SpectrumSettings::getAveragingValue(averagingIndex, m_settings.m_averagingMode) == 0 ?
             1 :
             SpectrumSettings::getAveragingValue(averagingIndex, m_settings.m_averagingMode))) / (float) m_glSpectrum->getSampleRate();

--- a/sdrgui/gui/glspectrumview.cpp
+++ b/sdrgui/gui/glspectrumview.cpp
@@ -2735,7 +2735,7 @@ void GLSpectrumView::applyChanges()
             float timeScaleDiv = ((float)m_sampleRate / (float)m_timingRate);
 
             if (m_fftSize > m_fftOverlap) {
-                timeScaleDiv *= m_fftSize / (m_fftSize - m_fftOverlap);
+                timeScaleDiv *= m_fftSize / (float)(m_fftSize - m_fftOverlap);
             }
 
             if (!m_invertedWaterfall) {
@@ -2828,7 +2828,7 @@ void GLSpectrumView::applyChanges()
             float timeScaleDiv = ((float)m_sampleRate / (float)m_timingRate);
 
             if (m_fftSize > m_fftOverlap) {
-                timeScaleDiv *= m_fftSize / (m_fftSize - m_fftOverlap);
+                timeScaleDiv *= m_fftSize / (float)(m_fftSize - m_fftOverlap);
             }
 
             if (!m_invertedWaterfall) {


### PR DESCRIPTION
Unintentionally removed some implicit typecasting with my previous commit. Here I add them back explicitly.