### PR TITLE
Update layout of ADS-B Display Settings Dialog to support small screens

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.ui
+++ b/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>417</width>
-    <height>742</height>
+    <height>467</height>
    </rect>
   </property>
   <property name="font">
@@ -20,565 +20,588 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="9" column="0">
-       <widget class="QLabel" name="displayNavAids">
-        <property name="text">
-         <string>Display NAVAIDs</string>
-        </property>
-       </widget>
-      </item>
-      <item row="21" column="1">
-       <widget class="QSpinBox" name="airfieldElevation">
-        <property name="toolTip">
-         <string>Barometric altitude reported by aircraft when on airfield surface</string>
-        </property>
-        <property name="minimum">
-         <number>-10000</number>
-        </property>
-        <property name="maximum">
-         <number>30000</number>
-        </property>
-        <property name="singleStep">
-         <number>10</number>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="airportRangeLabel">
-        <property name="text">
-         <string>Airport display distance (km)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="heliportsLabel">
-        <property name="text">
-         <string>Display heliports</string>
-        </property>
-       </widget>
-      </item>
-      <item row="12" column="1">
-       <widget class="QSpinBox" name="timeout">
-        <property name="toolTip">
-         <string>How long in seconds after not receiving any frames will an aircraft be removed from the table and map</string>
-        </property>
-        <property name="maximum">
-         <number>1000000</number>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QCheckBox" name="heliports">
-        <property name="toolTip">
-         <string>When checked, heliports are displayed on the map</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="22" column="1">
-       <widget class="QSpinBox" name="transitionAltitude">
-        <property name="toolTip">
-         <string>Transition altitude in feet</string>
-        </property>
-        <property name="minimum">
-         <number>2500</number>
-        </property>
-        <property name="maximum">
-         <number>20000</number>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QComboBox" name="airportSize">
-        <property name="toolTip">
-         <string>Sets the minimum airport size that will be displayed on the map</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Small</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Medium</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Large</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="units">
-        <property name="toolTip">
-         <string>The units to use for altitude, speed and climb rate</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>ft, kn, ft/min</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>m, kph, m/s</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="mapTypeLabel">
-        <property name="text">
-         <string>Map type</string>
-        </property>
-       </widget>
-      </item>
-      <item row="16" column="0">
-       <widget class="QLabel" name="autoResizeTableColumnsLabel">
-        <property name="text">
-         <string>Resize columns after adding aircraft</string>
-        </property>
-       </widget>
-      </item>
-      <item row="17" column="1">
-       <widget class="QCheckBox" name="displayStats">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Display demodulator statistics</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="18" column="0">
-       <widget class="QLabel" name="verboseModelMatchingLabel">
-        <property name="text">
-         <string>Log 3D model matching information</string>
-        </property>
-       </widget>
-      </item>
-      <item row="13" column="1">
-       <widget class="QPushButton" name="font">
-        <property name="toolTip">
-         <string>Select a font for the table</string>
-        </property>
-        <property name="text">
-         <string>Select...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="20" column="0">
-       <widget class="QLabel" name="checkWXAPIKeyLabel">
-        <property name="text">
-         <string>CheckWX API key</string>
-        </property>
-       </widget>
-      </item>
-      <item row="11" column="0">
-       <widget class="QLabel" name="photosLabel">
-        <property name="text">
-         <string>Display aircraft photos</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="airspacesLabel">
-        <property name="text">
-         <string>Airspaces to display</string>
-        </property>
-       </widget>
-      </item>
-      <item row="18" column="1">
-       <widget class="QCheckBox" name="verboseModelMatching">
-        <property name="toolTip">
-         <string>Log information about how aircraft are matched to 3D models</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="22" column="0">
-       <widget class="QLabel" name="transitionAltitudeLabel">
-        <property name="text">
-         <string>Transition altitude (ft)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1">
-       <widget class="QSpinBox" name="airspaceRange">
-        <property name="toolTip">
-         <string>Displays airspace within the specified distance in kilometres from My Position</string>
-        </property>
-        <property name="maximum">
-         <number>20000</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="mapType">
-        <property name="toolTip">
-         <string>Type of map to display</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Aviation</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Aviation (Dark)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Street</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Satellite</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="20" column="1">
-       <widget class="QLineEdit" name="checkWXAPIKey">
-        <property name="toolTip">
-         <string>checkwxapi.com API key for accessing airport weather (METARs)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="19" column="1">
-       <widget class="QLineEdit" name="aviationstackAPIKey">
-        <property name="toolTip">
-         <string>aviationstack.com API key for accessing flight information</string>
-        </property>
-       </widget>
-      </item>
-      <item row="19" column="0">
-       <widget class="QLabel" name="aviationstackAPIKeyLabel">
-        <property name="text">
-         <string>avaitionstack API key</string>
-        </property>
-       </widget>
-      </item>
-      <item row="11" column="1">
-       <widget class="QCheckBox" name="photos">
-        <property name="toolTip">
-         <string>Download and display photos of highlighted aircraft</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="mapProviderLabel">
-        <property name="text">
-         <string>Map provider</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QSpinBox" name="aircraftMinZoom">
-        <property name="toolTip">
-         <string>When map zoom (0 min zoom - 15 max zoom) is higher than this value, aircraft icon size will be scaled</string>
-        </property>
-        <property name="maximum">
-         <number>15</number>
-        </property>
-       </widget>
-      </item>
-      <item row="13" column="0">
-       <widget class="QLabel" name="fontLabel">
-        <property name="text">
-         <string>Table font</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="QListWidget" name="airspaces">
-        <property name="toolTip">
-         <string>Airspace categories to display</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>A</string>
-         </property>
-         <property name="toolTip">
-          <string>IFR only</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>B</string>
-         </property>
-         <property name="toolTip">
-          <string>IFR and VFR with ATC clearance</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>C</string>
-         </property>
-         <property name="toolTip">
-          <string>IFR and VFR with ATC clearance</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>D</string>
-         </property>
-         <property name="toolTip">
-          <string>IFR and VFR with ATC clearance</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>E</string>
-         </property>
-         <property name="toolTip">
-          <string>IFR with clearance and VFR</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>G</string>
-         </property>
-         <property name="toolTip">
-          <string>Uncontrolled</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>FIR</string>
-         </property>
-         <property name="toolTip">
-          <string>Flight Information Region</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>CTR</string>
-         </property>
-         <property name="toolTip">
-          <string>Controlled Traffic Region</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>TMZ</string>
-         </property>
-         <property name="toolTip">
-          <string>Transponder Mandatory Zone</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>RMZ</string>
-         </property>
-         <property name="toolTip">
-          <string>Radio Mandatory Zone</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>RESTRICTED</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>GLIDING</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>DANGER</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>PROHIBITED</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>WAVE</string>
-         </property>
-         <property name="checkState">
-          <enum>Unchecked</enum>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="airspaceRangeLabel">
-        <property name="text">
-         <string>Airspace display distance (km)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="unitsLabel">
-        <property name="text">
-         <string>Units</string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="1">
-       <widget class="QCheckBox" name="navAids">
-        <property name="toolTip">
-         <string>Display NAVAIDs such as VORs and NDBs</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="airportSizeLabel">
-        <property name="text">
-         <string>Display airports with size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QSpinBox" name="airportRange">
-        <property name="toolTip">
-         <string>Displays airports within the specified distance in kilometres from My Position</string>
-        </property>
-        <property name="maximum">
-         <number>20000</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="mapProvider">
-        <property name="toolTip">
-         <string>Mapping service</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>osm</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>mapboxgl</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="16" column="1">
-       <widget class="QCheckBox" name="autoResizeTableColumns">
-        <property name="toolTip">
-         <string>Resize the columns in the table after an aircraft is added to it</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="12" column="0">
-       <widget class="QLabel" name="timeoutLabel">
-        <property name="text">
-         <string>Aircraft timeout (s)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="21" column="0">
-       <widget class="QLabel" name="airfieldElevationLabel">
-        <property name="text">
-         <string>Airfield barometric altitude (ft)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="17" column="0">
-       <widget class="QLabel" name="displayStatsLabel">
-        <property name="text">
-         <string>Display demodulator statistics</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="aircraftMinZoomLabel">
-        <property name="text">
-         <string>Zoom level for aircraft scaling</string>
-        </property>
-       </widget>
-      </item>
-      <item row="10" column="0">
-       <widget class="QLabel" name="atcCallsignsLabel">
-        <property name="text">
-         <string>Use ATC callsigns on map</string>
-        </property>
-       </widget>
-      </item>
-      <item row="10" column="1">
-       <widget class="QCheckBox" name="atcCallsigns">
-        <property name="toolTip">
-         <string>Use ATC callsigns (SPEEDBIRD) rather than ICAO (BAW) for aircraft labels on map</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
+    <widget class="QTabWidget" name="tabs">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="generalTab">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <layout class="QFormLayout" name="generalLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="unitsLabel">
+           <property name="text">
+            <string>Units</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="units">
+           <property name="toolTip">
+            <string>The units to use for altitude, speed and climb rate</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>ft, kn, ft/min</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>m, kph, m/s</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="photosLabel">
+           <property name="text">
+            <string>Display aircraft photos</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="photos">
+           <property name="toolTip">
+            <string>Download and display photos of highlighted aircraft</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="timeoutLabel">
+           <property name="text">
+            <string>Aircraft timeout (s)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="timeout">
+           <property name="toolTip">
+            <string>How long in seconds after not receiving any frames will an aircraft be removed from the table and map</string>
+           </property>
+           <property name="maximum">
+            <number>1000000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="fontLabel">
+           <property name="text">
+            <string>Table font</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QPushButton" name="font">
+           <property name="toolTip">
+            <string>Select a font for the table</string>
+           </property>
+           <property name="text">
+            <string>Select...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="autoResizeTableColumnsLabel">
+           <property name="text">
+            <string>Resize columns after adding aircraft</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QCheckBox" name="autoResizeTableColumns">
+           <property name="toolTip">
+            <string>Resize the columns in the table after an aircraft is added to it</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="displayStatsLabel">
+           <property name="text">
+            <string>Display demodulator statistics</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QCheckBox" name="displayStats">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Display demodulator statistics</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="verboseModelMatchingLabel">
+           <property name="text">
+            <string>Log 3D model matching information</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QCheckBox" name="verboseModelMatching">
+           <property name="toolTip">
+            <string>Log information about how aircraft are matched to 3D models</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="aviationstackAPIKeyLabel">
+           <property name="text">
+            <string>avaitionstack API key</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QLineEdit" name="aviationstackAPIKey">
+           <property name="toolTip">
+            <string>aviationstack.com API key for accessing flight information</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="checkWXAPIKeyLabel">
+           <property name="text">
+            <string>CheckWX API key</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="QLineEdit" name="checkWXAPIKey">
+           <property name="toolTip">
+            <string>checkwxapi.com API key for accessing airport weather (METARs)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="airfieldElevationLabel">
+           <property name="text">
+            <string>Airfield barometric altitude (ft)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="1">
+          <widget class="QSpinBox" name="airfieldElevation">
+           <property name="toolTip">
+            <string>Barometric altitude reported by aircraft when on airfield surface</string>
+           </property>
+           <property name="minimum">
+            <number>-10000</number>
+           </property>
+           <property name="maximum">
+            <number>30000</number>
+           </property>
+           <property name="singleStep">
+            <number>10</number>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="0">
+          <widget class="QLabel" name="transitionAltitudeLabel">
+           <property name="text">
+            <string>Transition altitude (ft)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="1">
+          <widget class="QSpinBox" name="transitionAltitude">
+           <property name="toolTip">
+            <string>Transition altitude in feet</string>
+           </property>
+           <property name="minimum">
+            <number>2500</number>
+           </property>
+           <property name="maximum">
+            <number>20000</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="mapTab">
+      <attribute name="title">
+       <string>Map</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QFormLayout" name="mapLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="mapProviderLabel">
+           <property name="text">
+            <string>Map provider</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="mapProvider">
+           <property name="toolTip">
+            <string>Mapping service</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>osm</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>mapboxgl</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="mapTypeLabel">
+           <property name="text">
+            <string>Map type</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QComboBox" name="mapType">
+           <property name="toolTip">
+            <string>Type of map to display</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>Aviation</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Aviation (Dark)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Street</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Satellite</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="aircraftMinZoomLabel">
+           <property name="text">
+            <string>Zoom level for aircraft scaling</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="aircraftMinZoom">
+           <property name="toolTip">
+            <string>When map zoom (0 min zoom - 15 max zoom) is higher than this value, aircraft icon size will be scaled</string>
+           </property>
+           <property name="maximum">
+            <number>15</number>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="airportSizeLabel">
+           <property name="text">
+            <string>Display airports with size</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QComboBox" name="airportSize">
+           <property name="toolTip">
+            <string>Sets the minimum airport size that will be displayed on the map</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>Small</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Medium</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Large</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="heliportsLabel">
+           <property name="text">
+            <string>Display heliports</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QCheckBox" name="heliports">
+           <property name="toolTip">
+            <string>When checked, heliports are displayed on the map</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="airportRangeLabel">
+           <property name="text">
+            <string>Airport display distance (km)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QSpinBox" name="airportRange">
+           <property name="toolTip">
+            <string>Displays airports within the specified distance in kilometres from My Position</string>
+           </property>
+           <property name="maximum">
+            <number>20000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="airspacesLabel">
+           <property name="text">
+            <string>Airspaces to display</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QListWidget" name="airspaces">
+           <property name="toolTip">
+            <string>Airspace categories to display</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>A</string>
+            </property>
+            <property name="toolTip">
+             <string>IFR only</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>B</string>
+            </property>
+            <property name="toolTip">
+             <string>IFR and VFR with ATC clearance</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>C</string>
+            </property>
+            <property name="toolTip">
+             <string>IFR and VFR with ATC clearance</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>D</string>
+            </property>
+            <property name="toolTip">
+             <string>IFR and VFR with ATC clearance</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>E</string>
+            </property>
+            <property name="toolTip">
+             <string>IFR with clearance and VFR</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>G</string>
+            </property>
+            <property name="toolTip">
+             <string>Uncontrolled</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>FIR</string>
+            </property>
+            <property name="toolTip">
+             <string>Flight Information Region</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>CTR</string>
+            </property>
+            <property name="toolTip">
+             <string>Controlled Traffic Region</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>TMZ</string>
+            </property>
+            <property name="toolTip">
+             <string>Transponder Mandatory Zone</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>RMZ</string>
+            </property>
+            <property name="toolTip">
+             <string>Radio Mandatory Zone</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>RESTRICTED</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>GLIDING</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>DANGER</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>PROHIBITED</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>WAVE</string>
+            </property>
+            <property name="checkState">
+             <enum>Unchecked</enum>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="airspaceRangeLabel">
+           <property name="text">
+            <string>Airspace display distance (km)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QSpinBox" name="airspaceRange">
+           <property name="toolTip">
+            <string>Displays airspace within the specified distance in kilometres from My Position</string>
+           </property>
+           <property name="maximum">
+            <number>20000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="displayNavAids">
+           <property name="text">
+            <string>Display NAVAIDs</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="QCheckBox" name="navAids">
+           <property name="toolTip">
+            <string>Display NAVAIDs such as VORs and NDBs</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="1">
+          <widget class="QCheckBox" name="atcCallsigns">
+           <property name="toolTip">
+            <string>Use ATC callsigns (SPEEDBIRD) rather than ICAO (BAW) for aircraft labels on map</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="atcCallsignsLabel">
+           <property name="text">
+            <string>Use ATC callsigns on map</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
@@ -593,26 +616,6 @@
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>units</tabstop>
-  <tabstop>mapProvider</tabstop>
-  <tabstop>mapType</tabstop>
-  <tabstop>airportSize</tabstop>
-  <tabstop>heliports</tabstop>
-  <tabstop>airportRange</tabstop>
-  <tabstop>airspaces</tabstop>
-  <tabstop>airspaceRange</tabstop>
-  <tabstop>navAids</tabstop>
-  <tabstop>photos</tabstop>
-  <tabstop>timeout</tabstop>
-  <tabstop>font</tabstop>
-  <tabstop>autoResizeTableColumns</tabstop>
-  <tabstop>displayStats</tabstop>
-  <tabstop>verboseModelMatching</tabstop>
-  <tabstop>aviationstackAPIKey</tabstop>
-  <tabstop>checkWXAPIKey</tabstop>
-  <tabstop>airfieldElevation</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Fix #1896 - Split widgets in to 2 tabs, so it can fit on small Android screens