### PR TITLE
Decrease default floor in Db calculation from -120dB to -150dB

### DIFF
--- a/plugins/channelrx/channelpower/channelpowergui.cpp
+++ b/plugins/channelrx/channelpower/channelpowergui.cpp
@@ -371,12 +371,11 @@ void ChannelPowerGUI::tick()
     double magAvg, magPulseAvg, magMaxPeak, magMinPeak;
     m_channelPower->getMagLevels(magAvg, magPulseAvg, magMaxPeak, magMinPeak);
 
-    double powDbAvg, powDbPulseAvg, powDbMaxPeak, powDbMinPeak, powDbPathLoss;
+    double powDbAvg, powDbPulseAvg, powDbMaxPeak, powDbMinPeak;
     powDbAvg = std::numeric_limits<double>::quiet_NaN();
     powDbPulseAvg = std::numeric_limits<double>::quiet_NaN();
     powDbMaxPeak = std::numeric_limits<double>::quiet_NaN();
     powDbMinPeak = std::numeric_limits<double>::quiet_NaN();
-    powDbPathLoss = std::numeric_limits<double>::quiet_NaN();
 
     const int precision = 2;
 

--- a/sdrbase/util/db.h
+++ b/sdrbase/util/db.h
@@ -26,7 +26,7 @@
 class SDRBASE_API CalcDb
 {
 public:
-	static double dbPower(double magsq, double floor = 1e-12);
+	static double dbPower(double magsq, double floor = 1e-15); // Floor at -150dB
 	static double powerFromdB(double powerdB);
 	static double frexp10(double arg, int *exp);
 };


### PR DESCRIPTION
As Airspy HF+ can operate in this region. Fixes #2020