### PR TITLE
Fix not remove source buddy

### DIFF
--- a/sdrbase/device/deviceapi.h
+++ b/sdrbase/device/deviceapi.h
@@ -159,10 +159,8 @@ public:
     DSPDeviceSinkEngine *getDeviceSinkEngine() { return m_deviceSinkEngine; }
     DSPDeviceMIMOEngine *getDeviceMIMOEngine() { return m_deviceMIMOEngine; }
 
-    void addSourceBuddy(DeviceAPI* buddy);
-    void addSinkBuddy(DeviceAPI* buddy);
-    void removeSourceBuddy(DeviceAPI* buddy);
-    void removeSinkBuddy(DeviceAPI* buddy);
+    void addBuddy(DeviceAPI* buddy);
+    void removeBuddy(DeviceAPI* buddy);
     void clearBuddiesLists();
     void *getBuddySharedPtr() const { return m_buddySharedPtr; }
     void setBuddySharedPtr(void *ptr) { m_buddySharedPtr = ptr; }

--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -482,24 +482,11 @@ void MainWindow::sampleSourceCreate(
     {
         if (*it != deviceUISet) // do not add to itself
         {
-            if ((*it)->m_deviceSourceEngine) // it is a source device
+            if ((deviceUISet->m_deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
+                (deviceUISet->m_deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
             {
-                if ((deviceUISet->m_deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
-                    (deviceUISet->m_deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
-                {
-                    (*it)->m_deviceAPI->addSourceBuddy(deviceUISet->m_deviceAPI);
-                    nbOfBuddies++;
-                }
-            }
-
-            if ((*it)->m_deviceSinkEngine) // it is a sink device
-            {
-                if ((deviceUISet->m_deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
-                    (deviceUISet->m_deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
-                {
-                    (*it)->m_deviceAPI->addSourceBuddy(deviceUISet->m_deviceAPI);
-                    nbOfBuddies++;
-                }
+                (*it)->m_deviceAPI->addBuddy(deviceUISet->m_deviceAPI);
+                nbOfBuddies++;
             }
         }
     }
@@ -713,24 +700,11 @@ void MainWindow::sampleSinkCreate(
     {
         if (*it != deviceUISet) // do not add to itself
         {
-            if ((*it)->m_deviceSourceEngine) // it is a source device
+            if ((deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
+                (deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
             {
-                if ((deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
-                    (deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
-                {
-                    (*it)->m_deviceAPI->addSinkBuddy(deviceAPI);
-                    nbOfBuddies++;
-                }
-            }
-
-            if ((*it)->m_deviceSinkEngine) // it is a sink device
-            {
-                if ((deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
-                    (deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
-                {
-                    (*it)->m_deviceAPI->addSinkBuddy(deviceAPI);
-                    nbOfBuddies++;
-                }
+                (*it)->m_deviceAPI->addBuddy(deviceAPI);
+                nbOfBuddies++;
             }
         }
     }

--- a/sdrsrv/mainserver.cpp
+++ b/sdrsrv/mainserver.cpp
@@ -501,24 +501,11 @@ void MainServer::changeSampleSource(int deviceSetIndex, int selectedDeviceIndex)
         {
             if (*it != deviceSet) // do not add to itself
             {
-                if ((*it)->m_deviceSourceEngine) // it is a source device
+                if ((deviceSet->m_deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
+                    (deviceSet->m_deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
                 {
-                    if ((deviceSet->m_deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
-                        (deviceSet->m_deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
-                    {
-                        (*it)->m_deviceAPI->addSourceBuddy(deviceSet->m_deviceAPI);
-                        nbOfBuddies++;
-                    }
-                }
-
-                if ((*it)->m_deviceSinkEngine) // it is a sink device
-                {
-                    if ((deviceSet->m_deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
-                        (deviceSet->m_deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
-                    {
-                        (*it)->m_deviceAPI->addSourceBuddy(deviceSet->m_deviceAPI);
-                        nbOfBuddies++;
-                    }
+                    (*it)->m_deviceAPI->addBuddy(deviceSet->m_deviceAPI);
+                    nbOfBuddies++;
                 }
             }
         }
@@ -587,24 +574,11 @@ void MainServer::changeSampleSink(int deviceSetIndex, int selectedDeviceIndex)
         {
             if (*it != deviceSet) // do not add to itself
             {
-                if ((*it)->m_deviceSourceEngine) // it is a source device
+                if ((deviceSet->m_deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
+                    (deviceSet->m_deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
                 {
-                    if ((deviceSet->m_deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
-                        (deviceSet->m_deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
-                    {
-                        (*it)->m_deviceAPI->addSinkBuddy(deviceSet->m_deviceAPI);
-                        nbOfBuddies++;
-                    }
-                }
-
-                if ((*it)->m_deviceSinkEngine) // it is a sink device
-                {
-                    if ((deviceSet->m_deviceAPI->getHardwareId() == (*it)->m_deviceAPI->getHardwareId()) &&
-                        (deviceSet->m_deviceAPI->getSamplingDeviceSerial() == (*it)->m_deviceAPI->getSamplingDeviceSerial()))
-                    {
-                        (*it)->m_deviceAPI->addSinkBuddy(deviceSet->m_deviceAPI);
-                        nbOfBuddies++;
-                    }
+                    (*it)->m_deviceAPI->addBuddy(deviceSet->m_deviceAPI);
+                    nbOfBuddies++;
                 }
             }
         }


### PR DESCRIPTION
fix _clearBuddiesLists_ only calls _removeSinkBuddy_, missing source buddies.

additionally:

- merge _addSinkBuddy_ and _addSourceBuddy_ into _addBuddy_.
- merge _removeSinkBuddy_ and _removeSourceBuddy_ into _removeBuddy_.
- both functions mentioned above are dispatched by _DeviceAPI.m_streamType_ 