### PR TITLE
Fix resize cursor not being cleared when mouse moves over child widgets

### DIFF
--- a/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodgui.cpp
+++ b/plugins/channelmimo/beamsteeringcwmod/beamsteeringcwmodgui.cpp
@@ -133,6 +133,7 @@ BeamSteeringCWModGUI::BeamSteeringCWModGUI(PluginAPI* pluginAPI, DeviceUISet *de
     makeUIConnections();
     displayRateAndShift();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 BeamSteeringCWModGUI::~BeamSteeringCWModGUI()

--- a/plugins/channelmimo/doa2/doa2gui.cpp
+++ b/plugins/channelmimo/doa2/doa2gui.cpp
@@ -161,6 +161,7 @@ DOA2GUI::DOA2GUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, MIMOChannel *ch
     ui->halfWLLabel->setText(QString("%1/2").arg(QChar(0xBB, 0x03)));
     ui->azUnits->setText(QString("%1").arg(QChar(0260)));
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 DOA2GUI::~DOA2GUI()

--- a/plugins/channelmimo/interferometer/interferometergui.cpp
+++ b/plugins/channelmimo/interferometer/interferometergui.cpp
@@ -168,6 +168,7 @@ InterferometerGUI::InterferometerGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUI
     makeUIConnections();
     displayRateAndShift();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 InterferometerGUI::~InterferometerGUI()

--- a/plugins/channelrx/chanalyzer/chanalyzergui.cpp
+++ b/plugins/channelrx/chanalyzer/chanalyzergui.cpp
@@ -596,6 +596,7 @@ ChannelAnalyzerGUI::ChannelAnalyzerGUI(PluginAPI* pluginAPI, DeviceUISet *device
     makeUIConnections();
 	applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 ChannelAnalyzerGUI::~ChannelAnalyzerGUI()

--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -5033,6 +5033,7 @@ ADSBDemodGUI::ADSBDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
     m_redrawMapTimer.setSingleShot(true);
     ui->map->installEventFilter(this);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 ADSBDemodGUI::~ADSBDemodGUI()

--- a/plugins/channelrx/demodais/aisdemodgui.cpp
+++ b/plugins/channelrx/demodais/aisdemodgui.cpp
@@ -835,6 +835,7 @@ AISDemodGUI::AISDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 void AISDemodGUI::customContextMenuRequested(QPoint pos)

--- a/plugins/channelrx/demodam/amdemodgui.cpp
+++ b/plugins/channelrx/demodam/amdemodgui.cpp
@@ -500,6 +500,7 @@ AMDemodGUI::AMDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandS
 	displaySettings();
     makeUIConnections();
 	applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 AMDemodGUI::~AMDemodGUI()

--- a/plugins/channelrx/demodapt/aptdemodgui.cpp
+++ b/plugins/channelrx/demodapt/aptdemodgui.cpp
@@ -680,6 +680,7 @@ APTDemodGUI::APTDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 APTDemodGUI::~APTDemodGUI()

--- a/plugins/channelrx/demodatv/atvdemodgui.cpp
+++ b/plugins/channelrx/demodatv/atvdemodgui.cpp
@@ -333,6 +333,7 @@ ATVDemodGUI::ATVDemodGUI(PluginAPI* objPluginAPI, DeviceUISet *deviceUISet, Base
 
     makeUIConnections();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 ATVDemodGUI::~ATVDemodGUI()

--- a/plugins/channelrx/demodbfm/bfmdemodgui.cpp
+++ b/plugins/channelrx/demodbfm/bfmdemodgui.cpp
@@ -453,6 +453,7 @@ BFMDemodGUI::BFMDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
 	displaySettings();
     makeUIConnections();
 	applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 BFMDemodGUI::~BFMDemodGUI()

--- a/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
@@ -445,6 +445,7 @@ ChirpChatDemodGUI::ChirpChatDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUI
     resetLoRaStatus();
 	applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 ChirpChatDemodGUI::~ChirpChatDemodGUI()

--- a/plugins/channelrx/demoddab/dabdemodgui.cpp
+++ b/plugins/channelrx/demoddab/dabdemodgui.cpp
@@ -577,6 +577,7 @@ DABDemodGUI::DABDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 DABDemodGUI::~DABDemodGUI()

--- a/plugins/channelrx/demoddatv/datvdemodgui.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodgui.cpp
@@ -314,6 +314,7 @@ DATVDemodGUI::DATVDemodGUI(PluginAPI* objPluginAPI, DeviceUISet *deviceUISet, Ba
     resetToDefaults(); // does applySettings()
     makeUIConnections();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 DATVDemodGUI::~DATVDemodGUI()

--- a/plugins/channelrx/demoddsc/dscdemodgui.cpp
+++ b/plugins/channelrx/demoddsc/dscdemodgui.cpp
@@ -664,6 +664,7 @@ DSCDemodGUI::DSCDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 void DSCDemodGUI::createMenuOpenURLAction(QMenu* tableContextMenu, const QString& text, const QString& url, const QString& arg)

--- a/plugins/channelrx/demoddsd/dsddemodgui.cpp
+++ b/plugins/channelrx/demoddsd/dsddemodgui.cpp
@@ -434,6 +434,7 @@ DSDDemodGUI::DSDDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
 	displaySettings();
     makeUIConnections();
 	applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 DSDDemodGUI::~DSDDemodGUI()

--- a/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemodgui.cpp
@@ -334,6 +334,7 @@ FreeDVDemodGUI::FreeDVDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
     makeUIConnections();
 	applyBandwidths(5 - ui->spanLog2->value(), true); // does applySettings(true)
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 FreeDVDemodGUI::~FreeDVDemodGUI()

--- a/plugins/channelrx/demodft8/ft8demodgui.cpp
+++ b/plugins/channelrx/demodft8/ft8demodgui.cpp
@@ -655,6 +655,7 @@ FT8DemodGUI::FT8DemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
 
 	applyBandwidths(m_settings.m_filterBank[m_settings.m_filterIndex].m_spanLog2, true); // does applySettings(true)
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 
     populateBandPresets();
     setupMessagesView();

--- a/plugins/channelrx/demodils/ilsdemodgui.cpp
+++ b/plugins/channelrx/demodils/ilsdemodgui.cpp
@@ -1110,6 +1110,7 @@ ILSDemodGUI::ILSDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
     drawILSOnMap();
 
     bool devMode = false;

--- a/plugins/channelrx/demodm17/m17demodgui.cpp
+++ b/plugins/channelrx/demodm17/m17demodgui.cpp
@@ -515,6 +515,7 @@ M17DemodGUI::M17DemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     makeUIConnections();
 	applySettings(QList<QString>(), true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 M17DemodGUI::~M17DemodGUI()

--- a/plugins/channelrx/demodnavtex/navtexdemodgui.cpp
+++ b/plugins/channelrx/demodnavtex/navtexdemodgui.cpp
@@ -613,6 +613,7 @@ NavtexDemodGUI::NavtexDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 void NavtexDemodGUI::customContextMenuRequested(QPoint pos)

--- a/plugins/channelrx/demodnfm/nfmdemodgui.cpp
+++ b/plugins/channelrx/demodnfm/nfmdemodgui.cpp
@@ -443,6 +443,7 @@ NFMDemodGUI::NFMDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     makeUIConnections();
 	applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 NFMDemodGUI::~NFMDemodGUI()

--- a/plugins/channelrx/demodpacket/packetdemodgui.cpp
+++ b/plugins/channelrx/demodpacket/packetdemodgui.cpp
@@ -496,6 +496,7 @@ PacketDemodGUI::PacketDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 PacketDemodGUI::~PacketDemodGUI()

--- a/plugins/channelrx/demodpager/pagerdemodgui.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodgui.cpp
@@ -556,6 +556,7 @@ PagerDemodGUI::PagerDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Bas
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 void PagerDemodGUI::customContextMenuRequested(QPoint pos)

--- a/plugins/channelrx/demodradiosonde/radiosondedemodgui.cpp
+++ b/plugins/channelrx/demodradiosonde/radiosondedemodgui.cpp
@@ -669,6 +669,7 @@ RadiosondeDemodGUI::RadiosondeDemodGUI(PluginAPI* pluginAPI, DeviceUISet *device
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 void RadiosondeDemodGUI::customContextMenuRequested(QPoint pos)

--- a/plugins/channelrx/demodrtty/rttydemodgui.cpp
+++ b/plugins/channelrx/demodrtty/rttydemodgui.cpp
@@ -501,6 +501,7 @@ RttyDemodGUI::RttyDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 RttyDemodGUI::~RttyDemodGUI()

--- a/plugins/channelrx/demodssb/ssbdemodgui.cpp
+++ b/plugins/channelrx/demodssb/ssbdemodgui.cpp
@@ -425,6 +425,7 @@ SSBDemodGUI::SSBDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
 
 	applyBandwidths(m_settings.m_filterBank[m_settings.m_filterIndex].m_spanLog2, true); // does applySettings(true)
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 SSBDemodGUI::~SSBDemodGUI()

--- a/plugins/channelrx/demodvor/vordemodgui.cpp
+++ b/plugins/channelrx/demodvor/vordemodgui.cpp
@@ -343,6 +343,7 @@ VORDemodGUI::VORDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 VORDemodGUI::~VORDemodGUI()

--- a/plugins/channelrx/demodvormc/vordemodmcgui.cpp
+++ b/plugins/channelrx/demodvormc/vordemodmcgui.cpp
@@ -1286,6 +1286,7 @@ VORDemodMCGUI::VORDemodMCGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Bas
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 VORDemodMCGUI::~VORDemodMCGUI()

--- a/plugins/channelrx/demodwfm/wfmdemodgui.cpp
+++ b/plugins/channelrx/demodwfm/wfmdemodgui.cpp
@@ -266,6 +266,7 @@ WFMDemodGUI::WFMDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     displaySettings();
     makeUIConnections();
 	applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 WFMDemodGUI::~WFMDemodGUI()

--- a/plugins/channelrx/filesink/filesinkgui.cpp
+++ b/plugins/channelrx/filesink/filesinkgui.cpp
@@ -234,6 +234,7 @@ FileSinkGUI::FileSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 FileSinkGUI::~FileSinkGUI()

--- a/plugins/channelrx/freqscanner/freqscannergui.cpp
+++ b/plugins/channelrx/freqscanner/freqscannergui.cpp
@@ -461,6 +461,7 @@ FreqScannerGUI::FreqScannerGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
     displaySettings();
     makeUIConnections();
     applyAllSettings();
+    m_resizer.enableChildMouseTracking();
 
     ui->table->setItemDelegateForColumn(COL_FREQUENCY, new FrequencyDelegate("Auto", 3));
     ui->table->setItemDelegateForColumn(COL_POWER, new DecimalDelegate(1));

--- a/plugins/channelrx/freqtracker/freqtrackergui.cpp
+++ b/plugins/channelrx/freqtracker/freqtrackergui.cpp
@@ -376,6 +376,7 @@ FreqTrackerGUI::FreqTrackerGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
     makeUIConnections();
 	applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 FreqTrackerGUI::~FreqTrackerGUI()

--- a/plugins/channelrx/heatmap/heatmapgui.cpp
+++ b/plugins/channelrx/heatmap/heatmapgui.cpp
@@ -633,6 +633,7 @@ HeatMapGUI::HeatMapGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandS
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 
     plotPowerVsTimeChart();
 }

--- a/plugins/channelrx/localsink/localsinkgui.cpp
+++ b/plugins/channelrx/localsink/localsinkgui.cpp
@@ -157,6 +157,7 @@ LocalSinkGUI::LocalSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 LocalSinkGUI::~LocalSinkGUI()

--- a/plugins/channelrx/noisefigure/noisefiguregui.cpp
+++ b/plugins/channelrx/noisefigure/noisefiguregui.cpp
@@ -672,6 +672,7 @@ NoiseFigureGUI::NoiseFigureGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 void NoiseFigureGUI::customContextMenuRequested(QPoint pos)

--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -2223,6 +2223,7 @@ RadioAstronomyGUI::RadioAstronomyGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUI
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 
     create2DImage();
 

--- a/plugins/channelrx/radioclock/radioclockgui.cpp
+++ b/plugins/channelrx/radioclock/radioclockgui.cpp
@@ -331,6 +331,7 @@ RadioClockGUI::RadioClockGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Bas
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 RadioClockGUI::~RadioClockGUI()

--- a/plugins/channelrx/remotesink/remotesinkgui.cpp
+++ b/plugins/channelrx/remotesink/remotesinkgui.cpp
@@ -134,6 +134,7 @@ RemoteSinkGUI::RemoteSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Bas
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 RemoteSinkGUI::~RemoteSinkGUI()

--- a/plugins/channelrx/remotetcpsink/remotetcpsinkgui.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinkgui.cpp
@@ -215,6 +215,7 @@ RemoteTCPSinkGUI::RemoteTCPSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISe
     makeUIConnections();
     applyAllSettings();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 RemoteTCPSinkGUI::~RemoteTCPSinkGUI()

--- a/plugins/channelrx/sigmffilesink/sigmffilesinkgui.cpp
+++ b/plugins/channelrx/sigmffilesink/sigmffilesinkgui.cpp
@@ -220,6 +220,7 @@ SigMFFileSinkGUI::SigMFFileSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISe
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 SigMFFileSinkGUI::~SigMFFileSinkGUI()

--- a/plugins/channelrx/udpsink/udpsinkgui.cpp
+++ b/plugins/channelrx/udpsink/udpsinkgui.cpp
@@ -221,6 +221,7 @@ UDPSinkGUI::UDPSinkGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandS
 	applySettingsImmediate(true);
 	applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 UDPSinkGUI::~UDPSinkGUI()

--- a/plugins/channeltx/filesource/filesourcegui.cpp
+++ b/plugins/channeltx/filesource/filesourcegui.cpp
@@ -218,6 +218,7 @@ FileSourceGUI::FileSourceGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Bas
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 FileSourceGUI::~FileSourceGUI()

--- a/plugins/channeltx/localsource/localsourcegui.cpp
+++ b/plugins/channeltx/localsource/localsourcegui.cpp
@@ -131,6 +131,7 @@ LocalSourceGUI::LocalSourceGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, B
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 LocalSourceGUI::~LocalSourceGUI()

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_modgui.cpp
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_modgui.cpp
@@ -484,6 +484,7 @@ IEEE_802_15_4_ModGUI::IEEE_802_15_4_ModGUI(PluginAPI* pluginAPI, DeviceUISet *de
     makeUIConnections();
     applySettings();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 IEEE_802_15_4_ModGUI::~IEEE_802_15_4_ModGUI()

--- a/plugins/channeltx/modais/aismodgui.cpp
+++ b/plugins/channeltx/modais/aismodgui.cpp
@@ -510,6 +510,7 @@ AISModGUI::AISModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSam
     makeUIConnections();
     applySettings();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 AISModGUI::~AISModGUI()

--- a/plugins/channeltx/modam/ammodgui.cpp
+++ b/plugins/channeltx/modam/ammodgui.cpp
@@ -410,6 +410,7 @@ AMModGUI::AMModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSampl
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 AMModGUI::~AMModGUI()

--- a/plugins/channeltx/modatv/atvmodgui.cpp
+++ b/plugins/channeltx/modatv/atvmodgui.cpp
@@ -122,6 +122,7 @@ ATVModGUI::ATVModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSam
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 ATVModGUI::~ATVModGUI()

--- a/plugins/channeltx/modchirpchat/chirpchatmodgui.cpp
+++ b/plugins/channeltx/modchirpchat/chirpchatmodgui.cpp
@@ -469,6 +469,7 @@ ChirpChatModGUI::ChirpChatModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet,
     makeUIConnections();
     applySettings();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 ChirpChatModGUI::~ChirpChatModGUI()

--- a/plugins/channeltx/moddatv/datvmodgui.cpp
+++ b/plugins/channeltx/moddatv/datvmodgui.cpp
@@ -115,6 +115,7 @@ DATVModGUI::DATVModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandS
     displaySettings();
     makeUIConnections();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
     if (!m_settings.m_tsFileName.isEmpty())
         configureTsFileName();
 }

--- a/plugins/channeltx/modfreedv/freedvmodgui.cpp
+++ b/plugins/channeltx/modfreedv/freedvmodgui.cpp
@@ -422,6 +422,7 @@ FreeDVModGUI::FreeDVModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
 
     displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
     applyBandwidths(5 - ui->spanLog2->value(), true); // does applySettings(true)
     DialPopup::addPopupsToChildDials(this);
 }

--- a/plugins/channeltx/modm17/m17modgui.cpp
+++ b/plugins/channeltx/modm17/m17modgui.cpp
@@ -528,6 +528,7 @@ M17ModGUI::M17ModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSam
     makeUIConnections();
     applySettings(QList<QString>{"channelMarker", "rollupState"});
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 M17ModGUI::~M17ModGUI()

--- a/plugins/channeltx/modnfm/nfmmodgui.cpp
+++ b/plugins/channeltx/modnfm/nfmmodgui.cpp
@@ -516,6 +516,7 @@ NFMModGUI::NFMModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSam
     makeUIConnections();
     applySettings();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 NFMModGUI::~NFMModGUI()

--- a/plugins/channeltx/modpacket/packetmodgui.cpp
+++ b/plugins/channeltx/modpacket/packetmodgui.cpp
@@ -531,6 +531,7 @@ PacketModGUI::PacketModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
     makeUIConnections();
     applySettings();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 PacketModGUI::~PacketModGUI()

--- a/plugins/channeltx/modpsk31/psk31modgui.cpp
+++ b/plugins/channeltx/modpsk31/psk31modgui.cpp
@@ -412,6 +412,7 @@ PSK31GUI::PSK31GUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSampl
     makeUIConnections();
     applySettings();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 
     m_initialToolTip = ui->txButton->toolTip();
 }

--- a/plugins/channeltx/modrtty/rttymodgui.cpp
+++ b/plugins/channeltx/modrtty/rttymodgui.cpp
@@ -491,6 +491,7 @@ RttyModGUI::RttyModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandS
     makeUIConnections();
     applySettings();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 
     m_initialToolTip = ui->txButton->toolTip();
 }

--- a/plugins/channeltx/modssb/ssbmodgui.cpp
+++ b/plugins/channeltx/modssb/ssbmodgui.cpp
@@ -505,6 +505,7 @@ SSBModGUI::SSBModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSam
     makeUIConnections();
     applyBandwidths(5 - ui->spanLog2->value(), true); // does applySettings(true)
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 SSBModGUI::~SSBModGUI()

--- a/plugins/channeltx/modwfm/wfmmodgui.cpp
+++ b/plugins/channeltx/modwfm/wfmmodgui.cpp
@@ -426,6 +426,7 @@ WFMModGUI::WFMModGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, BasebandSam
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 WFMModGUI::~WFMModGUI()

--- a/plugins/channeltx/remotesource/remotesourcegui.cpp
+++ b/plugins/channeltx/remotesource/remotesourcegui.cpp
@@ -210,6 +210,7 @@ RemoteSourceGUI::RemoteSourceGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet,
     displayPosition();
     displayRateAndShift();
     applySettings(true);
+    m_resizer.enableChildMouseTracking();
 }
 
 RemoteSourceGUI::~RemoteSourceGUI()

--- a/plugins/channeltx/udpsource/udpsourcegui.cpp
+++ b/plugins/channeltx/udpsource/udpsourcegui.cpp
@@ -178,6 +178,7 @@ UDPSourceGUI::UDPSourceGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
     makeUIConnections();
     applySettings(true);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 UDPSourceGUI::~UDPSourceGUI()

--- a/plugins/feature/afc/afcgui.cpp
+++ b/plugins/feature/afc/afcgui.cpp
@@ -174,6 +174,7 @@ AFCGUI::AFCGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *featur
 	applySettings(true);
     makeUIConnections();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 AFCGUI::~AFCGUI()

--- a/plugins/feature/ambe/ambegui.cpp
+++ b/plugins/feature/ambe/ambegui.cpp
@@ -62,6 +62,7 @@ AMBEGUI::AMBEGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feat
     refreshInUseList();
     displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 AMBEGUI::~AMBEGUI()

--- a/plugins/feature/antennatools/antennatoolsgui.cpp
+++ b/plugins/feature/antennatools/antennatoolsgui.cpp
@@ -149,6 +149,7 @@ AntennaToolsGUI::AntennaToolsGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISe
     displaySettings();
     applySettings(true);
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 AntennaToolsGUI::~AntennaToolsGUI()

--- a/plugins/feature/aprs/aprsgui.cpp
+++ b/plugins/feature/aprs/aprsgui.cpp
@@ -586,6 +586,7 @@ APRSGUI::APRSGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *feat
     displaySettings();
     applySettings(true);
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 APRSGUI::~APRSGUI()

--- a/plugins/feature/demodanalyzer/demodanalyzergui.cpp
+++ b/plugins/feature/demodanalyzer/demodanalyzergui.cpp
@@ -191,6 +191,7 @@ DemodAnalyzerGUI::DemodAnalyzerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUI
 	applySettings(true);
     makeUIConnections();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 DemodAnalyzerGUI::~DemodAnalyzerGUI()

--- a/plugins/feature/gs232controller/gs232controllergui.cpp
+++ b/plugins/feature/gs232controller/gs232controllergui.cpp
@@ -266,6 +266,7 @@ GS232ControllerGUI::GS232ControllerGUI(PluginAPI* pluginAPI, FeatureUISet *featu
     m_gs232Controller->getInputMessageQueue()->push(GS232Controller::MsgScanAvailableChannelOrFeatures::create());
 
     new DialogPositioner(&m_dfmStatusDialog, true);
+    m_resizer.enableChildMouseTracking();
 }
 
 void GS232ControllerGUI::updateInputControllerList()

--- a/plugins/feature/jogdialcontroller/jogdialcontrollergui.cpp
+++ b/plugins/feature/jogdialcontroller/jogdialcontrollergui.cpp
@@ -178,6 +178,7 @@ JogdialControllerGUI::JogdialControllerGUI(PluginAPI* pluginAPI, FeatureUISet *f
     displaySettings();
 	applySettings(true);
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 JogdialControllerGUI::~JogdialControllerGUI()

--- a/plugins/feature/limerfe/limerfegui.cpp
+++ b/plugins/feature/limerfe/limerfegui.cpp
@@ -164,6 +164,7 @@ LimeRFEGUI::LimeRFEGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature
     highlightApplyButton(false);
     m_timer.setInterval(500);
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 LimeRFEGUI::~LimeRFEGUI()

--- a/plugins/feature/map/mapgui.cpp
+++ b/plugins/feature/map/mapgui.cpp
@@ -334,6 +334,7 @@ MapGUI::MapGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *featur
     new DialogPositioner(&m_beaconDialog, true);
     new DialogPositioner(&m_ibpBeaconDialog, true);
     new DialogPositioner(&m_radioTimeDialog, true);
+    m_resizer.enableChildMouseTracking();
 }
 
 MapGUI::~MapGUI()

--- a/plugins/feature/pertester/pertestergui.cpp
+++ b/plugins/feature/pertester/pertestergui.cpp
@@ -156,6 +156,7 @@ PERTesterGUI::PERTesterGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Fea
     displaySettings();
     applySettings(true);
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 PERTesterGUI::~PERTesterGUI()

--- a/plugins/feature/radiosonde/radiosondegui.cpp
+++ b/plugins/feature/radiosonde/radiosondegui.cpp
@@ -194,6 +194,7 @@ RadiosondeGUI::RadiosondeGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, F
     displaySettings();
     applySettings(true);
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
     plotChart();
 }

