### PR TITLE
Reverse byte ordering of CRC in packet mode in M17 modem

### DIFF
--- a/modemm17/M17Modulator.h
+++ b/modemm17/M17Modulator.h
@@ -309,8 +309,8 @@ public:
         if (last_packet)
         {
             packet_assembly[25] = 0x80 | ((packet_size+2)<<2); // sent packet size includes CRC
-            packet_assembly[packet_size]   = crc_.get_bytes()[1];
-            packet_assembly[packet_size+1] = crc_.get_bytes()[0];
+            packet_assembly[packet_size]   = crc_.get_bytes()[0];
+            packet_assembly[packet_size+1] = crc_.get_bytes()[1];
         }
         else
         {

--- a/plugins/channelrx/demodm17/m17demodprocessor.cpp
+++ b/plugins/channelrx/demodm17/m17demodprocessor.cpp
@@ -328,7 +328,7 @@ bool M17DemodProcessor::decode_packet(modemm17::M17FrameDecoder::packet_buffer_t
             crc16(*it);
         }
 
-        uint16_t calcChecksum = crc16.get_bytes()[0] + (crc16.get_bytes()[1]<<8);
+        uint16_t calcChecksum = crc16.get_bytes()[1] + (crc16.get_bytes()[0]<<8);
         uint16_t xmitChecksum = m_currentPacket.back() + (m_currentPacket.end()[-2]<<8);
 
         if (calcChecksum == xmitChecksum) // (checksum == 0x0f47)


### PR DESCRIPTION
For #1826, reverse byte ordering of CRC in packet mode in M17 modem