### PR TITLE
Indicate audio FIFO underflow/overflow in GUI

### DIFF
--- a/plugins/channelrx/demodwfm/wfmdemod.h
+++ b/plugins/channelrx/demodwfm/wfmdemod.h
@@ -95,6 +95,7 @@ public:
 	double getMagSq() const { return m_running ? m_basebandSink->getMagSq() : 0.0; }
     bool getSquelchOpen() const { return m_running && m_basebandSink->getSquelchOpen(); }
     int getAudioSampleRate() const { return m_running ? m_basebandSink->getAudioSampleRate() : 0; }
+    QDateTime getAudioFifoErrorDateTime() const { return m_running ? m_basebandSink->getAudioFifoErrorDateTime() : QDateTime(); }
 
     void getMagSqLevels(double& avg, double& peak, int& nbSamples)
     {

--- a/plugins/channelrx/demodwfm/wfmdemodbaseband.cpp
+++ b/plugins/channelrx/demodwfm/wfmdemodbaseband.cpp
@@ -44,6 +44,8 @@ WFMDemodBaseband::WFMDemodBaseband()
     m_channelSampleRate = 0;
 
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()));
+    connect(m_sink.getAudioFifo(), &AudioFifo::underflow, this, &WFMDemodBaseband::audioUnderflow);
+    connect(m_sink.getAudioFifo(), &AudioFifo::overflow, this, &WFMDemodBaseband::audioOverflow);
 }
 
 WFMDemodBaseband::~WFMDemodBaseband()
@@ -187,4 +189,14 @@ void WFMDemodBaseband::setBasebandSampleRate(int sampleRate)
 {
     m_channelizer->setBasebandSampleRate(sampleRate);
     m_sink.applyChannelSettings(m_channelizer->getChannelSampleRate(), m_channelizer->getChannelFrequencyOffset());
+}
+
+void WFMDemodBaseband::audioUnderflow()
+{
+    m_audioFifoErrorDateTime = QDateTime::currentDateTime();
+}
+
+void WFMDemodBaseband::audioOverflow()
+{
+    m_audioFifoErrorDateTime = QDateTime::currentDateTime();
 }

--- a/plugins/channelrx/demodwfm/wfmdemodbaseband.h
+++ b/plugins/channelrx/demodwfm/wfmdemodbaseband.h
@@ -20,6 +20,7 @@
 
 #include <QObject>
 #include <QRecursiveMutex>
+#include <QDateTime>
 
 #include "dsp/samplesinkfifo.h"
 #include "util/message.h"
@@ -73,6 +74,7 @@ public:
     void setChannel(ChannelAPI *channel);
     void setFifoLabel(const QString& label) { m_sampleFifo.setLabel(label); }
     void setAudioFifoLabel(const QString& label) { m_sink.setAudioFifoLabel(label); }
+    QDateTime getAudioFifoErrorDateTime() { return m_audioFifoErrorDateTime; }
 
 private:
     SampleSinkFifo m_sampleFifo;
@@ -82,6 +84,7 @@ private:
 	MessageQueue m_inputMessageQueue; //!< Queue for asynchronous inbound communication
     WFMDemodSettings m_settings;
     QRecursiveMutex m_mutex;
+    QDateTime m_audioFifoErrorDateTime;
 
     bool handleMessage(const Message& cmd);
     void applySettings(const WFMDemodSettings& settings, bool force = false);
@@ -89,6 +92,8 @@ private:
 private slots:
     void handleInputMessages();
     void handleData(); //!< Handle data when samples have to be processed
+    void audioUnderflow();
+    void audioOverflow();
 };
 
 #endif // INCLUDE_WFMDEMODBASEBAND_H

--- a/plugins/channelrx/demodwfm/wfmdemodgui.cpp
+++ b/plugins/channelrx/demodwfm/wfmdemodgui.cpp
@@ -218,7 +218,8 @@ WFMDemodGUI::WFMDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     m_basebandSampleRate(1),
 	m_basicSettingsShown(false),
     m_squelchOpen(false),
-    m_audioSampleRate(-1)
+    m_audioSampleRate(-1),
+    m_recentAudioFifoError(false)
 {
 	setAttribute(Qt::WA_DeleteOnClose, true);
     m_helpURL = "plugins/channelrx/demodwfm/readme.md";
@@ -361,11 +362,15 @@ void WFMDemodGUI::tick()
 
     int audioSampleRate = m_wfmDemod->getAudioSampleRate();
     bool squelchOpen = m_wfmDemod->getSquelchOpen();
+    int secsSinceAudioFifoError = m_wfmDemod->getAudioFifoErrorDateTime().secsTo(QDateTime::currentDateTime());
+    bool recentAudioFifoError = (secsSinceAudioFifoError < 1) && squelchOpen;
 
-    if ((audioSampleRate != m_audioSampleRate) || (squelchOpen != m_squelchOpen))
+    if ((audioSampleRate != m_audioSampleRate) || (squelchOpen != m_squelchOpen) || (recentAudioFifoError != m_recentAudioFifoError))
     {
         if (audioSampleRate < 0) {
             ui->audioMute->setStyleSheet("QToolButton { background-color : red; }");
+        } else if (recentAudioFifoError) {
+            ui->audioMute->setStyleSheet("QToolButton { background-color : rgb(120,120,0); }");
         } else if (squelchOpen) {
             ui->audioMute->setStyleSheet("QToolButton { background-color : green; }");
         } else {
@@ -374,6 +379,7 @@ void WFMDemodGUI::tick()
 
         m_audioSampleRate = audioSampleRate;
         m_squelchOpen = squelchOpen;
+        m_recentAudioFifoError = recentAudioFifoError;
     }
 }
 

--- a/plugins/channelrx/demodwfm/wfmdemodgui.h
+++ b/plugins/channelrx/demodwfm/wfmdemodgui.h
@@ -58,6 +58,7 @@ private:
     bool m_audioMute;
     bool m_squelchOpen;
     int m_audioSampleRate;
+    bool m_recentAudioFifoError;
 
 	WFMDemod* m_wfmDemod;
 	MessageQueue m_inputMessageQueue;

--- a/sdrbase/audio/audiofifo.h
+++ b/sdrbase/audio/audiofifo.h
@@ -68,6 +68,7 @@ private:
 signals:
 	void dataReady();
 	void overflow(int nsamples);
+    void underflow();
 };
 
 #endif // INCLUDE_AUDIOFIFO_H


### PR DESCRIPTION
Currently, there appears to be no indication if audio underflow occurs. There's a message in the log if overflow occurs.

This PR indicates if overflow/underflow has occurred in the last second, by setting the background of the audio mute button to yellow.

![image](https://github.com/f4exb/sdrangel/assets/57259258/cc373ac3-2798-45cf-b156-15650b1e4e0c)

Currently the patch is just for WFM Demod - but if you think this is the way to go, I can add to other demods.

Although much of the time underflows are inaudible (to my ears at least), I think it's useful to indicate there's a problem for when audio is being piped to an external demod, as it may be more problematic. (Good example of when they occur, is with some RTL SDRs running at 3.2MSa/s - as not all can quite do it).

The patch also changes how the audio output device works slightly, to try to avoid some zero padding. Currently, the readData(char* data, qint64 maxLen) function always returns the indicated maxLen amount of data, and zero pads if there isn't enough data in the audio FIFOs. The patch changes this, so that zeros are only output if there is no data in any of the audio FIFOs. If there is some, then we just output what is available, giving a bit more time for some more to be added to the FIFOs.