--- a/plugins/feature/remotecontrol/remotecontrolgui.cpp
+++ b/plugins/feature/remotecontrol/remotecontrolgui.cpp
@@ -157,6 +157,7 @@ RemoteControlGUI::RemoteControlGUI(PluginAPI* pluginAPI, FeatureUISet *featureUI
     displaySettings();
     applySettings(true);
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 RemoteControlGUI::~RemoteControlGUI()

--- a/plugins/feature/rigctlserver/rigctlservergui.cpp
+++ b/plugins/feature/rigctlserver/rigctlservergui.cpp
@@ -154,6 +154,7 @@ RigCtlServerGUI::RigCtlServerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISe
     displaySettings();
 	applySettings(true);
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 RigCtlServerGUI::~RigCtlServerGUI()

--- a/plugins/feature/satellitetracker/satellitetrackergui.cpp
+++ b/plugins/feature/satellitetracker/satellitetrackergui.cpp
@@ -333,6 +333,7 @@ SatelliteTrackerGUI::SatelliteTrackerGUI(PluginAPI* pluginAPI, FeatureUISet *fea
     displaySettings();
     applySettings(true);
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
     // Get initial list of satellites
     on_updateSatData_clicked();

--- a/plugins/feature/simpleptt/simplepttgui.cpp
+++ b/plugins/feature/simpleptt/simplepttgui.cpp
@@ -227,6 +227,7 @@ SimplePTTGUI::SimplePTTGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Fea
 	applySettings(true);
     makeUIConnections();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 SimplePTTGUI::~SimplePTTGUI()

--- a/plugins/feature/startracker/startrackergui.cpp
+++ b/plugins/feature/startracker/startrackergui.cpp
@@ -408,6 +408,7 @@ StarTrackerGUI::StarTrackerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet,
     applySettings(true);
     disconnect(ui->azimuth, SIGNAL(valueChanged(double)), this, SLOT(on_azimuth_valueChanged(double)));
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
     // Populate subchart menu
     on_chartSelect_currentIndexChanged(0);

--- a/plugins/feature/vorlocalizer/vorlocalizergui.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizergui.cpp
@@ -1217,6 +1217,7 @@ VORLocalizerGUI::VORLocalizerGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISe
     // List already opened channels
     channelsRefresh();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 VORLocalizerGUI::~VORLocalizerGUI()

--- a/plugins/samplesink/aaroniartsaoutput/aaroniartsaoutputgui.cpp
+++ b/plugins/samplesink/aaroniartsaoutput/aaroniartsaoutputgui.cpp
@@ -99,6 +99,7 @@ AaroniaRTSAOutputGui::AaroniaRTSAOutputGui(DeviceUISet *deviceUISet, QWidget* pa
     m_forceSettings = true;
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 AaroniaRTSAOutputGui::~AaroniaRTSAOutputGui()

--- a/plugins/samplesink/audiooutput/audiooutputgui.cpp
+++ b/plugins/samplesink/audiooutput/audiooutputgui.cpp
@@ -63,6 +63,7 @@ AudioOutputGui::AudioOutputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
     makeUIConnections();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 AudioOutputGui::~AudioOutputGui()

--- a/plugins/samplesink/bladerf1output/bladerf1outputgui.cpp
+++ b/plugins/samplesink/bladerf1output/bladerf1outputgui.cpp
@@ -70,6 +70,7 @@ Bladerf1OutputGui::Bladerf1OutputGui(DeviceUISet *deviceUISet, QWidget* parent) 
 
 	displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
 	connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
 }

--- a/plugins/samplesink/bladerf2output/bladerf2outputgui.cpp
+++ b/plugins/samplesink/bladerf2output/bladerf2outputgui.cpp
@@ -84,6 +84,7 @@ BladeRF2OutputGui::BladeRF2OutputGui(DeviceUISet *deviceUISet, QWidget* parent) 
 
     displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     m_sampleSink->setMessageQueueToGUI(&m_inputMessageQueue);

--- a/plugins/samplesink/fileoutput/fileoutputgui.cpp
+++ b/plugins/samplesink/fileoutput/fileoutputgui.cpp
@@ -75,6 +75,7 @@ FileOutputGui::FileOutputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 	displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
     m_deviceSampleSink = (FileOutput*) m_deviceUISet->m_deviceAPI->getSampleSink();
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);

--- a/plugins/samplesink/hackrfoutput/hackrfoutputgui.cpp
+++ b/plugins/samplesink/hackrfoutput/hackrfoutputgui.cpp
@@ -68,6 +68,7 @@ HackRFOutputGui::HackRFOutputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 	displayBandwidths();
 	sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
 	connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
 }

