### PR TITLE
Disable build of LAME frontend

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -483,7 +483,7 @@ if (NOT FFMPEG_FOUND AND NOT USE_PRECOMPILED_LIBS)
             UPDATE_DISCONNECTED TRUE
             DEPENDS ${MPG123_DEPENDS}
             PREFIX "${EXTERNAL_BUILD_LIBRARIES}/lame"
-            CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env PKG_CONFIG_PATH=${MPG123_PKG_CONFIG_DIR} <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --enable-shared
+            CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env PKG_CONFIG_PATH=${MPG123_PKG_CONFIG_DIR} <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --enable-shared --disable-frontend
             BUILD_COMMAND ${MAKE}
             TEST_COMMAND ""
             )


### PR DESCRIPTION
The external library LAME (v3.100) frontend binaries fail to build (https://github.com/f4exb/sdrangel/issues/1933) on MacOS currently with:
```log
parse.c:417:34: error: call to undeclared function 'id3tag_set_comment_ucs2'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```
We dont need the LAME frontend binaries themselves, only the shared library, so we can disable their build and avoid this bug in their current code.