### PR TITLE
Mac: Scan all plugins for qml

### DIFF
--- a/cmake/cpack/deploy_mac.cmake.in
+++ b/cmake/cpack/deploy_mac.cmake.in
@@ -38,5 +38,5 @@ endforeach()
 
 # Run macdeployqt which should copy all libraries and frameworks and Qt plugins and qml
 message ("Running macdeployqt in ${CPACK_TEMPORARY_INSTALL_DIRECTORY}")
-execute_process ( COMMAND macdeployqt ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/SDRangel.app -always-overwrite -verbose=1 -qmldir=@CMAKE_CURRENT_SOURCE_DIR@/../../plugins/feature/map )
+execute_process ( COMMAND macdeployqt ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/SDRangel.app -always-overwrite -verbose=1 -qmldir=@CMAKE_CURRENT_SOURCE_DIR@/../../plugins/ )
 


### PR DESCRIPTION
On mac, fix missing QML libs, by scanning all plugins, not just the map. For #2010