--- a/plugins/samplesink/limesdroutput/limesdroutputgui.cpp
+++ b/plugins/samplesink/limesdroutput/limesdroutputgui.cpp
@@ -97,6 +97,7 @@ LimeSDROutputGUI::LimeSDROutputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 LimeSDROutputGUI::~LimeSDROutputGUI()

--- a/plugins/samplesink/localoutput/localoutputgui.cpp
+++ b/plugins/samplesink/localoutput/localoutputgui.cpp
@@ -83,6 +83,7 @@ LocalOutputGui::LocalOutputGui(DeviceUISet *deviceUISet, QWidget* parent) :
     m_forceSettings = true;
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 LocalOutputGui::~LocalOutputGui()

--- a/plugins/samplesink/plutosdroutput/plutosdroutputgui.cpp
+++ b/plugins/samplesink/plutosdroutput/plutosdroutputgui.cpp
@@ -84,6 +84,7 @@ PlutoSDROutputGUI::PlutoSDROutputGUI(DeviceUISet *deviceUISet, QWidget* parent) 
 
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 PlutoSDROutputGUI::~PlutoSDROutputGUI()

--- a/plugins/samplesink/remoteoutput/remoteoutputgui.cpp
+++ b/plugins/samplesink/remoteoutput/remoteoutputgui.cpp
@@ -94,6 +94,7 @@ RemoteOutputSinkGui::RemoteOutputSinkGui(DeviceUISet *deviceUISet, QWidget* pare
     sendSettings();
     makeUIConnections();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 RemoteOutputSinkGui::~RemoteOutputSinkGui()

--- a/plugins/samplesink/soapysdroutput/soapysdroutputgui.cpp
+++ b/plugins/samplesink/soapysdroutput/soapysdroutputgui.cpp
@@ -104,6 +104,7 @@ SoapySDROutputGui::SoapySDROutputGui(DeviceUISet *deviceUISet, QWidget* parent) 
 
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 SoapySDROutputGui::~SoapySDROutputGui()

--- a/plugins/samplesink/testsink/testsinkgui.cpp
+++ b/plugins/samplesink/testsink/testsinkgui.cpp
@@ -79,6 +79,7 @@ TestSinkGui::TestSinkGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 	displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(openDeviceSettingsDialog(const QPoint &)));

