### PR TITLE
Radiosonde CSV header fix

### DIFF
--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -133,16 +133,3 @@ jobs:
         run: |
           cd build
           make -j3
-      - name: Stop XProtectBehaviorService
-        run: |
-          echo "killing XProject as it can interfere with hdiutil"; sudo pkill -9 XProtect >/dev/null || true;
-          echo "waiting..."; while pgrep XProtect; do sleep 3; done;
-      - name: Build DMG
-        run: |
-          cd build
-          make package -j3
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.get_filename.outputs.filename }}.dmg
-          path: ${{ github.workspace }}/build/${{ steps.get_filename.outputs.filename }}.dmg

--- a/plugins/channelrx/demodradiosonde/radiosondedemod.cpp
+++ b/plugins/channelrx/demodradiosonde/radiosondedemod.cpp
@@ -383,7 +383,7 @@ void RadiosondeDemod::applySettings(const RadiosondeDemodSettings& settings, boo
                 if (newFile)
                 {
                     // Write header
-                    m_logStream << "Date,Time,Data,Serial,Frame,Lat,Lon,Alt (m),Speed (m/s),V/R (m/s),Heading,P (hPa),T (C), U (%)\n";
+                    m_logStream << "Date,Time,Data,Serial,Frame,Lat,Lon,Alt (m),Speed (m/s),V/R (m/s),Heading,P (hPa),T (C),U (%)\n";
                 }
             }
             else

--- a/plugins/samplesource/sdrplayv3/CMakeLists.txt
+++ b/plugins/samplesource/sdrplayv3/CMakeLists.txt
@@ -56,11 +56,11 @@ target_link_libraries(${TARGET_NAME}
         ${SDRPLAY_LIBRARIES}
 )
 
-# Library name is wrong in 3.12 release
+#  /usr/local/lib doesn't seem to be searched by default
 if (APPLE AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL arm64))
     add_custom_command(TARGET ${TARGET_NAME}
         POST_BUILD COMMAND
-        ${CMAKE_INSTALL_NAME_TOOL} -change libsdrplay_api_arm64.so.3.12 /Library/SDRplayAPI/3.12.0/lib/libsdrplay_api.so.3.12.0  $<TARGET_FILE:${TARGET_NAME}>)
+        ${CMAKE_INSTALL_NAME_TOOL} -change libsdrplay_api.so.3.12 /usr/local/lib/libsdrplay_api.so.3.12  $<TARGET_FILE:${TARGET_NAME}>)
 endif()
 
 install(TARGETS ${TARGET_NAME} DESTINATION ${INSTALL_FOLDER})


### PR DESCRIPTION
Fix radiosonde CSV header - for #1915.

Also updates SDRplay library path on Mac, to support API 3.12.1.