### PR TITLE
File Input: Start file browser in directory of last file selected.

### DIFF
--- a/plugins/samplesource/fileinput/fileinputgui.cpp
+++ b/plugins/samplesource/fileinput/fileinputgui.cpp
@@ -319,7 +319,7 @@ void FileInputGUI::on_showFileDialog_clicked(bool checked)
 {
     (void) checked;
 	QString fileName = QFileDialog::getOpenFileName(this,
-	    tr("Open I/Q record file"), ".", tr("SDR I/Q Files (*.sdriq *.wav)"), 0);
+	    tr("Open I/Q record file"), QFileInfo(m_settings.m_fileName).dir().path(), tr("SDR I/Q Files (*.sdriq *.wav)"), 0);
 
 
 	if (fileName != "")


### PR DESCRIPTION
In File Input plugin, start file browser in directory containing last selected file, so you don't have to keep on browsing through lots of directories to get to other files in the same directory.