--- a/plugins/samplesink/usrpoutput/usrpoutputgui.cpp
+++ b/plugins/samplesink/usrpoutput/usrpoutputgui.cpp
@@ -90,6 +90,7 @@ USRPOutputGUI::USRPOutputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 USRPOutputGUI::~USRPOutputGUI()

--- a/plugins/samplesink/xtrxoutput/xtrxoutputgui.cpp
+++ b/plugins/samplesink/xtrxoutput/xtrxoutputgui.cpp
@@ -78,6 +78,7 @@ XTRXOutputGUI::XTRXOutputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 
     displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
 }

--- a/plugins/samplesource/aaroniartsainput/aaroniartsainputgui.cpp
+++ b/plugins/samplesource/aaroniartsainput/aaroniartsainputgui.cpp
@@ -78,6 +78,7 @@ AaroniaRTSAInputGui::AaroniaRTSAInputGui(DeviceUISet *deviceUISet, QWidget* pare
 
     displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
     connect(&m_updateTimer, SIGNAL(timeout()), this, SLOT(updateHardware()));
     connect(&m_statusTimer, SIGNAL(timeout()), this, SLOT(updateStatus()));

--- a/plugins/samplesource/airspy/airspygui.cpp
+++ b/plugins/samplesource/airspy/airspygui.cpp
@@ -69,6 +69,7 @@ AirspyGui::AirspyGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 AirspyGui::~AirspyGui()

--- a/plugins/samplesource/airspyhf/airspyhfgui.cpp
+++ b/plugins/samplesource/airspyhf/airspyhfgui.cpp
@@ -68,6 +68,7 @@ AirspyHFGui::AirspyHFGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 AirspyHFGui::~AirspyHFGui()

--- a/plugins/samplesource/androidsdrdriverinput/androidsdrdriverinputgui.cpp
+++ b/plugins/samplesource/androidsdrdriverinput/androidsdrdriverinputgui.cpp
@@ -82,6 +82,7 @@ AndroidSDRDriverInputGui::AndroidSDRDriverInputGui(DeviceUISet *deviceUISet, QWi
     m_forceSettings = true;
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 AndroidSDRDriverInputGui::~AndroidSDRDriverInputGui()

--- a/plugins/samplesource/audioinput/audioinputgui.cpp
+++ b/plugins/samplesource/audioinput/audioinputgui.cpp
@@ -60,6 +60,7 @@ AudioInputGui::AudioInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     m_sampleSource->setMessageQueueToGUI(&m_inputMessageQueue);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 AudioInputGui::~AudioInputGui()

--- a/plugins/samplesource/bladerf1input/bladerf1inputgui.cpp
+++ b/plugins/samplesource/bladerf1input/bladerf1inputgui.cpp
@@ -78,6 +78,7 @@ Bladerf1InputGui::Bladerf1InputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 	sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 Bladerf1InputGui::~Bladerf1InputGui()

--- a/plugins/samplesource/bladerf2input/bladerf2inputgui.cpp
+++ b/plugins/samplesource/bladerf2input/bladerf2inputgui.cpp
@@ -100,6 +100,7 @@ BladeRF2InputGui::BladeRF2InputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 BladeRF2InputGui::~BladeRF2InputGui()

--- a/plugins/samplesource/fcdpro/fcdprogui.cpp
+++ b/plugins/samplesource/fcdpro/fcdprogui.cpp
@@ -155,6 +155,7 @@ FCDProGui::FCDProGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 	displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
 	connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     m_sampleSource->setMessageQueueToGUI(&m_inputMessageQueue);

--- a/plugins/samplesource/fcdproplus/fcdproplusgui.cpp
+++ b/plugins/samplesource/fcdproplus/fcdproplusgui.cpp
@@ -73,6 +73,7 @@ FCDProPlusGui::FCDProPlusGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 	displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
 	connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     m_sampleSource->setMessageQueueToGUI(&m_inputMessageQueue);

--- a/plugins/samplesource/fileinput/fileinputgui.cpp
+++ b/plugins/samplesource/fileinput/fileinputgui.cpp
@@ -80,6 +80,7 @@ FileInputGUI::FileInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
     m_sampleSource->setMessageQueueToGUI(&m_inputMessageQueue);
 
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 FileInputGUI::~FileInputGUI()

--- a/plugins/samplesource/hackrfinput/hackrfinputgui.cpp
+++ b/plugins/samplesource/hackrfinput/hackrfinputgui.cpp
@@ -73,6 +73,7 @@ HackRFInputGui::HackRFInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 HackRFInputGui::~HackRFInputGui()

--- a/plugins/samplesource/kiwisdr/kiwisdrgui.cpp
+++ b/plugins/samplesource/kiwisdr/kiwisdrgui.cpp
@@ -76,6 +76,7 @@ KiwiSDRGui::KiwiSDRGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
     displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
     connect(&m_updateTimer, SIGNAL(timeout()), this, SLOT(updateHardware()));
     connect(&m_statusTimer, SIGNAL(timeout()), this, SLOT(updateStatus()));

--- a/plugins/samplesource/limesdrinput/limesdrinputgui.cpp
+++ b/plugins/samplesource/limesdrinput/limesdrinputgui.cpp
@@ -105,6 +105,7 @@ LimeSDRInputGUI::LimeSDRInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(openDeviceSettingsDialog(const QPoint &)));
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 LimeSDRInputGUI::~LimeSDRInputGUI()

--- a/plugins/samplesource/localinput/localinputgui.cpp
+++ b/plugins/samplesource/localinput/localinputgui.cpp
@@ -84,6 +84,7 @@ LocalInputGui::LocalInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 	displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
 	connect(&m_statusTimer, SIGNAL(timeout()), this, SLOT(updateStatus()));
 	m_statusTimer.start(500);

--- a/plugins/samplesource/perseus/perseusgui.cpp
+++ b/plugins/samplesource/perseus/perseusgui.cpp
@@ -66,6 +66,7 @@ PerseusGui::PerseusGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 PerseusGui::~PerseusGui()

--- a/plugins/samplesource/plutosdrinput/plutosdrinputgui.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinputgui.cpp
@@ -86,6 +86,7 @@ PlutoSDRInputGui::PlutoSDRInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     m_sampleSource->setMessageQueueToGUI(&m_inputMessageQueue);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 PlutoSDRInputGui::~PlutoSDRInputGui()

--- a/plugins/samplesource/remoteinput/remoteinputgui.cpp
+++ b/plugins/samplesource/remoteinput/remoteinputgui.cpp
@@ -101,6 +101,7 @@ RemoteInputGui::RemoteInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
     m_forceSettings = true;
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 RemoteInputGui::~RemoteInputGui()

--- a/plugins/samplesource/remotetcpinput/remotetcpinputgui.cpp
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputgui.cpp
@@ -90,6 +90,7 @@ RemoteTCPInputGui::RemoteTCPInputGui(DeviceUISet *deviceUISet, QWidget* parent) 
     sendSettings();
     makeUIConnections();
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 RemoteTCPInputGui::~RemoteTCPInputGui()

--- a/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
@@ -64,6 +64,7 @@ RTLSDRGui::RTLSDRGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
 	displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
 	m_gains = m_sampleSource->getGains();
 	displayGains();

--- a/plugins/samplesource/sdrplay/sdrplaygui.cpp
+++ b/plugins/samplesource/sdrplay/sdrplaygui.cpp
@@ -87,6 +87,7 @@ SDRPlayGui::SDRPlayGui(DeviceUISet *deviceUISet, QWidget* parent) :
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     m_sampleSource->setMessageQueueToGUI(&m_inputMessageQueue);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 SDRPlayGui::~SDRPlayGui()

--- a/plugins/samplesource/sdrplayv3/sdrplayv3gui.cpp
+++ b/plugins/samplesource/sdrplayv3/sdrplayv3gui.cpp
@@ -123,6 +123,7 @@ SDRPlayV3Gui::SDRPlayV3Gui(DeviceUISet *deviceUISet, QWidget* parent) :
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     m_sdrPlayV3Input->setMessageQueueToGUI(&m_inputMessageQueue);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 SDRPlayV3Gui::~SDRPlayV3Gui()

--- a/plugins/samplesource/sigmffileinput/sigmffileinputgui.cpp
+++ b/plugins/samplesource/sigmffileinput/sigmffileinputgui.cpp
@@ -82,6 +82,7 @@ SigMFFileInputGUI::SigMFFileInputGUI(DeviceUISet *deviceUISet, QWidget* parent) 
 	setAccelerationCombo();
 	displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
     updateStartStop();
 
 	ui->trackNavTimeSlider->setEnabled(false);

--- a/plugins/samplesource/soapysdrinput/soapysdrinputgui.cpp
+++ b/plugins/samplesource/soapysdrinput/soapysdrinputgui.cpp
@@ -106,6 +106,7 @@ SoapySDRInputGui::SoapySDRInputGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
     sendSettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 }
 
 SoapySDRInputGui::~SoapySDRInputGui()

