### PR TITLE
Fix M17 packet type decoding.

### DIFF
--- a/plugins/channelrx/demodm17/m17demod.cpp
+++ b/plugins/channelrx/demodm17/m17demod.cpp
@@ -57,7 +57,8 @@ M17Demod::M17Demod(DeviceAPI *deviceAPI) :
         m_thread(nullptr),
         m_basebandSink(nullptr),
         m_running(false),
-        m_basebandSampleRate(0)
+        m_basebandSampleRate(0),
+        m_scopeXYSink(nullptr)
 {
     qDebug("M17Demod::M17Demod");
 	setObjectName(m_channelId);
@@ -141,6 +142,7 @@ void M17Demod::start()
     if (m_basebandSampleRate != 0) {
         m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
     }
+    m_basebandSink->setScopeXYSink(m_scopeXYSink);
 
     m_basebandSink->reset();
     m_thread->start();
@@ -750,4 +752,12 @@ void M17Demod::handleIndexInDeviceSetChanged(int index)
         .arg(index);
     m_basebandSink->setFifoLabel(fifoLabel);
     m_basebandSink->setAudioFifoLabel(fifoLabel);
+}
+
+void M17Demod::setScopeXYSink(BasebandSampleSink* sampleSink)
+{
+    m_scopeXYSink = sampleSink;
+    if (m_running) {
+        m_basebandSink->setScopeXYSink(sampleSink);
+    }
 }

--- a/plugins/channelrx/demodm17/m17demod.h
+++ b/plugins/channelrx/demodm17/m17demod.h
@@ -209,7 +209,7 @@ public:
             SWGSDRangel::SWGChannelSettings& response);
 
     uint32_t getNumberOfDeviceStreams() const;
-	void setScopeXYSink(BasebandSampleSink* sampleSink) { if (m_running) { m_basebandSink->setScopeXYSink(sampleSink); } }
+	void setScopeXYSink(BasebandSampleSink* sampleSink);
 	void configureMyPosition(float myLatitude, float myLongitude) { if (m_running) { m_basebandSink->configureMyPosition(myLatitude, myLongitude); } }
 	double getMagSq() { return m_running ? m_basebandSink->getMagSq() : 0.0; }
 	bool getSquelchOpen() const { return m_running && m_basebandSink->getSquelchOpen(); }
@@ -281,7 +281,7 @@ private:
     bool m_running;
 	M17DemodSettings m_settings;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
-
+    BasebandSampleSink *m_scopeXYSink;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;
 

