### PR TITLE
fix memset() arguments order in vkfftengine

### DIFF
--- a/sdrbase/dsp/vkfftengine.cpp
+++ b/sdrbase/dsp/vkfftengine.cpp
@@ -26,7 +26,7 @@ vkFFTEngine::vkFFTEngine() :
     m_reuse(true)
 {
     vkGPU = new VkGPU();
-    memset(vkGPU, sizeof(VkGPU), 0);
+    memset(vkGPU, 0, sizeof(VkGPU));
     vkGPU->device_id = 0; // Could be set in GUI to support multiple GPUs
 }
 
@@ -64,9 +64,9 @@ void vkFFTEngine::configure(int n, bool inverse)
 
     // Allocate and intialise plan
     m_currentPlan->m_configuration = new VkFFTConfiguration();
-    memset(m_currentPlan->m_configuration, sizeof(VkFFTConfiguration), 0);
+    memset(m_currentPlan->m_configuration, 0, sizeof(VkFFTConfiguration));
     m_currentPlan->m_app = new VkFFTApplication();
-    memset(m_currentPlan->m_app, sizeof(VkFFTApplication), 0);
+    memset(m_currentPlan->m_app, 0, sizeof(VkFFTApplication));
     m_currentPlan->m_configuration->FFTdim = 1;
     m_currentPlan->m_configuration->size[0] = n;
     m_currentPlan->m_configuration->size[1] = 1;


### PR DESCRIPTION
just noticed during compilation. Not a big issue, but better to fix, to not have some potential garbage in variables which are not set explicitly.