--- a/plugins/samplesource/testsource/testsourcegui.cpp
+++ b/plugins/samplesource/testsource/testsourcegui.cpp
@@ -79,6 +79,7 @@ TestSourceGui::TestSourceGui(DeviceUISet *deviceUISet, QWidget* parent) :
 
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(openDeviceSettingsDialog(const QPoint &)));
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 TestSourceGui::~TestSourceGui()

--- a/plugins/samplesource/usrpinput/usrpinputgui.cpp
+++ b/plugins/samplesource/usrpinput/usrpinputgui.cpp
@@ -86,6 +86,7 @@ USRPInputGUI::USRPInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 
     displaySettings();
     makeUIConnections();
+    m_resizer.enableChildMouseTracking();
 
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     m_usrpInput->setMessageQueueToGUI(&m_inputMessageQueue);

--- a/plugins/samplesource/xtrxinput/xtrxinputgui.cpp
+++ b/plugins/samplesource/xtrxinput/xtrxinputgui.cpp
@@ -85,6 +85,7 @@ XTRXInputGUI::XTRXInputGUI(DeviceUISet *deviceUISet, QWidget* parent) :
 
     connect(&m_inputMessageQueue, SIGNAL(messageEnqueued()), this, SLOT(handleInputMessages()), Qt::QueuedConnection);
     DialPopup::addPopupsToChildDials(this);
