### PR TITLE
Optimize eumerator of origin device

### DIFF
--- a/devices/limesdr/devicelimesdr.cpp
+++ b/devices/limesdr/devicelimesdr.cpp
@@ -51,7 +51,7 @@ void DeviceLimeSDR::enumOriginDevices(const QString& hardwareId, PluginInterface
             findSerial((const char *) deviceList[i], serial);
 
             DeviceLimeSDRParams limeSDRParams;
-            limeSDRParams.open(deviceList[i]);
+            limeSDRParams.open(deviceList[i], false);
             limeSDRParams.close();
 
             QString displayedName(QString("LimeSDR[%1:$1] %2").arg(i).arg(serial.c_str()));

--- a/devices/limesdr/devicelimesdrparam.cpp
+++ b/devices/limesdr/devicelimesdrparam.cpp
@@ -18,7 +18,7 @@
 #include <QDebug>
 #include "devicelimesdrparam.h"
 
-bool DeviceLimeSDRParams::open(lms_info_str_t deviceStr)
+bool DeviceLimeSDRParams::open(lms_info_str_t deviceStr, bool init)
 {
     getHardwareType((const char *) deviceStr);
 
@@ -30,10 +30,13 @@ bool DeviceLimeSDRParams::open(lms_info_str_t deviceStr)
         return false;
     }
 
-    if (LMS_Init(m_dev) < 0)
+    if (init) 
     {
-        qCritical() << "DeviceLimeSDRParams::open: cannot init device " << deviceStr;
-        return false;
+        if (LMS_Init(m_dev) < 0)
+        {
+            qCritical() << "DeviceLimeSDRParams::open: cannot init device " << deviceStr;
+            return false;
+        }
     }
 
     int n;

--- a/devices/limesdr/devicelimesdrparam.h
+++ b/devices/limesdr/devicelimesdrparam.h
@@ -96,7 +96,7 @@ struct DEVICES_API DeviceLimeSDRParams
     /**
      * Opens and initialize the device and obtain information (# channels, ranges, ...)
      */
-    bool open(lms_info_str_t deviceStr);
+    bool open(lms_info_str_t deviceStr, bool init = true);
     void close();
     lms_device_t *getDevice() { return m_dev; }
 

--- a/sdrbase/device/deviceenumerator.cpp
+++ b/sdrbase/device/deviceenumerator.cpp
@@ -245,95 +245,86 @@ bool DeviceEnumerator::isMIMOEnumerated(const QString& deviceHwId, int deviceSeq
     return false;
 }
 
-void DeviceEnumerator::enumerateDevices(PluginAPI::SamplingDeviceRegistrations& deviceRegistrations, DevicesEnumeration& enumeration, PluginInterface::SamplingDevice::StreamType type)
+void DeviceEnumerator::enumerateDevices(std::initializer_list<PluginAPI::SamplingDeviceRegistrations*> deviceRegistrationsList, std::initializer_list<DevicesEnumeration*> enumerations)
 {
-    DevicesEnumeration tempEnumeration;
+    auto enumerationsArray = enumerations.begin();
     PluginInterface::OriginDevices originDevices;
     QStringList originDevicesHwIds;
-
-    for (int i = 0; i < deviceRegistrations.count(); i++)
-    {
-        qDebug("DeviceEnumerator::enumerateDevices: %s", qPrintable(deviceRegistrations[i].m_deviceId));
-        emit enumeratingDevices(deviceRegistrations[i].m_deviceId);
-        deviceRegistrations[i].m_plugin->enumOriginDevices(originDevicesHwIds, originDevices);
-        PluginInterface::SamplingDevices samplingDevices;
-        if (type == PluginInterface::SamplingDevice::StreamSingleRx) {
-            samplingDevices = deviceRegistrations[i].m_plugin->enumSampleSources(originDevices);
-        } else if (type == PluginInterface::SamplingDevice::StreamSingleTx) {
-            samplingDevices = deviceRegistrations[i].m_plugin->enumSampleSinks(originDevices);
-        } else {
-            samplingDevices = deviceRegistrations[i].m_plugin->enumSampleMIMO(originDevices);
-        }
-
-        for (int j = 0; j < samplingDevices.count(); j++)
-        {
-            tempEnumeration.push_back(
-                DeviceEnumeration(
-                    samplingDevices[j],
-                    deviceRegistrations[i].m_plugin,
-                    0   // Index will be set when adding to enumeration below
-                )
-            );
-        }
-    }
 
     // We don't remove devices that are no-longer found from the enumeration list, in case their
     // index is referenced in some other object (E.g. DeviceGUI)
     // Instead we mark as removed. If later re-added, then we re-use the same index
-    for (DevicesEnumeration::iterator it = enumeration.begin(); it != enumeration.end(); ++it)
+    for(size_t i = 0; i < 3; i++) 
     {
-        bool found = false;
-        for (DevicesEnumeration::iterator it2 = tempEnumeration.begin(); it2 != tempEnumeration.end(); ++it2)
-        {
-            if (it->m_samplingDevice == it2->m_samplingDevice)
+        if (enumerationsArray[i] != nullptr) {
+            for(auto &device : *enumerationsArray[i]) 
             {
-                found = true;
-                break;
+                device.m_samplingDevice.removed = true;
             }
-        }
-        if (!found) {
-            it->m_samplingDevice.removed = true;
         }
     }
-
-    // Add new entries and update existing (in case re-added or sequence number has changed)
-    int index = enumeration.size();
-    for (DevicesEnumeration::iterator it = tempEnumeration.begin(); it != tempEnumeration.end(); ++it)
+    for (auto const &deviceRegistrations : deviceRegistrationsList)
     {
-
-        bool found = false;
-        for (DevicesEnumeration::iterator it2 = enumeration.begin(); it2 != enumeration.end(); ++it2)
+        for (auto &deviceRegistration : *deviceRegistrations) 
         {
-            if (it->m_samplingDevice == it2->m_samplingDevice)
+            qDebug("DeviceEnumerator::enumerateDevices: %s", qPrintable(deviceRegistration.m_deviceId));
+            emit enumeratingDevices(deviceRegistration.m_deviceId);
+            deviceRegistration.m_plugin->enumOriginDevices(originDevicesHwIds, originDevices);
+            auto func = [&](const PluginInterface::SamplingDevices &devices, DevicesEnumeration& enumeration) 
             {
-                it2->m_samplingDevice.removed = false;
-                it2->m_samplingDevice.displayedName = it->m_samplingDevice.displayedName;
-                found = true;
-                break;
+                for (auto &newDevice : devices) 
+                {
+                    auto found = std::find_if(enumeration.begin(), enumeration.end(), [&](const DeviceEnumeration &device) 
+                    {
+                        return device.m_samplingDevice == newDevice;
+                    });
+                    if (found == enumeration.end()) 
+                    {
+                        enumeration.emplace_back(newDevice, deviceRegistration.m_plugin, enumeration.size());
+                    }
+                    else
+                    {
+                        found->m_samplingDevice.removed = false;
+                    }
+                }
+            };
+            if (enumerationsArray[PluginInterface::SamplingDevice::StreamType::StreamSingleRx]) 
+            {
+                func(deviceRegistration.m_plugin->enumSampleSources(originDevices), *enumerationsArray[PluginInterface::SamplingDevice::StreamType::StreamSingleRx]);
             }
-
-        }
-        if (!found)
-        {
-            it->m_index = index++;
-            enumeration.push_back(*it);
+            if (enumerationsArray[PluginInterface::SamplingDevice::StreamType::StreamSingleTx]) 
+            {
+                func(deviceRegistration.m_plugin->enumSampleSinks(originDevices), *enumerationsArray[PluginInterface::SamplingDevice::StreamType::StreamSingleTx]);
+            }
+            if (enumerationsArray[PluginInterface::SamplingDevice::StreamType::StreamMIMO]) 
+            {
+                func(deviceRegistration.m_plugin->enumSampleMIMO(originDevices), *enumerationsArray[PluginInterface::SamplingDevice::StreamType::StreamMIMO]);
+            }
         }
     }
 }
 
 void DeviceEnumerator::enumerateRxDevices(PluginManager *pluginManager)
 {
-    enumerateDevices(pluginManager->getSourceDeviceRegistrations(), m_rxEnumeration, PluginInterface::SamplingDevice::StreamSingleRx);
+    enumerateDevices({&pluginManager->getSourceDeviceRegistrations()}, { &m_rxEnumeration, nullptr, nullptr });
 }
 
 void DeviceEnumerator::enumerateTxDevices(PluginManager *pluginManager)
 {
-    enumerateDevices(pluginManager->getSinkDeviceRegistrations(), m_txEnumeration, PluginInterface::SamplingDevice::StreamSingleTx);
+    enumerateDevices({&pluginManager->getSinkDeviceRegistrations()}, { nullptr, &m_txEnumeration, nullptr });
 }
 
 void DeviceEnumerator::enumerateMIMODevices(PluginManager *pluginManager)
 {
-    enumerateDevices(pluginManager->getMIMODeviceRegistrations(), m_mimoEnumeration, PluginInterface::SamplingDevice::StreamMIMO);
+    enumerateDevices({&pluginManager->getMIMODeviceRegistrations()}, { nullptr, nullptr, &m_mimoEnumeration });
+}
+
+void DeviceEnumerator::enumerateAllDevices(PluginManager *pluginManager)
+{
+    enumerateDevices(
+        {&pluginManager->getSourceDeviceRegistrations(), &pluginManager->getSinkDeviceRegistrations(), &pluginManager->getMIMODeviceRegistrations()},
+        { &m_rxEnumeration, &m_txEnumeration, &m_mimoEnumeration }
+        );
 }
 
 void DeviceEnumerator::listRxDeviceNames(QList<QString>& list, std::vector<int>& indexes) const

--- a/sdrbase/device/deviceenumerator.h
+++ b/sdrbase/device/deviceenumerator.h
@@ -41,6 +41,7 @@ public:
     void enumerateRxDevices(PluginManager *pluginManager);
     void enumerateTxDevices(PluginManager *pluginManager);
     void enumerateMIMODevices(PluginManager *pluginManager);
+    void enumerateAllDevices(PluginManager *pluginManager);
     void addNonDiscoverableDevices(PluginManager *pluginManager, const DeviceUserArgs& deviceUserArgs);
     void listRxDeviceNames(QList<QString>& list, std::vector<int>& indexes) const;
     void listTxDeviceNames(QList<QString>& list, std::vector<int>& indexes) const;
@@ -93,7 +94,7 @@ private:
     DevicesEnumeration m_txEnumeration;
     DevicesEnumeration m_mimoEnumeration;
 
-    void enumerateDevices(PluginAPI::SamplingDeviceRegistrations& deviceRegistrations, DevicesEnumeration& enumeration, PluginInterface::SamplingDevice::StreamType type);
+    void enumerateDevices(std::initializer_list<PluginAPI::SamplingDeviceRegistrations*>  deviceRegistrations, std::initializer_list<DevicesEnumeration*> enumerations);
     PluginInterface *getRxRegisteredPlugin(PluginManager *pluginManager, const QString& deviceHwId);
     PluginInterface *getTxRegisteredPlugin(PluginManager *pluginManager, const QString& deviceHwId);
     PluginInterface *getMIMORegisteredPlugin(PluginManager *pluginManager, const QString& deviceHwId);

--- a/sdrbase/plugin/pluginmanager.cpp
+++ b/sdrbase/plugin/pluginmanager.cpp
@@ -130,9 +130,7 @@ void PluginManager::loadPluginsFinal()
         it->pluginInterface->initPlugin(&m_pluginAPI);
     }
 
-    DeviceEnumerator::instance()->enumerateRxDevices(this);
-    DeviceEnumerator::instance()->enumerateTxDevices(this);
-    DeviceEnumerator::instance()->enumerateMIMODevices(this);
+    DeviceEnumerator::instance()->enumerateAllDevices(this);
 }
 
 void PluginManager::loadPluginsNonDiscoverable(const DeviceUserArgs& deviceUserArgs)


### PR DESCRIPTION
- Rewrite **_enumerateDevices_**: support to enumerate all devices in one call
- Add **_enumerateAllDevices_** to reduce startup period
- Optimize LimeSDR enumerating by skipping LMS_Init

i have tested it on LimeSDR for all sinks, sources and MIMOs.
it's my first complicated PR, so please feel free to advise or edit.