### PR TITLE
Audio optimize & default input/output bugfix

### DIFF
--- a/plugins/samplesource/audioinput/audioinputgui.cpp
+++ b/plugins/samplesource/audioinput/audioinputgui.cpp
@@ -186,8 +186,7 @@ void AudioInputGui::updateSampleRateAndFrequency()
 void AudioInputGui::refreshDeviceList()
 {
     ui->device->blockSignals(true);
-    AudioDeviceManager *audioDeviceManager = DSPEngine::instance()->getAudioDeviceManager();
-    const QList<AudioDeviceInfo>& audioList = audioDeviceManager->getInputDevices();
+    const QList<AudioDeviceInfo>& audioList = AudioDeviceInfo::availableInputDevices();
 
     ui->device->clear();
     for (const auto &itAudio : audioList)

--- a/plugins/samplesource/fcdpro/fcdproinput.cpp
+++ b/plugins/samplesource/fcdpro/fcdproinput.cpp
@@ -174,7 +174,7 @@ void FCDProInput::closeDevice()
 bool FCDProInput::openFCDAudio(const char* cardname)
 {
     AudioDeviceManager *audioDeviceManager = DSPEngine::instance()->getAudioDeviceManager();
-    const QList<AudioDeviceInfo>& audioList = audioDeviceManager->getInputDevices();
+    const QList<AudioDeviceInfo>& audioList = AudioDeviceInfo::availableInputDevices();
 
     for (const auto &itAudio : audioList)
     {

--- a/plugins/samplesource/fcdproplus/fcdproplusinput.cpp
+++ b/plugins/samplesource/fcdproplus/fcdproplusinput.cpp
@@ -176,7 +176,7 @@ void FCDProPlusInput::closeDevice()
 bool FCDProPlusInput::openFCDAudio(const char* cardname)
 {
     AudioDeviceManager *audioDeviceManager = DSPEngine::instance()->getAudioDeviceManager();
-    const QList<AudioDeviceInfo>& audioList = audioDeviceManager->getInputDevices();
+    const QList<AudioDeviceInfo>& audioList = AudioDeviceInfo::availableInputDevices();
 
     for (const auto &itAudio : audioList)
     {

--- a/sdrbase/audio/audiodeviceinfo.cpp
+++ b/sdrbase/audio/audiodeviceinfo.cpp
@@ -73,28 +73,28 @@ QString AudioDeviceInfo::realm() const
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 const QList<AudioDeviceInfo> &AudioDeviceInfo::availableInputDevices()
 {
-    if (!m_inputDevicesEnumerated) {
+    if (!inputDevicesEnumerated) {
         QList<QAudioDevice> devInfos = QMediaDevices::audioInputs();
         for (auto devInfo : devInfos) {
-            m_inputDevices.append(AudioDeviceInfo(devInfo));
+            inputDevices.append(AudioDeviceInfo(devInfo));
         }
-        m_inputDevicesEnumerated = true;
+        inputDevicesEnumerated = true;
     }
 
-    return m_inputDevices;
+    return inputDevices;
 }
 
 const QList<AudioDeviceInfo> &AudioDeviceInfo::availableOutputDevices()
 {
-    if (!m_outputDevicesEnumerated) {
+    if (!outputDevicesEnumerated) {
         QList<QAudioDevice> devInfos = QMediaDevices::audioOutputs();
         for (auto devInfo : devInfos) {
-            m_outputDevices.append(AudioDeviceInfo(devInfo));
+            outputDevices.append(AudioDeviceInfo(devInfo));
         }
-        m_outputDevicesEnumerated = true;
+        outputDevicesEnumerated = true;
     }
 
-    return m_outputDevices;
+    return outputDevices;
 }
 #else
 const QList<AudioDeviceInfo> &AudioDeviceInfo::availableInputDevices()

--- a/sdrbase/audio/audiodeviceinfo.cpp
+++ b/sdrbase/audio/audiodeviceinfo.cpp
@@ -20,6 +20,10 @@
 
 #include "audiodeviceinfo.h"
 
+bool inputDevicesEnumerated = false, outputDevicesEnumerated = false;
+QList<AudioDeviceInfo> inputDevices, outputDevices;
+AudioDeviceInfo defaultInputDevice_, defaultOutputDevice_;
+
 QString AudioDeviceInfo::deviceName() const
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -67,69 +71,81 @@ QString AudioDeviceInfo::realm() const
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-QList<AudioDeviceInfo> AudioDeviceInfo::availableInputDevices()
+const QList<AudioDeviceInfo> &AudioDeviceInfo::availableInputDevices()
 {
-    QList<QAudioDevice> devInfos = QMediaDevices::audioInputs();
-    QList<AudioDeviceInfo> list;
-
-    for (auto devInfo : devInfos) {
-        list.append(AudioDeviceInfo(devInfo));
+    if (!m_inputDevicesEnumerated) {
+        QList<QAudioDevice> devInfos = QMediaDevices::audioInputs();
+        for (auto devInfo : devInfos) {
+            m_inputDevices.append(AudioDeviceInfo(devInfo));
+        }
+        m_inputDevicesEnumerated = true;
     }
 
-    return list;
+    return m_inputDevices;
 }
 
-QList<AudioDeviceInfo> AudioDeviceInfo::availableOutputDevices()
+const QList<AudioDeviceInfo> &AudioDeviceInfo::availableOutputDevices()
 {
-    QList<QAudioDevice> devInfos = QMediaDevices::audioOutputs();
-    QList<AudioDeviceInfo> list;
-
-    for (auto devInfo : devInfos) {
-        list.append(AudioDeviceInfo(devInfo));
+    if (!m_outputDevicesEnumerated) {
+        QList<QAudioDevice> devInfos = QMediaDevices::audioOutputs();
+        for (auto devInfo : devInfos) {
+            m_outputDevices.append(AudioDeviceInfo(devInfo));
+        }
+        m_outputDevicesEnumerated = true;
     }
 
-    return list;
+    return m_outputDevices;
 }
 #else
-QList<AudioDeviceInfo> AudioDeviceInfo::availableInputDevices()
+const QList<AudioDeviceInfo> &AudioDeviceInfo::availableInputDevices()
 {
-    QList<QAudioDeviceInfo> devInfos = QAudioDeviceInfo::availableDevices(QAudio::AudioInput);
-    QList<AudioDeviceInfo> list;
-
-    for (auto devInfo : devInfos) {
-        list.append(AudioDeviceInfo(devInfo));
+    if (!inputDevicesEnumerated) {
+        QList<QAudioDeviceInfo> devInfos = QAudioDeviceInfo::availableDevices(QAudio::AudioInput);
+        for (auto devInfo : devInfos) {
+            inputDevices.append(AudioDeviceInfo(devInfo));
+        }
+        inputDevicesEnumerated = true;
     }
 
-    return list;
+    return inputDevices;
 }
 
-QList<AudioDeviceInfo> AudioDeviceInfo::availableOutputDevices()
+const QList<AudioDeviceInfo> &AudioDeviceInfo::availableOutputDevices()
 {
-    QList<QAudioDeviceInfo> devInfos = QAudioDeviceInfo::availableDevices(QAudio::AudioOutput);
-    QList<AudioDeviceInfo> list;
-
-    for (auto devInfo : devInfos) {
-        list.append(AudioDeviceInfo(devInfo));
+    if (!outputDevicesEnumerated) {
+        QList<QAudioDeviceInfo> devInfos = QAudioDeviceInfo::availableDevices(QAudio::AudioOutput);
+        for (auto devInfo : devInfos) {
+            outputDevices.append(AudioDeviceInfo(devInfo));
+        }
+        outputDevicesEnumerated = true;
     }
 
-    return list;
+    return outputDevices;
 }
 #endif
 
-AudioDeviceInfo AudioDeviceInfo::defaultOutputDevice()
+const AudioDeviceInfo &AudioDeviceInfo::defaultOutputDevice()
 {
+    if (defaultOutputDevice_.m_deviceInfo.isNull()) 
+    {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    return AudioDeviceInfo(QMediaDevices::defaultAudioOutput());
+        defaultOutputDevice_ = AudioDeviceInfo(QMediaDevices::defaultAudioOutput());
 #else
-    return AudioDeviceInfo(QAudioDeviceInfo::defaultOutputDevice());
+        defaultOutputDevice_ = AudioDeviceInfo(QAudioDeviceInfo::defaultOutputDevice());
 #endif
+    }
+    return defaultOutputDevice_;
 }
 
-AudioDeviceInfo AudioDeviceInfo::defaultInputDevice()
+const AudioDeviceInfo &AudioDeviceInfo::defaultInputDevice()
 {
+    if (defaultInputDevice_.m_deviceInfo.isNull()) 
+    {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    return AudioDeviceInfo(QMediaDevices::defaultAudioInput());
+        defaultInputDevice_ = AudioDeviceInfo(QMediaDevices::defaultAudioInput());
 #else
-    return AudioDeviceInfo(QAudioDeviceInfo::defaultInputDevice());
+        defaultInputDevice_ = AudioDeviceInfo(QAudioDeviceInfo::defaultInputDevice());
 #endif
+    }
+    return defaultInputDevice_;
 }

--- a/sdrbase/audio/audiodeviceinfo.h
+++ b/sdrbase/audio/audiodeviceinfo.h
@@ -67,10 +67,10 @@ public:
     bool isFormatSupported(const QAudioFormat &settings) const;
     QList<int> supportedSampleRates() const;
 
-    static QList<AudioDeviceInfo> availableInputDevices();
-    static QList<AudioDeviceInfo> availableOutputDevices();
-    static AudioDeviceInfo defaultInputDevice();
-    static AudioDeviceInfo defaultOutputDevice();
+    static const QList<AudioDeviceInfo> &availableInputDevices();
+    static const QList<AudioDeviceInfo> &availableOutputDevices();
+    static const AudioDeviceInfo &defaultInputDevice();
+    static const AudioDeviceInfo &defaultOutputDevice();
 
 private:
 

--- a/sdrbase/audio/audiodevicemanager.cpp
+++ b/sdrbase/audio/audiodevicemanager.cpp
@@ -82,20 +82,22 @@ QDataStream& operator>>(QDataStream& ds, AudioDeviceManager::OutputDeviceInfo& i
 AudioDeviceManager::AudioDeviceManager()
 {
     qDebug("AudioDeviceManager::AudioDeviceManager: scan input devices");
-    m_inputDevicesInfo = AudioDeviceInfo::availableInputDevices();
+    {
+        auto &devicesInfo = AudioDeviceInfo::availableInputDevices();
 
-    for (int i = 0; i < m_inputDevicesInfo.size(); i++) {
-        qDebug("AudioDeviceManager::AudioDeviceManager: input device #%d: %s", i, qPrintable(m_inputDevicesInfo[i].deviceName()));
+        for (int i = 0; i < devicesInfo.size(); i++) {
+            qDebug("AudioDeviceManager::AudioDeviceManager: input device #%d: %s", i, qPrintable(devicesInfo[i].deviceName()));
+        }
     }
-
     qDebug("AudioDeviceManager::AudioDeviceManager: scan output devices");
 
-    m_outputDevicesInfo = AudioDeviceInfo::availableOutputDevices();
+    {
+        auto &devicesInfo = AudioDeviceInfo::availableOutputDevices();
 
-    for (int i = 0; i < m_outputDevicesInfo.size(); i++) {
-        qDebug("AudioDeviceManager::AudioDeviceManager: output device #%d: %s", i, qPrintable(m_outputDevicesInfo[i].deviceName()));
+        for (int i = 0; i < devicesInfo.size(); i++) {
+            qDebug("AudioDeviceManager::AudioDeviceManager: output device #%d: %s", i, qPrintable(devicesInfo[i].deviceName()));
+        }
     }
-
     m_defaultInputStarted = false;
     m_defaultOutputStarted = false;
 
@@ -142,9 +144,9 @@ bool AudioDeviceManager::getOutputDeviceName(int outputDeviceIndex, QString &dev
     }
     else
     {
-        if (outputDeviceIndex < m_outputDevicesInfo.size())
+        if (outputDeviceIndex < AudioDeviceInfo::availableOutputDevices().size())
         {
-            deviceName = m_outputDevicesInfo[outputDeviceIndex].deviceName();
+            deviceName = AudioDeviceInfo::availableOutputDevices()[outputDeviceIndex].deviceName();
             return true;
         }
         else
@@ -163,9 +165,9 @@ bool AudioDeviceManager::getInputDeviceName(int inputDeviceIndex, QString &devic
     }
     else
     {
-        if (inputDeviceIndex < m_inputDevicesInfo.size())
+        if (inputDeviceIndex < AudioDeviceInfo::availableInputDevices().size())
         {
-            deviceName = m_inputDevicesInfo[inputDeviceIndex].deviceName();
+            deviceName = AudioDeviceInfo::availableInputDevices()[inputDeviceIndex].deviceName();
             return true;
         }
         else
@@ -177,10 +179,10 @@ bool AudioDeviceManager::getInputDeviceName(int inputDeviceIndex, QString &devic
 
 int AudioDeviceManager::getOutputDeviceIndex(const QString &deviceName) const
 {
-    for (int i = 0; i < m_outputDevicesInfo.size(); i++)
+    for (int i = 0; i < AudioDeviceInfo::availableOutputDevices().size(); i++)
     {
-        //qDebug("AudioDeviceManager::getOutputDeviceIndex: %d: %s|%s", i, qPrintable(deviceName), qPrintable(m_outputDevicesInfo[i].deviceName()));
-        if (deviceName == m_outputDevicesInfo[i].deviceName()) {
+        //qDebug("AudioDeviceManager::getOutputDeviceIndex: %d: %s|%s", i, qPrintable(deviceName), qPrintable(AudioDeviceInfo::availableOutputDevices()[i].deviceName()));
+        if (deviceName == AudioDeviceInfo::availableOutputDevices()[i].deviceName()) {
             return i;
         }
     }
@@ -190,10 +192,10 @@ int AudioDeviceManager::getOutputDeviceIndex(const QString &deviceName) const
 
 int AudioDeviceManager::getInputDeviceIndex(const QString &deviceName) const
 {
-    for (int i = 0; i < m_inputDevicesInfo.size(); i++)
+    for (int i = 0; i < AudioDeviceInfo::availableInputDevices().size(); i++)
     {
-        //qDebug("AudioDeviceManager::getInputDeviceIndex: %d: %s|%s", i, qPrintable(deviceName), qPrintable(m_inputDevicesInfo[i].deviceName()));
-        if (deviceName == m_inputDevicesInfo[i].deviceName()) {
+        //qDebug("AudioDeviceManager::getInputDeviceIndex: %d: %s|%s", i, qPrintable(deviceName), qPrintable(AudioDeviceInfo::availableInputDevices()[i].deviceName()));
+        if (deviceName == AudioDeviceInfo::availableInputDevices()[i].deviceName()) {
             return i;
         }
     }
@@ -295,7 +297,7 @@ void AudioDeviceManager::addAudioSink(AudioFifo* audioFifo, MessageQueue *sample
         if (outputDeviceIndex < 0) {
             audioOutputDevice->setDeviceName("System default");
         } else {
-            audioOutputDevice->setDeviceName(m_outputDevicesInfo[outputDeviceIndex].deviceName());
+            audioOutputDevice->setDeviceName(AudioDeviceInfo::availableOutputDevices()[outputDeviceIndex].deviceName());
         }
 
         qDebug("AudioDeviceManager::addAudioSink: new AudioOutputDevice on thread: %p", thread);
@@ -382,7 +384,7 @@ void AudioDeviceManager::addAudioSource(AudioFifo* audioFifo, MessageQueue *samp
         if (inputDeviceIndex < 0) {
             audioInputDevice->setDeviceName("System default");
         } else {
-            audioInputDevice->setDeviceName(m_outputDevicesInfo[inputDeviceIndex].deviceName());
+            audioInputDevice->setDeviceName(AudioDeviceInfo::availableOutputDevices()[inputDeviceIndex].deviceName());
         }
 
         qDebug("AudioDeviceManager::addAudioSource: new AudioInputDevice on thread: %p", thread);
@@ -789,9 +791,9 @@ void AudioDeviceManager::inputInfosCleanup()
 {
     QSet<QString> deviceNames;
     deviceNames.insert(m_defaultDeviceName);
-    QList<AudioDeviceInfo>::const_iterator itd = m_inputDevicesInfo.begin();
+    QList<AudioDeviceInfo>::const_iterator itd = AudioDeviceInfo::availableInputDevices().begin();
 
-    for (; itd != m_inputDevicesInfo.end(); ++itd)
+    for (; itd != AudioDeviceInfo::availableInputDevices().end(); ++itd)
     {
         qDebug("AudioDeviceManager::inputInfosCleanup: device: %s", qPrintable(itd->deviceName()));
         deviceNames.insert(itd->deviceName());
@@ -817,9 +819,9 @@ void AudioDeviceManager::outputInfosCleanup()
 {
     QSet<QString> deviceNames;
     deviceNames.insert(m_defaultDeviceName);
-    QList<AudioDeviceInfo>::const_iterator itd = m_outputDevicesInfo.begin();
+    QList<AudioDeviceInfo>::const_iterator itd = AudioDeviceInfo::availableOutputDevices().begin();
 
-    for (; itd != m_outputDevicesInfo.end(); ++itd)
+    for (; itd != AudioDeviceInfo::availableOutputDevices().end(); ++itd)
     {
         qDebug("AudioDeviceManager::outputInfosCleanup: device: %s", qPrintable(itd->deviceName()));
         deviceNames.insert(itd->deviceName());

--- a/sdrbase/audio/audiodevicemanager.cpp
+++ b/sdrbase/audio/audiodevicemanager.cpp
@@ -502,7 +502,7 @@ void AudioDeviceManager::startAudioOutput(int outputDeviceIndex)
         m_audioOutputInfos[deviceName].udpChannelMode = udpChannelMode;
         m_audioOutputInfos[deviceName].udpChannelCodec = udpChannelCodec;
         m_audioOutputInfos[deviceName].udpDecimationFactor = decimationFactor;
-        m_defaultOutputStarted = (outputDeviceIndex == -1);
+        m_defaultOutputStarted |= (outputDeviceIndex == -1);
     }
     else
     {
@@ -540,7 +540,7 @@ void AudioDeviceManager::startAudioInput(int inputDeviceIndex)
 
         m_audioInputs[inputDeviceIndex]->setVolume(volume);
         m_audioInputInfos[deviceName].volume = volume;
-        m_defaultInputStarted = (inputDeviceIndex == -1);
+        m_defaultInputStarted |= (inputDeviceIndex == -1);
     }
     else
     {

--- a/sdrbase/audio/audiodevicemanager.h
+++ b/sdrbase/audio/audiodevicemanager.h
@@ -102,9 +102,6 @@ public:
 	AudioDeviceManager();
 	~AudioDeviceManager();
 
-    const QList<AudioDeviceInfo>& getInputDevices() const { return m_inputDevicesInfo; }
-    const QList<AudioDeviceInfo>& getOutputDevices() const { return m_outputDevicesInfo; }
-
     bool getOutputDeviceName(int outputDeviceIndex, QString &deviceName) const;
     bool getInputDeviceName(int inputDeviceIndex, QString &deviceName) const;
     int getOutputDeviceIndex(const QString &deviceName) const;
@@ -136,9 +133,6 @@ public:
     static const QString m_defaultDeviceName;
 
 private:
-    QList<AudioDeviceInfo> m_inputDevicesInfo;
-    QList<AudioDeviceInfo> m_outputDevicesInfo;
-
     QMap<AudioFifo*, int> m_audioSinkFifos; //< audio sink FIFO to audio output device index-1 map
     QMap<AudioFifo*, MessageQueue*> m_audioFifoToSinkMessageQueues; //!< audio sink FIFO to attached sink message queue
     QMap<int, QList<MessageQueue*> > m_outputDeviceSinkMessageQueues; //!< sink message queues attached to device

--- a/sdrbase/audio/audiooutputdevice.cpp
+++ b/sdrbase/audio/audiooutputdevice.cpp
@@ -91,7 +91,7 @@ bool AudioOutputDevice::start(int deviceIndex, int sampleRate)
         }
         else
         {
-            QList<AudioDeviceInfo> devicesInfo = AudioDeviceInfo::availableOutputDevices();
+            auto &devicesInfo = AudioDeviceInfo::availableOutputDevices();
 
             if (deviceIndex < devicesInfo.size())
             {

--- a/sdrbase/webapi/webapiadapter.cpp
+++ b/sdrbase/webapi/webapiadapter.cpp
@@ -454,8 +454,8 @@ int WebAPIAdapter::instanceAudioGet(
 {
     (void) error;
     DSPEngine *dspEngine = DSPEngine::instance();
-    const QList<AudioDeviceInfo>& audioInputDevices = dspEngine->getAudioDeviceManager()->getInputDevices();
-    const QList<AudioDeviceInfo>& audioOutputDevices = dspEngine->getAudioDeviceManager()->getOutputDevices();
+    const QList<AudioDeviceInfo>& audioInputDevices = AudioDeviceInfo::availableInputDevices();
+    const QList<AudioDeviceInfo>& audioOutputDevices = AudioDeviceInfo::availableOutputDevices();
     int nbInputDevices = audioInputDevices.size();
     int nbOutputDevices = audioOutputDevices.size();
 

--- a/sdrgui/gui/audiodialog.cpp
+++ b/sdrgui/gui/audiodialog.cpp
@@ -40,14 +40,14 @@ AudioDialogX::AudioDialogX(AudioDeviceManager* audioDeviceManager, QWidget* pare
 	// out panel
 
 	AudioDeviceManager::OutputDeviceInfo outDeviceInfo;
-	AudioDeviceInfo defaultOutputDeviceInfo = AudioDeviceInfo::defaultOutputDevice();
+	const AudioDeviceInfo &defaultOutputDeviceInfo = AudioDeviceInfo::defaultOutputDevice();
 	treeItem = new QTreeWidgetItem(ui->audioOutTree);
 	treeItem->setText(1, AudioDeviceManager::m_defaultDeviceName);
 	bool found = m_audioDeviceManager->getOutputDeviceInfo(AudioDeviceManager::m_defaultDeviceName, outDeviceInfo);
 	treeItem->setText(0, found ? "__" : "_D");
 	ui->audioOutTree->setCurrentItem(treeItem);
 
-	const QList<AudioDeviceInfo>& outputDevices = m_audioDeviceManager->getOutputDevices();
+	const QList<AudioDeviceInfo>& outputDevices = AudioDeviceInfo::availableOutputDevices();
 
     for(QList<AudioDeviceInfo>::const_iterator it = outputDevices.begin(); it != outputDevices.end(); ++it)
     {
@@ -75,7 +75,7 @@ AudioDialogX::AudioDialogX(AudioDeviceManager* audioDeviceManager, QWidget* pare
     treeItem->setText(0, found ? "__" : "_D");
     ui->audioInTree->setCurrentItem(treeItem);
 
-    const QList<AudioDeviceInfo>& inputDevices = m_audioDeviceManager->getInputDevices();
+    const QList<AudioDeviceInfo>& inputDevices = AudioDeviceInfo::availableInputDevices();
 
     for(QList<AudioDeviceInfo>::const_iterator it = inputDevices.begin(); it != inputDevices.end(); ++it)
     {

--- a/sdrgui/gui/audioselectdialog.cpp
+++ b/sdrgui/gui/audioselectdialog.cpp
@@ -40,7 +40,7 @@ AudioSelectDialog::AudioSelectDialog(const AudioDeviceManager* audioDeviceManage
     defaultItem->setText(2, tr("%1").arg(sampleRate));
     defaultItem->setTextAlignment(2, Qt::AlignRight);
 
-    QList<AudioDeviceInfo> devices = input ? m_audioDeviceManager->getInputDevices() : m_audioDeviceManager->getOutputDevices();
+    const QList<AudioDeviceInfo> &devices = input ? AudioDeviceInfo::availableInputDevices() : AudioDeviceInfo::availableOutputDevices();
 
     for(QList<AudioDeviceInfo>::const_iterator it = devices.begin(); it != devices.end(); ++it)
     {


### PR DESCRIPTION
Makes every **AudioDeviceInfo** singleton to reduce QAudioDeviceInfo calls. frequently calling WASAPI enumerate when startup will lead to crash on my PC... not really know why but it's an optimization anyway.

Fix things about `m_defaultInputStarted `and `m_defaultOutputStarted`. It creates default devices multiple times, causing totally broken and noncontinuous audio.