+    m_resizer.enableChildMouseTracking();
 }
 
 XTRXInputGUI::~XTRXInputGUI()

--- a/sdrgui/channel/channelgui.cpp
+++ b/sdrgui/channel/channelgui.cpp
@@ -42,8 +42,8 @@ ChannelGUI::ChannelGUI(QWidget *parent) :
     m_deviceSetIndex(0),
     m_channelIndex(0),
     m_contextMenuType(ContextMenuNone),
-    m_drag(false),
     m_resizer(this),
+    m_drag(false),
     m_disableResize(false),
     m_mdi(nullptr)
 {
@@ -198,8 +198,6 @@ ChannelGUI::ChannelGUI(QWidget *parent) :
         this,
         &ChannelGUI::onWidgetRolled
     );
-
-    m_resizer.enableChildMouseTracking();
 }
 
 ChannelGUI::~ChannelGUI()

--- a/sdrgui/channel/channelgui.h
+++ b/sdrgui/channel/channelgui.h
@@ -107,6 +107,7 @@ protected:
     RollupContents* m_rollupContents;
     ContextMenuType m_contextMenuType;
     QString m_displayedName;
+    FramelessWindowResizer m_resizer;
 
 protected slots:
     void shrinkWindow();
@@ -138,7 +139,6 @@ private:
     bool m_drag;
     QPoint m_DragPosition;
     QMap<QWidget*, int> m_heightsMap;
