### PR TITLE
Fix/typos

### DIFF
--- a/plugins/channelrx/demodadsb/readme.md
+++ b/plugins/channelrx/demodadsb/readme.md
@@ -86,7 +86,7 @@ Clicking the Display Settings button will open the Display Settings dialog, whic
 * The font used for the table.
 * Whether demodulator statistics are displayed (primarily an option for developers).
 * Whether the columns in the table are automatically resized after an aircraft is added to it. If unchecked, columns can be resized manually and should be saved with presets.
-* The transistion altitude in feet for use in ATC mode. Below the TA, altitude will be displayed. Above the TA flight levels will be displayed.
+* The transition altitude in feet for use in ATC mode. Below the TA, altitude will be displayed. Above the TA flight levels will be displayed.
 
 You can also enter an [aviationstack](https://aviationstack.com/product) API key, needed to download flight information (such as departure and arrival airports and times).
 

--- a/plugins/channelrx/demoddatv/readme.md
+++ b/plugins/channelrx/demoddatv/readme.md
@@ -114,7 +114,7 @@ Use this dial to flip through standard DATV symbol rates: 25, 33, 66, 125, 250, 
 
 <h5>B.2a.4: FEC rate</h5>
 
-Dpends on the standard and modulation
+Depends on the standard and modulation
 
   - DVB-S with all modulations: 1/2 , 2/3 , 3/4, 5/6 and 7/8.
   - DVB-S2 and QPSK: 1/4, 1/3, 2/5, 1/2, 3/5, 2/3, 3/4, 4/5, 5/6, 8/9, 9/10

--- a/plugins/channelrx/demodendoftrain/endoftraindemodgui.ui
+++ b/plugins/channelrx/demodendoftrain/endoftraindemodgui.ui
@@ -736,7 +736,7 @@
         <string>Light Batt</string>
        </property>
        <property name="toolTip">
-        <string>Market light battery condtion</string>
+        <string>Market light battery condition</string>
        </property>
       </column>
       <column>

--- a/plugins/channelrx/demodendoftrain/readme.md
+++ b/plugins/channelrx/demodendoftrain/readme.md
@@ -4,7 +4,7 @@
 
 This plugin can be used to demodulate End-of-Train packets. These are packets transmitted by an [End-of-Train Device](https://en.wikipedia.org/wiki/End-of-train_device),
 that can be found on some trains.
-It transmits information about whether motion is detected, brake pressue, whether the marker light is on and battery information.
+It transmits information about whether motion is detected, brake pressure, whether the marker light is on and battery information.
 
 * Frequency: 457.9375 MHz (North America, India), 477.7 MHz (Australia) and 450.2625 MHz (New Zealand).
 * Modulation: FSK, 1800Hz space, 1200 mark, +-3kHz deviation.
@@ -93,7 +93,7 @@ The received packets table displays the contents of the packets that have been r
 * Disc - Discretionary bit that is used for varying data by different vendors.
 * Valve - Valve circuit status (Ok or Fail).
 * Conf - Confirmation indicator.
-* Turbine - Air tubine equiped.
+* Turbine - Air turbine equipped.
 * Motion - Whether motion is detected (i.e. is the rear of the train is moving).
 * Light Batt - Marker light battery condition (Ok or Low).
 * Light - Marker light status (On or off).

--- a/plugins/channelrx/demodssb/readme.md
+++ b/plugins/channelrx/demodssb/readme.md
@@ -159,7 +159,7 @@ Use this button to toggle noise reduction on/off. Right click on this button to 
 
 <h4>13.4.1: Noise reduction scheme</h4>
 
-Use this combo box to choose the noise reduction scheme among the follwing:
+Use this combo box to choose the noise reduction scheme among the following:
 
   - **Average**: calculates the average of magnitudes of the FFT (PSD) and sets the magnitude threshold to this average multiplied by a factor that can be set with the control next (13.4.2).
 

--- a/plugins/channelrx/freqscanner/readme.md
+++ b/plugins/channelrx/freqscanner/readme.md
@@ -18,7 +18,7 @@ Specifies the channel (such as an AM, NFM or DSD Demod), by device set and chann
 
 <h3>2: Minimum frequency shift from center frequency of reception for channel</h3>
 
-Use the wheels of keyboard to adjust the minimim frequency shift in Hz from the center frequency of reception for the channel (1).
+Use the wheels of keyboard to adjust the minimum frequency shift in Hz from the center frequency of reception for the channel (1).
 
 This setting is typically used to avoid having the channel (1) centered at DC, which can be problematic for some demodulators used with SDRs with a DC spike.
 
@@ -34,7 +34,7 @@ Power threshold in dB that determines whether a frequency is active or not.
 
 Specifies the time in milliseconds that the Frequency Scanner should wait after adjusting the device center frequency, before starting a measurement.
 This time should take in to account PLL settle time and the device to host transfer latency, so that the measurement only starts when IQ data
-that corresponds to the set frequency is being recieved.
+that corresponds to the set frequency is being received.
 
 <h3>6: t_s - Scan time</h3>
 
@@ -93,7 +93,7 @@ The frequency table contains the list of frequencies to be scanned, along with r
 
 - Freq (Hz): Specifies the channel center frequencies to be scanned. Values should be entered in Hertz.
 - Annotation: An annotation (description) for the frequency, that is obtained from the closest matching [annotation marker](../../../sdrgui/gui/spectrummarkers.md) in the Main Spectrum.
-- Enable: Determines whether the frequency will be scanned. This can be used to temporaily disable frequencies you aren't interested in.
+- Enable: Determines whether the frequency will be scanned. This can be used to temporarily disable frequencies you aren't interested in.
 - Power (dB): Displays the measured power in decibels from the last scan. The cell will have a green background if the power was above the threshold (4).
 - Active Count: Displays the number of scans in which the power for this frequency was above the threshold (4). This allows you to see which frequencies are commonly in use.
 - Notes: Available for user-entry of notes/information about this frequency.

--- a/plugins/channeltx/modpsk31/readme.md
+++ b/plugins/channeltx/modpsk31/readme.md
@@ -80,7 +80,7 @@ The substitutions are applied when the Transmit Settings dialog is closed.
 
 <h3>14: Transmitted Text</h3>
 
-The trasnmitted text area shows characters as they are transmitted.
+The transmitted text area shows characters as they are transmitted.
 
 Holding the cursor over an acronym may show a tooltip with the decoded acronym.
 

--- a/plugins/channeltx/modrtty/readme.md
+++ b/plugins/channeltx/modrtty/readme.md
@@ -117,7 +117,7 @@ The substitutions are applied when the Transmit Settings dialog is closed.
 
 <h3>21: Transmitted Text</h3>
 
-The trasnmitted text area shows characters as they are transmitted.
+The transmitted text area shows characters as they are transmitted.
 
 Holding the cursor over an acronym may show a tooltip with the decoded acronym.
 

--- a/plugins/feature/map/readme.md
+++ b/plugins/feature/map/readme.md
@@ -144,14 +144,14 @@ This is only supported on 2D raster maps and the 3D map.
 <h3>11: Display MUF Contours</h3>
 
 When checked, contours will be downloaded and displayed on the 3D map, showing the MUF (Maximum Usable Frequency) for a 3000km path that reflects off the ionosphere.
-The contours will be updated every 15 minutes. MUF contour data is available for the preceeding 5 days.
+The contours will be updated every 15 minutes. MUF contour data is available for the preceding 5 days.
 
 ![MUF contours](../../../doc/img/Map_plugin_muf.png)
 
 <h3>12: Display coF2 Contours</h3>
 
 When checked, contours will be downloaded and displayed on the 3D map, showing coF2 (F2 layer critical frequency), the maximum frequency at which radio waves will be reflected vertically from the F2 region of the ionosphere.
-The contours will be updated every 15 minutes. coF2 contour data is available for the preceeding 5 days.
+The contours will be updated every 15 minutes. coF2 contour data is available for the preceding 5 days.
 
 <h3>13: Display NASA GIBS Data</h3>
 
@@ -159,7 +159,7 @@ When checked, enables overlay of data from NASA GIBS (Global Imagery Browse Serv
 such as land and sea temperatures, atmospheric conditions, flux measurements and the like.
 Details of available data products can be found [here](https://nasa-gibs.github.io/gibs-api-docs/available-visualizations/#visualization-product-catalog).
 
-For some data sets, GIBS has data spanning many decades. The data period may be hours, days or months. The 3D map will attemp to show data from the closest time set in the 3D map's timescale.
+For some data sets, GIBS has data spanning many decades. The data period may be hours, days or months. The 3D map will attempt to show data from the closest time set in the 3D map's timescale.
 The 2D map will only show data from the default date (which is displayed in the table at the bottom).
 
 ![NASA GIBS](../../../doc/img/Map_plugin_GIBS.png)
@@ -221,7 +221,7 @@ For the 3D map, the settings include:
 For ECI (Earth Centred Inertial) the camera is fixed in space and the globe will rotate under it.
 
 The "Download 3D Models" button will download the 3D models of aircraft, ships and satellites that are required for the 3D map.
-These are not included with the SDRangel distribution, so must be downloaded. It is recommeded to restart SDRangel after downloading the models.
+These are not included with the SDRangel distribution, so must be downloaded. It is recommended to restart SDRangel after downloading the models.
 
 ![Map Display Settings Dialog Items Tab](../../../doc/img/Map_plugin_display_settings_items.png)
 
@@ -265,7 +265,7 @@ To the right of the timeline is the fullscreen toggle button, which allows the 3
 
 <h4>SDRs</h4>
 
-The map can display KiwiSDRs and Spy Servers that are publically accessible via the internet. A URL is displayed in the info box.
+The map can display KiwiSDRs and Spy Servers that are publicly accessible via the internet. A URL is displayed in the info box.
 Clicking on the URL will open a new KiwiSDR or RemoteTCPInput device which will connect to the corresponding SDR.
 Before connecting, you should check the whether the number of users is below the maximum. Server data is updated every 2 minutes.
 

--- a/plugins/feature/satellitetracker/satellitetrackergui.ui
+++ b/plugins/feature/satellitetracker/satellitetrackergui.ui
@@ -713,7 +713,7 @@
         <string>Norad ID</string>
        </property>
        <property name="toolTip">
-        <string>Norad catalog idenfitier for the satellite</string>
+        <string>Norad catalog identifier for the satellite</string>
        </property>
       </column>
      </widget>

--- a/plugins/feature/sid/readme.md
+++ b/plugins/feature/sid/readme.md
@@ -140,7 +140,7 @@ When checked, displays imagary from NASA's SDO (Solar Dynamic Observatory) and E
 
 SDOs images the Sun in a variety of UV and EUV wavelengths. SOHO shows images of the solar corona. The images are near real-time, updated every 15 minutes.
 
-Solar flares are particularly visible in the AIA 131 Å images.
+Solar flares are particularly visible in the AIA 131 Ã… images.
 
 <h3>18: Image or Video Selection</h3>
 
@@ -150,24 +150,24 @@ Selects whether to display images (unchecked) or video (checked).
 
 Selects which image / wavelength to view.
 
-* AIA 94 Å to 1700 Å - The AIA (Atmospheric Imaging Assembly) images the solar atmosphere at multiple EUV (Extreme Ultraviolet) and UV (Ultraviolet) wavelengths:
+* AIA 94 Ã… to 1700 Ã… - The AIA (Atmospheric Imaging Assembly) images the solar atmosphere at multiple EUV (Extreme Ultraviolet) and UV (Ultraviolet) wavelengths:
    
 | Band    | Region									|
 |---------|-----------------------------------------|
-| 94 Å    | Flaring									|
-| 131 Å   | Flaring									|	
-| 171 Å   | Quiet corona, upper transition region 	|
-| 193 Å   | Corona and hot flare plasma			 	|
-| 211 Å   | Active corona							|
-| 304 Å   | Chromosphere, transition region		    |
-| 335 Å   | Active corona							|
-| 1600 Å  | Transition region, upper photoshere     |
-| 1700 Å  | Temperature minimum, photosphere		|
+| 94 Ã…    | Flaring									|
+| 131 Ã…   | Flaring									|
+| 171 Ã…   | Quiet corona, upper transition region 	|
+| 193 Ã…   | Corona and hot flare plasma			 	|
+| 211 Ã…   | Active corona							|
+| 304 Ã…   | Chromosphere, transition region		    |
+| 335 Ã…   | Active corona							|
+| 1600 Ã…  | Transition region, upper photoshere     |
+| 1700 Ã…  | Temperature minimum, photosphere		|
 
 [Ref](https://sdo.gsfc.nasa.gov/data/channels.php)
 
 * MHI Magnetogram - HMI (Helioseismic and Magnetic Imager) Magnetogram shows the magnetic field in the photosphere, with black and white indicating opposite polarities.
-* MHI Intensitygram - Brightness in a visible light band (6173 Å - Red - Iron spectral line), useful for observing sun spots.
+* MHI Intensitygram - Brightness in a visible light band (6173 Ã… - Red - Iron spectral line), useful for observing sun spots.
 * Dopplergram - Shows velocities along the line-of-sight.
 
 * LASCO (Large Angle Spectrometric Coronagraph) shows solar corona. C2 shows corona up to 8.4Mkm. C3 shows corona up to 23Mkm.

--- a/plugins/feature/sid/readme.md
+++ b/plugins/feature/sid/readme.md
@@ -18,7 +18,7 @@ The SID chart can plot multiple series, allowing different signals from differen
 This can be useful as SIDs can be localized to specific regions in the atmosphere, thus not all signals may be affected. 
 Data can come from multiple [Channel Power](../../channelrx/channelpower/readme.md) plugins within a single device, or separate devices.
 
-To help determine the cause of a SID, addtional data can be plotted from a variety of sources:
+To help determine the cause of a SID, additional data can be plotted from a variety of sources:
 
 * the chart can plot X-ray data from the GOES satellites, to allow visual correlation of spikes in the X-ray flux measurement with spikes in the VLF power measurements,
 * it can display images and video from the Solar Dynamics Observatory at EUV wavelengths, which may visually show the solar flare,
@@ -63,9 +63,9 @@ Number of samples to use in a moving average filter that can be applied to the d
 
 Check to display long wavelength (0.1-0.8nm) X-Ray data from the primary GOES satellite (Currently GOES 16) on the chart.
 
-This is probably the most useful data in order to see when a solar flare has occured, as there will typically be a sharp peak.
+This is probably the most useful data in order to see when a solar flare has occurred, as there will typically be a sharp peak.
 The GOES satellites are in a geostationary orbit around the Earth, so the measured increase in X-ray flux from a flare will be approximately 8 minutes
-after it has occured.
+after it has occurred.
 The Y-axis indicates the flare classification. M and X class flares are those most likely to have a measurable impact on the ionosphere.
 
 ![X-Ray data showing M class flare](../../../doc/img/SID_plugin_xray.png)
@@ -201,11 +201,11 @@ When clicked, the X-axis is set 1 day later than the current setting, at the sam
 
 <h3>26: Start Time</h3>
 
-Displays/sets the current start time of the chart (X-axis minimum). It's possible to scroll through hours/days/months by clicking on the relevent segment and using the mouse scroll wheel.
+Displays/sets the current start time of the chart (X-axis minimum). It's possible to scroll through hours/days/months by clicking on the relevant segment and using the mouse scroll wheel.
 
 <h3>27: End Time</h3>
 
-Displays/sets the current end time of the chart (X-axis maximum). It's possible to scroll through hours/days/months by clicking on the relevent segment and using the mouse scroll wheel.
+Displays/sets the current end time of the chart (X-axis maximum). It's possible to scroll through hours/days/months by clicking on the relevant segment and using the mouse scroll wheel.
 
 <h3>28: Min</h3>
 
@@ -248,7 +248,7 @@ In order to check that a peak in the spectrum is a real VLF signal, you can:
 * Check that the signal has diurnal variation (it should vary with the time of day, due to the changes in the ionosphere). 
 * Check with online lists of VLF signals (E.g. https://sidstation.loudet.org/stations-list-en.xhtml or https://www.mwlist.org/vlf.php). A number of these are plotted on the [Map](../../feature/map/readme.md) feature.
 
-Occasionally, the X-ray flux data may drop to 0. This is typically when the GOES satellite is in eclipse (The Earth or moon is inbetween the satellite and the Sun).
+Occasionally, the X-ray flux data may drop to 0. This is typically when the GOES satellite is in eclipse (The Earth or Moon is in between the satellite and the Sun).
 
 SIDs are most likely to be detected when it's day time in the path between the signal source and receiver, as at night, the atmosphere is shielded from the X-rays by the Earth.
 Also, as the D layer in the ionosphere essentially disappears at night, the received power is not as constant as during the day.

--- a/plugins/feature/skymap/readme.md
+++ b/plugins/feature/skymap/readme.md
@@ -82,7 +82,7 @@ For WWT, when checked, displays names of constellations and Ecliptic text (when 
 
 For WWT, this option enables the display of constellations. How the constellations are drawn can be customised in the Display Settings dialog (12).
 
-<h3>7: Display gird</h3>
+<h3>7: Display grid</h3>
 
 When checked, displays a coordinate grid.
 
@@ -113,7 +113,7 @@ Select a Star Tracker, Rotator Controller, Satellite Tracker or Map plugin to re
 
 When clicked, opens the Display Settings dialog. The Display Settings dialog allows the user to set:
 
-* Observation location (latitude and longitude in degreees).
+* Observation location (latitude and longitude in degrees).
 * Antenna beamwidth in degrees.
 * Settings for WWT, such as how the constellations are drawn, what grids are displayed and how the Solar System view appears.
 

--- a/plugins/samplesource/androidsdrdriverinput/readme.md
+++ b/plugins/samplesource/androidsdrdriverinput/readme.md
@@ -15,7 +15,7 @@ Device start / stop button.
 
   - Blue triangle icon: device is ready and can be started
   - Green square icon: device is running and can be stopped
-  - Red square icon: an error has occured with the connection to the device. The plugin will continually try to reconnect.
+  - Red square icon: an error has occurred with the connection to the device. The plugin will continually try to reconnect.
 
 <h3>2: Center frequency</h3>
 


### PR DESCRIPTION
This PR fixes some small errors in documentation and user-visible texts.

I think that errors in the user interface and documentation should be treated as programming errors, that is detected and fixed when possible. May I suggest that you add tho the CI workflow a check with codespell to flag such errors?

I'm using this command to find the errors only in some files while ignoring some false positives:
`find . \( -name '*.md' -o -name '*.ui' \) -exec codespell --ignore-words-list=cach,currenty,doas,ehr,inout,lits,nd,ned,playfull,som,verry,vor,wapping --summary {} \+`