--- a/plugins/channelrx/demodm17/m17demodgui.cpp
+++ b/plugins/channelrx/demodm17/m17demodgui.cpp
@@ -520,6 +520,7 @@ M17DemodGUI::M17DemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseban
 
 M17DemodGUI::~M17DemodGUI()
 {
+    m_m17Demod->setScopeXYSink(nullptr);
 	delete m_scopeVisXY;
     ui->screenTV->setParent(nullptr); // Prefer memory leak to core dump... ~TVScreen() is buggy
 	delete ui;

--- a/plugins/channelrx/demodm17/m17demodgui.ui
+++ b/plugins/channelrx/demodm17/m17demodgui.ui
@@ -921,7 +921,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>Baud rate: 2.4k: NXDN48, dPMR 4.8k: DMR, D-Star, YSF, NXDN96</string>
+             <string>Baud rate</string>
             </property>
             <item>
              <property name="text">

--- a/plugins/channelrx/demodm17/m17demodprocessor.cpp
+++ b/plugins/channelrx/demodm17/m17demodprocessor.cpp
@@ -195,9 +195,9 @@ bool M17DemodProcessor::decode_lsf(modemm17::M17FrameDecoder::lsf_buffer_t const
     m_currentPacket.clear();
     m_packetFrameCounter = 0;
 
-    if (!lsf[111]) // LSF type bit 0
+    if (!(lsf[13] & 1)) // LSF type bit 0
     {
-        uint8_t packet_type = (lsf[109] << 1) | lsf[110];
+        uint8_t packet_type = (lsf[13] >> 1) & 0x3;
 
         switch (packet_type)
         {
@@ -254,7 +254,7 @@ void M17DemodProcessor::decode_type(uint16_t type)
                 m_typeInfo += "DAT";
                 break;
             case 2:
-                m_typeInfo += "UNK";
+                m_typeInfo += "ENC"; // Encapsulated passes LSF up stack along with data
                 break;
             case 3:
                 m_typeInfo += "UNK";

--- a/plugins/channelrx/demodm17/m17demodsettings.cpp
+++ b/plugins/channelrx/demodm17/m17demodsettings.cpp
@@ -34,7 +34,7 @@ void M17DemodSettings::resetToDefaults()
 {
     m_inputFrequencyOffset = 0;
     m_rfBandwidth = 12500.0;
-    m_fmDeviation = 3500.0;
+    m_fmDeviation = 2400.0;
     m_volume = 2.0;
     m_baudRate = 4800;
     m_squelchGate = 5; // 10s of ms at 48000 Hz sample rate. Corresponds to 2400 for AGC attack

--- a/plugins/channelrx/demodm17/m17demodsink.cpp
+++ b/plugins/channelrx/demodm17/m17demodsink.cpp
@@ -334,7 +334,7 @@ void M17DemodSink::applySettings(const M17DemodSettings& settings, const QList<Q
     }
 
     if (settingsKeys.contains("fmDeviation") || force) {
-        m_phaseDiscri.setFMScaling(48000.0f / (2.0f*settings.m_fmDeviation));
+        m_phaseDiscri.setFMScaling(48000.0f / (2.0f*M_PI*settings.m_fmDeviation));
     }
 
     if (settingsKeys.contains("squelchGate") || force)

--- a/plugins/channeltx/modm17/m17modgui.cpp
+++ b/plugins/channeltx/modm17/m17modgui.cpp
@@ -164,7 +164,7 @@ void M17ModGUI::on_rfBW_valueChanged(int value)
 void M17ModGUI::on_fmDev_valueChanged(int value)
 {
 	ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(value / 10.0, 0, 'f', 1));
-	m_settings.m_fmDeviation = value * 200.0;
+	m_settings.m_fmDeviation = value * 100.0;
 	applySettings(QList<QString>{"fmDeviation"});
 }
 
@@ -570,8 +570,8 @@ void M17ModGUI::displaySettings()
     ui->rfBWText->setText(QString("%1k").arg(m_settings.m_rfBandwidth / 1000.0, 0, 'f', 1));
     ui->rfBW->setValue(m_settings.m_rfBandwidth / 100.0);
 
-    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 2000.0, 0, 'f', 1));
-    ui->fmDev->setValue(m_settings.m_fmDeviation / 200.0);
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
+    ui->fmDev->setValue(m_settings.m_fmDeviation / 100.0);
 
     ui->volumeText->setText(QString("%1").arg(m_settings.m_volumeFactor, 0, 'f', 1));
     ui->volume->setValue(m_settings.m_volumeFactor * 10.0);

--- a/plugins/channeltx/modm17/m17modsettings.cpp
+++ b/plugins/channeltx/modm17/m17modsettings.cpp
@@ -35,7 +35,7 @@ void M17ModSettings::resetToDefaults()
 {
     m_inputFrequencyOffset = 0;
     m_rfBandwidth = 16000.0f;
-    m_fmDeviation = 10000.0f; //!< full deviation
+    m_fmDeviation = 2400.0; //!< peak deviation
     m_toneFrequency = 1000.0f;
     m_volumeFactor = 1.0f;
     m_channelMute = false;
@@ -146,7 +146,7 @@ bool M17ModSettings::deserialize(const QByteArray& data)
         d.readS32(1, &tmp, 0);
         m_inputFrequencyOffset = tmp;
         d.readReal(2, &m_rfBandwidth, 12500.0);
-        d.readReal(4, &m_fmDeviation, 10000.0);
+        d.readReal(4, &m_fmDeviation, 2400.0);
         d.readU32(5, &m_rgbColor);
         d.readReal(6, &m_toneFrequency, 1000.0);
         d.readReal(7, &m_volumeFactor, 1.0);

--- a/plugins/channeltx/modm17/m17modsource.cpp
+++ b/plugins/channeltx/modm17/m17modsource.cpp
@@ -177,7 +177,7 @@ void M17ModSource::modulateSample()
         calculateLevel(t);
         t1 = m_lowpass.filter(t) * 1.5f;
 
-        m_modPhasor += (m_settings.m_fmDeviation / (float) m_audioSampleRate) * t1;
+        m_modPhasor += ((2.0f * M_PI * m_settings.m_fmDeviation) / (float) m_audioSampleRate) * t1;
 
         // limit phasor range to ]-pi,pi]
         if (m_modPhasor > M_PI) {


### PR DESCRIPTION
Fix M17 packet decoding - bit indices were being used in to a byte array, as mentioned in #1892.

Also remove copy+paste error in GUI tooltip.