-    FramelessWindowResizer m_resizer;
     bool m_disableResize;
     QMdiArea *m_mdi;                    // Saved pointer to MDI when in full screen mode
 

--- a/sdrgui/device/devicegui.cpp
+++ b/sdrgui/device/devicegui.cpp
@@ -39,9 +39,9 @@ DeviceGUI::DeviceGUI(QWidget *parent) :
     m_deviceType(DeviceRx),
     m_deviceSetIndex(0),
     m_contextMenuType(ContextMenuNone),
+    m_resizer(this),
     m_drag(false),
-    m_currentDeviceIndex(-1),
-    m_resizer(this)
+    m_currentDeviceIndex(-1)
 {
     qDebug("DeviceGUI::DeviceGUI: %p", parent);
     setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
@@ -205,8 +205,6 @@ DeviceGUI::DeviceGUI(QWidget *parent) :
         this,
         &DeviceGUI::addChannelEmitted
     );
-
-    m_resizer.enableChildMouseTracking();
 }
 
 DeviceGUI::~DeviceGUI()

--- a/sdrgui/device/devicegui.h
+++ b/sdrgui/device/devicegui.h
@@ -96,6 +96,7 @@ protected:
     QString m_helpURL;
     QWidget *m_contents;
     ContextMenuType m_contextMenuType;
