### PR TITLE
DSD Demod - Fix loss of constellation

### DIFF
--- a/plugins/channelrx/demodam/amdemodgui.cpp
+++ b/plugins/channelrx/demodam/amdemodgui.cpp
@@ -611,6 +611,7 @@ void AMDemodGUI::audioSelect(const QPoint& p)
     qDebug("AMDemodGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demodbfm/bfmdemodgui.cpp
+++ b/plugins/channelrx/demodbfm/bfmdemodgui.cpp
@@ -532,6 +532,7 @@ void BFMDemodGUI::audioSelect(const QPoint& p)
     qDebug("BFMDemodGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demoddab/dabdemodgui.cpp
+++ b/plugins/channelrx/demoddab/dabdemodgui.cpp
@@ -701,6 +701,7 @@ void DABDemodGUI::audioSelect(const QPoint& p)
 {
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demoddatv/datvdemodgui.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodgui.cpp
@@ -515,6 +515,7 @@ void DATVDemodGUI::audioSelect(const QPoint& p)
     qDebug("DATVDemodGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demoddsd/dsddemod.cpp
+++ b/plugins/channelrx/demoddsd/dsddemod.cpp
@@ -59,7 +59,8 @@ DSDDemod::DSDDemod(DeviceAPI *deviceAPI) :
         ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSink),
         m_deviceAPI(deviceAPI),
         m_running(false),
-        m_basebandSampleRate(0)
+        m_basebandSampleRate(0),
+        m_scopeXYSink(nullptr)
 {
     qDebug("DSDDemod::DSDDemod");
 	setObjectName(m_channelId);
@@ -175,6 +176,7 @@ void DSDDemod::start()
     if (m_basebandSampleRate != 0) {
         m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
     }
+    m_basebandSink->setScopeXYSink(m_scopeXYSink);
 
     m_thread->start();
 
@@ -196,6 +198,14 @@ void DSDDemod::stop()
     m_running = false;
 	m_thread->exit();
 	m_thread->wait();
+}
+
+void DSDDemod::setScopeXYSink(BasebandSampleSink* sampleSink)
+{
+    m_scopeXYSink = sampleSink;
+    if (m_running) {
+        m_basebandSink->setScopeXYSink(sampleSink);
+    }
 }
 
 bool DSDDemod::handleMessage(const Message& cmd)

--- a/plugins/channelrx/demoddsd/dsddemod.h
+++ b/plugins/channelrx/demoddsd/dsddemod.h
@@ -155,7 +155,7 @@ public:
             SWGSDRangel::SWGChannelSettings& response);
 
     uint32_t getNumberOfDeviceStreams() const;
-	void setScopeXYSink(BasebandSampleSink* sampleSink) { if (m_running) { m_basebandSink->setScopeXYSink(sampleSink); } }
+	void setScopeXYSink(BasebandSampleSink* sampleSink);
 	void configureMyPosition(float myLatitude, float myLongitude) { if (m_running) { m_basebandSink->configureMyPosition(myLatitude, myLongitude); } }
 	double getMagSq() { return m_running ? m_basebandSink->getMagSq() : 0.0; }
 	bool getSquelchOpen() const { return m_running && m_basebandSink->getSquelchOpen(); }
@@ -186,7 +186,7 @@ private:
 	DSDDemodSettings m_settings;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
     QHash<Feature*, DSDDemodSettings::AvailableAMBEFeature> m_availableAMBEFeatures;
-
+    BasebandSampleSink *m_scopeXYSink;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;
 

--- a/plugins/channelrx/demoddsd/dsddemodgui.cpp
+++ b/plugins/channelrx/demoddsd/dsddemodgui.cpp
@@ -607,6 +607,7 @@ void DSDDemodGUI::audioSelect(const QPoint& p)
     qDebug("DSDDemodGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demoddsd/dsddemodgui.cpp
+++ b/plugins/channelrx/demoddsd/dsddemodgui.cpp
@@ -101,6 +101,11 @@ bool DSDDemodGUI::handleMessage(const Message& message)
         DSPSignalNotification& notif = (DSPSignalNotification&) message;
         m_deviceCenterFrequency = notif.getCenterFrequency();
         m_basebandSampleRate = notif.getSampleRate();
+        if (m_basebandSampleRate < 48000) {
+            setStatusText(QString("Sample rate must be >= 48000 Hz (Currently %1 Hz)").arg(m_basebandSampleRate));
+        } else {
+            setStatusText("");
+        }
         ui->deltaFrequency->setValueRange(false, 7, -m_basebandSampleRate/2, m_basebandSampleRate/2);
         ui->deltaFrequencyLabel->setToolTip(tr("Range %1 %L2 Hz").arg(QChar(0xB1)).arg(m_basebandSampleRate/2));
         updateAbsoluteCenterFrequency();

--- a/plugins/channelrx/demoddsd/dsddemodgui.ui
+++ b/plugins/channelrx/demoddsd/dsddemodgui.ui
@@ -18,7 +18,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>650</width>
+    <width>500</width>
     <height>392</height>
    </size>
   </property>
@@ -54,7 +54,7 @@
    </property>
    <property name="minimumSize">
     <size>
-     <width>648</width>
+     <width>500</width>
      <height>0</height>
     </size>
    </property>
@@ -533,7 +533,7 @@
        <widget class="QLabel" name="formatStatusText">
         <property name="minimumSize">
          <size>
-          <width>595</width>
+          <width>480</width>
           <height>0</height>
          </size>
         </property>
@@ -569,13 +569,13 @@
     <rect>
      <x>10</x>
      <y>180</y>
-     <width>600</width>
+     <width>480</width>
      <height>210</height>
     </rect>
    </property>
    <property name="minimumSize">
     <size>
-     <width>600</width>
+     <width>480</width>
      <height>210</height>
     </size>
    </property>
@@ -1261,6 +1261,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>ButtonSwitch</class>
+   <extends>QToolButton</extends>
+   <header>gui/buttonswitch.h</header>
+  </customwidget>
+  <customwidget>
    <class>RollupContents</class>
    <extends>QWidget</extends>
    <header>gui/rollupcontents.h</header>
@@ -1277,11 +1282,6 @@
    <extends>QWidget</extends>
    <header>gui/levelmeter.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ButtonSwitch</class>
-   <extends>QToolButton</extends>
-   <header>gui/buttonswitch.h</header>
   </customwidget>
   <customwidget>
    <class>TVScreen</class>

--- a/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
@@ -441,6 +441,7 @@ void FreeDVDemodGUI::audioSelect(const QPoint& p)
     qDebug("FreeDVDemodGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demodft8/ft8demodgui.cpp
+++ b/plugins/channelrx/demodft8/ft8demodgui.cpp
@@ -27,7 +27,6 @@
 #include "gui/basicchannelsettingsdialog.h"
 #include "gui/devicestreamselectiondialog.h"
 #include "gui/crightclickenabler.h"
-#include "gui/audioselectdialog.h"
 #include "gui/dialpopup.h"
 #include "gui/dialogpositioner.h"
 #include "util/db.h"

--- a/plugins/channelrx/demodils/ilsdemodgui.cpp
+++ b/plugins/channelrx/demodils/ilsdemodgui.cpp
@@ -1278,6 +1278,7 @@ void ILSDemodGUI::audioSelect(const QPoint& p)
     qDebug("ILSDemodGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demodm17/m17demodgui.cpp
+++ b/plugins/channelrx/demodm17/m17demodgui.cpp
@@ -644,6 +644,7 @@ void M17DemodGUI::audioSelect(const QPoint& p)
 {
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demodnfm/nfmdemodgui.cpp
+++ b/plugins/channelrx/demodnfm/nfmdemodgui.cpp
@@ -584,6 +584,7 @@ void NFMDemodGUI::audioSelect(const QPoint& p)
     qDebug("NFMDemodGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demodssb/ssbdemodgui.cpp
+++ b/plugins/channelrx/demodssb/ssbdemodgui.cpp
@@ -718,6 +718,7 @@ void SSBDemodGUI::audioSelect(const QPoint& p)
 {
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demodvor/vordemodgui.cpp
+++ b/plugins/channelrx/demodvor/vordemodgui.cpp
@@ -417,6 +417,7 @@ void VORDemodGUI::audioSelect(const QPoint& p)
     qDebug("VORDemodGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demodvormc/vordemodmcgui.cpp
+++ b/plugins/channelrx/demodvormc/vordemodmcgui.cpp
@@ -1368,6 +1368,7 @@ void VORDemodMCGUI::audioSelect(const QPoint& p)
     qDebug("VORDemodMCGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/demodwfm/wfmdemodgui.cpp
+++ b/plugins/channelrx/demodwfm/wfmdemodgui.cpp
@@ -336,6 +336,7 @@ void WFMDemodGUI::audioSelect(const QPoint& p)
     qDebug("WFMDemodGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName);
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channelrx/freqtracker/freqtrackergui.cpp
+++ b/plugins/channelrx/freqtracker/freqtrackergui.cpp
@@ -32,7 +32,6 @@
 #include "gui/devicestreamselectiondialog.h"
 #include "dsp/dspengine.h"
 #include "gui/crightclickenabler.h"
-#include "gui/audioselectdialog.h"
 #include "gui/dialpopup.h"
 #include "gui/dialogpositioner.h"
 #include "maincore.h"

--- a/plugins/channeltx/modam/ammodgui.cpp
+++ b/plugins/channeltx/modam/ammodgui.cpp
@@ -503,7 +503,7 @@ void AMModGUI::audioSelect(const QPoint& p)
     qDebug("AMModGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName, true); // true for input
     audioSelect.move(p);
-
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channeltx/modfreedv/freedvmodgui.cpp
+++ b/plugins/channeltx/modfreedv/freedvmodgui.cpp
@@ -550,6 +550,7 @@ void FreeDVModGUI::audioSelect(const QPoint& p)
     qDebug("FreeDVModGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName, true); // true for input
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channeltx/modm17/m17modgui.cpp
+++ b/plugins/channeltx/modm17/m17modgui.cpp
@@ -717,6 +717,7 @@ void M17ModGUI::audioSelect(const QPoint& p)
     qDebug("M17ModGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName, true); // true for input
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)
@@ -731,6 +732,7 @@ void M17ModGUI::audioFeedbackSelect(const QPoint& p)
     qDebug("M17ModGUI::audioFeedbackSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName, false); // false for output
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channeltx/modnfm/nfmmodgui.cpp
+++ b/plugins/channeltx/modnfm/nfmmodgui.cpp
@@ -623,6 +623,7 @@ void NFMModGUI::audioSelect(const QPoint& p)
     qDebug("NFMModGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName, true); // true for input
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)
@@ -637,6 +638,7 @@ void NFMModGUI::audioFeedbackSelect(const QPoint& p)
     qDebug("NFMModGUI::audioFeedbackSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName, false); // false for output
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channeltx/modssb/ssbmodgui.cpp
+++ b/plugins/channeltx/modssb/ssbmodgui.cpp
@@ -770,6 +770,7 @@ void SSBModGUI::audioSelect(const QPoint& p)
     qDebug("SSBModGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName, true); // true for input
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)
@@ -784,6 +785,7 @@ void SSBModGUI::audioFeedbackSelect(const QPoint& p)
     qDebug("SSBModGUI::audioFeedbackSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName, false); // false for output
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/channeltx/modwfm/wfmmodgui.cpp
+++ b/plugins/channeltx/modwfm/wfmmodgui.cpp
@@ -518,6 +518,7 @@ void WFMModGUI::audioSelect(const QPoint& p)
     qDebug("WFMModGUI::audioSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName, true); // true for input
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)
@@ -532,6 +533,7 @@ void WFMModGUI::audioFeedbackSelect(const QPoint& p)
     qDebug("WFMModGUI::audioFeedbackSelect");
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_audioDeviceName, false); // false for output
     audioSelect.move(p);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/samplemimo/audiocatsiso/audiocatsisogui.cpp
+++ b/plugins/samplemimo/audiocatsiso/audiocatsisogui.cpp
@@ -324,6 +324,7 @@ void AudioCATSISOGUI::on_transverter_clicked()
 void AudioCATSISOGUI::on_rxDeviceSelect_clicked()
 {
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_txDeviceName, true, this);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)
@@ -338,6 +339,7 @@ void AudioCATSISOGUI::on_rxDeviceSelect_clicked()
 void AudioCATSISOGUI::on_txDeviceSelect_clicked()
 {
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_txDeviceName, false, this);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)

--- a/plugins/samplesink/audiooutput/audiooutputgui.cpp
+++ b/plugins/samplesink/audiooutput/audiooutputgui.cpp
@@ -183,6 +183,7 @@ void AudioOutputGui::displaySettings()
 void AudioOutputGui::on_deviceSelect_clicked()
 {
     AudioSelectDialog audioSelect(DSPEngine::instance()->getAudioDeviceManager(), m_settings.m_deviceName, false, this);
+    new DialogPositioner(&audioSelect, false);
     audioSelect.exec();
 
     if (audioSelect.m_selected)


### PR DESCRIPTION
DSD Demod constellation will not appear if !m_running when GUI is created or if acquisition is restarted (which recreates the baseband object).

This patch fixes this, by saving a pointer to m_scopeXYSink in DSDDemod, so that it can be used to initialise the baseband/sink every time it is created.

Also, this patch adds a warning in the DSDDemod GUI if the sample rate is < 48kHz.

For #1836