### PR TITLE
Use channel sample rate of 48k in RTTY and PSK31 mods

### DIFF
--- a/plugins/channeltx/modpsk31/psk31modbaseband.cpp
+++ b/plugins/channeltx/modpsk31/psk31modbaseband.cpp
@@ -185,7 +185,8 @@ void PSK31Baseband::applySettings(const PSK31Settings& settings, bool force)
 {
     if ((settings.m_inputFrequencyOffset != m_settings.m_inputFrequencyOffset) || force)
     {
-        m_channelizer->setChannelization(m_channelizer->getChannelSampleRate(), settings.m_inputFrequencyOffset);
+        // Use fixed sample rate of 48000, so Cosine filter doesn't have a massive number of taps at high baseband sample rates (See #1862)
+        m_channelizer->setChannelization(48000, settings.m_inputFrequencyOffset);
         m_source.applyChannelSettings(m_channelizer->getChannelSampleRate(), m_channelizer->getChannelFrequencyOffset());
     }
 

--- a/plugins/channeltx/modrtty/rttymodbaseband.cpp
+++ b/plugins/channeltx/modrtty/rttymodbaseband.cpp
@@ -185,7 +185,8 @@ void RttyModBaseband::applySettings(const RttyModSettings& settings, bool force)
 {
     if ((settings.m_inputFrequencyOffset != m_settings.m_inputFrequencyOffset) || force)
     {
-        m_channelizer->setChannelization(m_channelizer->getChannelSampleRate(), settings.m_inputFrequencyOffset);
+        // Use fixed sample rate of 48000, so Cosine filter doesn't have a massive number of taps at high baseband sample rates (See #1862)
+        m_channelizer->setChannelization(48000, settings.m_inputFrequencyOffset);
         m_source.applyChannelSettings(m_channelizer->getChannelSampleRate(), m_channelizer->getChannelFrequencyOffset());
     }
 


### PR DESCRIPTION
Use channel sample rate of 48k in RTTY and PSK31 mods to reduce filter taps at high baseband sample rates.

Partially helps with #1862, but need to rewrite RaisedCosine filter normalisation code when I get some time.
