### PR TITLE
Attempt to fix scope trigger

### DIFF
--- a/sdrbase/dsp/scopevis.cpp
+++ b/sdrbase/dsp/scopevis.cpp
@@ -609,7 +609,7 @@ void ScopeVis::processTrace(const std::vector<ComplexVector::const_iterator>& vc
             }
 
             uint32_t triggerStreamIndex = triggerCondition->m_triggerData.m_streamIndex;
-            const Complex& s = *vbegin[triggerStreamIndex];
+            const Complex& s = vbegin[triggerStreamIndex][processed];
 
             if (m_triggerComparator.triggered(s, *triggerCondition)) // matched the current trigger
             {


### PR DESCRIPTION
This is a possible fix for #1901, but please review

Currently, the code in processTrace only ever appears to look at the first sample in a block of data

    const Complex& s = *vbegin[triggerStreamIndex];

I'm guessing it needs to be indexed using processed (as that variable isn't read anywhere else in the loop)

    const Complex& s = vbegin[triggerStreamIndex][processed];

And it seems to trigger more as I'd expect.