+    FramelessWindowResizer m_resizer;
 
 protected slots:
     void shrinkWindow();
@@ -130,7 +131,6 @@ private:
     QPoint m_DragPosition;
     int m_currentDeviceIndex; //!< Index in device plugins registrations
     ChannelAddDialog m_channelAddDialog;
-    FramelessWindowResizer m_resizer;
 
 private slots:
     void activateSettingsDialog();

--- a/sdrgui/feature/featuregui.cpp
+++ b/sdrgui/feature/featuregui.cpp
@@ -36,8 +36,8 @@ FeatureGUI::FeatureGUI(QWidget *parent) :
     QMdiSubWindow(parent),
     m_featureIndex(0),
     m_contextMenuType(ContextMenuNone),
-    m_drag(false),
     m_resizer(this),
+    m_drag(false),
     m_disableResize(false),
     m_mdi(nullptr)
 {
@@ -153,8 +153,6 @@ FeatureGUI::FeatureGUI(QWidget *parent) :
         this,
         &FeatureGUI::onWidgetRolled
     );
-
-    m_resizer.enableChildMouseTracking();
 }
 
 FeatureGUI::~FeatureGUI()

--- a/sdrgui/feature/featuregui.h
+++ b/sdrgui/feature/featuregui.h
@@ -82,6 +82,7 @@ protected:
     RollupContents m_rollupContents;
     ContextMenuType m_contextMenuType;
     QString m_displayedName;
+    FramelessWindowResizer m_resizer;
 
 protected slots:
     void shrinkWindow();
@@ -107,7 +108,6 @@ private:
     bool m_drag;
     QPoint m_DragPosition;
     QMap<QWidget*, int> m_heightsMap;
-    FramelessWindowResizer m_resizer;
     bool m_disableResize;
     QMdiArea *m_mdi;                    // Saved pointer to MDI when in full screen mode
 

--- a/sdrgui/gui/framelesswindowresizer.cpp
+++ b/sdrgui/gui/framelesswindowresizer.cpp
@@ -17,6 +17,7 @@
 
 #include <QGuiApplication>
 #include <QLayout>
+#include <QTableWidget>
 
 #include "framelesswindowresizer.h"
 
@@ -39,6 +40,14 @@ void FramelessWindowResizer::enableChildMouseTracking()
     QList<QWidget *> widgets = m_widget->findChildren<QWidget *>();
     for (auto widget : widgets) {
         widget->setMouseTracking(true);
+    }
+    // QTableWidgets don't send us mouseMoveEvents for some unknown reason
+    // so install an event filter on their viewport
+    QList<QTableWidget *> tables = m_widget->findChildren<QTableWidget *>();
+    for (auto table : tables)
+    {
+        table->viewport()->setMouseTracking(true);
+        table->viewport()->installEventFilter(this);
     }
 }
 
@@ -139,6 +148,16 @@ void FramelessWindowResizer::mouseReleaseEvent(QMouseEvent* event)
 void FramelessWindowResizer::leaveEvent(QEvent*)
 {
     clearCursor();
+}
+
+bool FramelessWindowResizer::eventFilter(QObject *obj, QEvent *event)
+{
+    if (event->type() == QEvent::MouseMove)
+    {
+        // Mouse moving over child table widget
+        clearCursor();
+    }
+    return QObject::eventFilter(obj, event);
 }
 
 void FramelessWindowResizer::mouseMoveEvent(QMouseEvent* event)

--- a/sdrgui/gui/framelesswindowresizer.h
+++ b/sdrgui/gui/framelesswindowresizer.h
@@ -30,8 +30,9 @@
 // and leaveEvent events to this class
 // Child widgets should have mouse tracking enabled, so cursor can be controlled properly
 // This can be achieved by calling enableChildMouseTracking
-class SDRGUI_API FramelessWindowResizer
+class SDRGUI_API FramelessWindowResizer : public QObject
 {
+    Q_OBJECT
 private:
     QWidget *m_widget;        // Widget to be resized
     bool m_vResizing;         // Whether we are resizing vertically
@@ -60,6 +61,7 @@ public:
     const int m_gripSize = 2;   // Size in pixels of the border of the window that can be clicked in to resize it
 
 protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
     bool mouseOnTopBorder(QPoint pos) const;
     bool mouseOnBottomBorder(QPoint pos) const;
     bool mouseOnLeftBorder(QPoint pos) const;
@@ -67,7 +69,6 @@ protected:
     bool mouseOnBorder(QPoint pos) const;
     void setCursor(const QCursor &cursor);
     void clearCursor();
-
 };
 
 #endif // SDRGUI_FRAMELESSWINDOWRESIZER_H_


### PR DESCRIPTION
Occasionally, when the cursor is moved into a window, it will stay as the resize cursor, rather than returning to the pointer, when not over the border.

This PR should fix that. Fix is to enable mouse tracking after all widgets have been created, not just those in ChannelGUI/FeatureGUI/DeviceGUI class. QTableWdigets also need special handling.
