### PR TITLE
Fix bug that prevents settings changes updates via reverse API (#2065)

### DIFF
--- a/plugins/channelrx/demodm17/m17demod.cpp
+++ b/plugins/channelrx/demodm17/m17demod.cpp
@@ -295,7 +295,7 @@ void M17Demod::applySettings(const M17DemodSettings& settings, const QList<QStri
         m_basebandSink->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/channelrx/freqscanner/freqscanner.cpp
+++ b/plugins/channelrx/freqscanner/freqscanner.cpp
@@ -707,7 +707,7 @@ void FreqScanner::applySettings(const FreqScannerSettings& settings, const QStri
         m_basebandSink->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/channelrx/localsink/localsink.cpp
+++ b/plugins/channelrx/localsink/localsink.cpp
@@ -376,7 +376,7 @@ void LocalSink::applySettings(const LocalSinkSettings& settings, const QList<QSt
         m_basebandSink->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/channelrx/remotetcpsink/remotetcpsink.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsink.cpp
@@ -239,7 +239,7 @@ void RemoteTCPSink::applySettings(const RemoteTCPSinkSettings& settings, const Q
     MsgConfigureRemoteTCPSink *msg = MsgConfigureRemoteTCPSink::create(settings, settingsKeys, force, remoteChange);
     m_basebandSink->getInputMessageQueue()->push(msg);
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/antennatools/antennatools.cpp
+++ b/plugins/feature/antennatools/antennatools.cpp
@@ -101,7 +101,7 @@ void AntennaTools::applySettings(const AntennaToolsSettings& settings, const QLi
 {
     qDebug() << "AntennaTools::applySettings:" << settings.getDebugString(settingsKeys, force) << " force: " << force;
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/aprs/aprs.cpp
+++ b/plugins/feature/aprs/aprs.cpp
@@ -214,7 +214,7 @@ void APRS::applySettings(const APRSSettings& settings, const QList<QString>& set
         m_worker->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/demodanalyzer/demodanalyzer.cpp
+++ b/plugins/feature/demodanalyzer/demodanalyzer.cpp
@@ -290,7 +290,7 @@ void DemodAnalyzer::applySettings(const DemodAnalyzerSettings& settings, const Q
     }
 
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/gs232controller/gs232controller.cpp
+++ b/plugins/feature/gs232controller/gs232controller.cpp
@@ -296,7 +296,7 @@ void GS232Controller::applySettings(const GS232ControllerSettings& settings, con
         m_worker->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/jogdialcontroller/jogdialcontroller.cpp
+++ b/plugins/feature/jogdialcontroller/jogdialcontroller.cpp
@@ -174,7 +174,7 @@ void JogdialController::applySettings(const JogdialControllerSettings& settings,
 {
     qDebug() << "JogdialController::applySettings:" << settings.getDebugString(settingsKeys, force) << " force: " << force;
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/map/map.cpp
+++ b/plugins/feature/map/map.cpp
@@ -145,7 +145,7 @@ void Map::applySettings(const MapSettings& settings, const QList<QString>& setti
 {
     qDebug() << "Map::applySettings:" << settings.getDebugString(settingsKeys, force) << " force: " << force;
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/pertester/pertester.cpp
+++ b/plugins/feature/pertester/pertester.cpp
@@ -196,7 +196,7 @@ void PERTester::applySettings(const PERTesterSettings& settings, const QList<QSt
         m_worker->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/radiosonde/radiosonde.cpp
+++ b/plugins/feature/radiosonde/radiosonde.cpp
@@ -139,7 +139,7 @@ void Radiosonde::applySettings(const RadiosondeSettings& settings, const QList<Q
 {
     qDebug() << "Radiosonde::applySettings:" << settings.getDebugString(settingsKeys, force) << " force: " << force;
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/rigctlserver/rigctlserver.cpp
+++ b/plugins/feature/rigctlserver/rigctlserver.cpp
@@ -173,7 +173,7 @@ void RigCtlServer::applySettings(const RigCtlServerSettings& settings, const QLi
     );
     m_worker->getInputMessageQueue()->push(msg);
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/satellitetracker/satellitetracker.cpp
+++ b/plugins/feature/satellitetracker/satellitetracker.cpp
@@ -216,7 +216,7 @@ void SatelliteTracker::applySettings(const SatelliteTrackerSettings& settings, c
         m_worker->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/sid/sid.cpp
+++ b/plugins/feature/sid/sid.cpp
@@ -166,7 +166,7 @@ void SIDMain::applySettings(const SIDSettings& settings, const QList<QString>& s
         m_worker->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/simpleptt/simpleptt.cpp
+++ b/plugins/feature/simpleptt/simpleptt.cpp
@@ -214,7 +214,7 @@ void SimplePTT::applySettings(const SimplePTTSettings& settings, const QList<QSt
         m_worker->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/skymap/skymap.cpp
+++ b/plugins/feature/skymap/skymap.cpp
@@ -116,7 +116,7 @@ void SkyMap::applySettings(const SkyMapSettings& settings, const QList<QString>&
 {
     qDebug() << "SkyMap::applySettings:" << settings.getDebugString(settingsKeys, force) << " force: " << force;
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/startracker/startracker.cpp
+++ b/plugins/feature/startracker/startracker.cpp
@@ -253,7 +253,7 @@ void StarTracker::applySettings(const StarTrackerSettings& settings, const QList
         m_worker->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/feature/vorlocalizer/vorlocalizer.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizer.cpp
@@ -347,7 +347,7 @@ void VORLocalizer::applySettings(const VORLocalizerSettings& settings, const QLi
         m_worker->getInputMessageQueue()->push(msg);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
                 settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplemimo/audiocatsiso/audiocatsiso.cpp
+++ b/plugins/samplemimo/audiocatsiso/audiocatsiso.cpp
@@ -557,7 +557,7 @@ void AudioCATSISO::applySettings(const AudioCATSISOSettings& settings, const QLi
         forwardTxChange = true;
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplemimo/bladerf2mimo/bladerf2mimo.cpp
+++ b/plugins/samplemimo/bladerf2mimo/bladerf2mimo.cpp
@@ -727,7 +727,7 @@ bool BladeRF2MIMO::applySettings(const BladeRF2MIMOSettings& settings, const QLi
 
     // Reverse API settings
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplemimo/limesdrmimo/limesdrmimo.cpp
+++ b/plugins/samplemimo/limesdrmimo/limesdrmimo.cpp
@@ -1012,7 +1012,7 @@ bool LimeSDRMIMO::applySettings(const LimeSDRMIMOSettings& settings, const QList
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplemimo/plutosdrmimo/plutosdrmimo.cpp
+++ b/plugins/samplemimo/plutosdrmimo/plutosdrmimo.cpp
@@ -713,7 +713,7 @@ bool PlutoSDRMIMO::applySettings(const PlutoSDRMIMOSettings& settings, const QLi
         plutoBox->set_params(DevicePlutoSDRBox::DEVICE_PHY, params);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplemimo/xtrxmimo/xtrxmimo.cpp
+++ b/plugins/samplemimo/xtrxmimo/xtrxmimo.cpp
@@ -770,7 +770,7 @@ bool XTRXMIMO::applySettings(const XTRXMIMOSettings& settings, const QList<QStri
 
     // Reverse API
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesink/aaroniartsaoutput/aaroniartsaoutput.cpp
+++ b/plugins/samplesink/aaroniartsaoutput/aaroniartsaoutput.cpp
@@ -286,7 +286,7 @@ void AaroniaRTSAOutput::applySettings(const AaroniaRTSAOutputSettings& settings,
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesink/audiooutput/audiooutput.cpp
+++ b/plugins/samplesink/audiooutput/audiooutput.cpp
@@ -238,7 +238,7 @@ void AudioOutput::applySettings(const AudioOutputSettings& settings, const QList
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesink/bladerf1output/bladerf1output.cpp
+++ b/plugins/samplesink/bladerf1output/bladerf1output.cpp
@@ -497,7 +497,7 @@ bool Bladerf1Output::applySettings(const BladeRF1OutputSettings& settings, const
         m_bladerfThread->startWork();
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesink/bladerf2output/bladerf2output.cpp
+++ b/plugins/samplesink/bladerf2output/bladerf2output.cpp
@@ -903,7 +903,7 @@ bool BladeRF2Output::applySettings(const BladeRF2OutputSettings& settings, const
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesink/fileoutput/fileoutput.cpp
+++ b/plugins/samplesink/fileoutput/fileoutput.cpp
@@ -316,7 +316,7 @@ void FileOutput::applySettings(const FileOutputSettings& settings, const QList<Q
         forwardChange = true;
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesink/hackrfoutput/hackrfoutput.cpp
+++ b/plugins/samplesink/hackrfoutput/hackrfoutput.cpp
@@ -495,7 +495,7 @@ bool HackRFOutput::applySettings(const HackRFOutputSettings& settings, const QLi
 	    m_hackRFThread->startWork();
 	}
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesink/limesdroutput/limesdroutput.cpp
+++ b/plugins/samplesink/limesdroutput/limesdroutput.cpp
@@ -1006,7 +1006,7 @@ bool LimeSDROutput::applySettings(const LimeSDROutputSettings& settings, const Q
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesink/localoutput/localoutput.cpp
+++ b/plugins/samplesink/localoutput/localoutput.cpp
@@ -214,7 +214,7 @@ void LocalOutput::applySettings(const LocalOutputSettings& settings, const QList
     QString remoteAddress;
     QList<QString> reverseAPIKeys;
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesink/plutosdroutput/plutosdroutput.cpp
+++ b/plugins/samplesink/plutosdroutput/plutosdroutput.cpp
@@ -538,7 +538,7 @@ bool PlutoSDROutput::applySettings(const PlutoSDROutputSettings& settings, const
         plutoBox->set_params(DevicePlutoSDRBox::DEVICE_PHY, params);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesink/remoteoutput/remoteoutput.cpp
+++ b/plugins/samplesink/remoteoutput/remoteoutput.cpp
@@ -302,7 +302,7 @@ void RemoteOutput::applySettings(const RemoteOutputSettings& settings, const QLi
 
     mutexLocker.unlock();
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesink/xtrxoutput/xtrxoutput.cpp
+++ b/plugins/samplesink/xtrxoutput/xtrxoutput.cpp
@@ -906,7 +906,7 @@ bool XTRXOutput::applySettings(const XTRXOutputSettings& settings, const QList<Q
         forceNCOFrequency = true;
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/aaroniartsainput/aaroniartsainput.cpp
+++ b/plugins/samplesource/aaroniartsainput/aaroniartsainput.cpp
@@ -299,7 +299,7 @@ bool AaroniaRTSAInput::applySettings(const AaroniaRTSAInputSettings& settings, c
         emit setWorkerSampleRate(settings.m_sampleRate);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/airspy/airspyinput.cpp
+++ b/plugins/samplesource/airspy/airspyinput.cpp
@@ -546,7 +546,7 @@ bool AirspyInput::applySettings(const AirspySettings& settings, const QList<QStr
 		}
 	}
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/airspyhf/airspyhfinput.cpp
+++ b/plugins/samplesource/airspyhf/airspyhfinput.cpp
@@ -576,7 +576,7 @@ bool AirspyHFInput::applySettings(const AirspyHFSettings& settings, const QList<
         m_deviceAPI->getDeviceEngineInputMessageQueue()->push(notif);
 	}
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/androidsdrdriverinput/androidsdrdriverinput.cpp
+++ b/plugins/samplesource/androidsdrdriverinput/androidsdrdriverinput.cpp
@@ -248,7 +248,7 @@ void AndroidSDRDriverInput::applySettings(const AndroidSDRDriverInputSettings& s
 
     mutexLocker.unlock();
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/audioinput/audioinput.cpp
+++ b/plugins/samplesource/audioinput/audioinput.cpp
@@ -310,7 +310,7 @@ void AudioInput::applySettings(const AudioInputSettings& settings, QList<QString
                 settings.m_iqImbalance ? "true" : "false");
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/bladerf2input/bladerf2input.cpp
+++ b/plugins/samplesource/bladerf2input/bladerf2input.cpp
@@ -978,7 +978,7 @@ bool BladeRF2Input::applySettings(const BladeRF2InputSettings& settings, const Q
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/fcdpro/fcdproinput.cpp
+++ b/plugins/samplesource/fcdpro/fcdproinput.cpp
@@ -495,7 +495,7 @@ void FCDProInput::applySettings(const FCDProSettings& settings, const QList<QStr
 		m_deviceAPI->configureCorrections(settings.m_dcBlock, settings.m_iqCorrection);
 	}
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/fcdproplus/fcdproplusinput.cpp
+++ b/plugins/samplesource/fcdproplus/fcdproplusinput.cpp
@@ -427,7 +427,7 @@ void FCDProPlusInput::applySettings(const FCDProPlusSettings& settings, const QL
 		m_deviceAPI->configureCorrections(settings.m_dcBlock, settings.m_iqImbalance);
 	}
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/fileinput/fileinput.cpp
+++ b/plugins/samplesource/fileinput/fileinput.cpp
@@ -554,7 +554,7 @@ bool FileInput::applySettings(const FileInputSettings& settings, const QList<QSt
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/hackrfinput/hackrfinput.cpp
+++ b/plugins/samplesource/hackrfinput/hackrfinput.cpp
@@ -522,7 +522,7 @@ bool HackRFInput::applySettings(const HackRFInputSettings& settings, const QList
         m_deviceAPI->getDeviceEngineInputMessageQueue()->push(notif);
 	}
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/kiwisdr/kiwisdrinput.cpp
+++ b/plugins/samplesource/kiwisdr/kiwisdrinput.cpp
@@ -314,7 +314,7 @@ bool KiwiSDRInput::applySettings(const KiwiSDRSettings& settings, const QList<QS
 		m_deviceAPI->getDeviceEngineInputMessageQueue()->push(notif);
 	}
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/limesdrinput/limesdrinput.cpp
+++ b/plugins/samplesource/limesdrinput/limesdrinput.cpp
@@ -1162,7 +1162,7 @@ bool LimeSDRInput::applySettings(const LimeSDRInputSettings& settings, const QLi
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/localinput/localinput.cpp
+++ b/plugins/samplesource/localinput/localinput.cpp
@@ -221,7 +221,7 @@ void LocalInput::applySettings(const LocalInputSettings& settings, const QList<Q
 
     mutexLocker.unlock();
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/perseus/perseusinput.cpp
+++ b/plugins/samplesource/perseus/perseusinput.cpp
@@ -402,7 +402,7 @@ bool PerseusInput::applySettings(const PerseusSettings& settings, const QList<QS
         m_deviceAPI->getDeviceEngineInputMessageQueue()->push(notif);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
@@ -591,7 +591,7 @@ bool PlutoSDRInput::applySettings(const PlutoSDRInputSettings& settings, const Q
         plutoBox->set_params(DevicePlutoSDRBox::DEVICE_PHY, params);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/remoteinput/remoteinput.cpp
+++ b/plugins/samplesource/remoteinput/remoteinput.cpp
@@ -287,7 +287,7 @@ void RemoteInput::applySettings(const RemoteInputSettings& settings, const QList
 
     mutexLocker.unlock();
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/remotetcpinput/remotetcpinput.cpp
+++ b/plugins/samplesource/remotetcpinput/remotetcpinput.cpp
@@ -244,7 +244,7 @@ void RemoteTCPInput::applySettings(const RemoteTCPInputSettings& settings, const
 
     mutexLocker.unlock();
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
@@ -567,7 +567,7 @@ bool RTLSDRInput::applySettings(const RTLSDRSettings& settings, const QList<QStr
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/sdrplay/sdrplayinput.cpp
+++ b/plugins/samplesource/sdrplay/sdrplayinput.cpp
@@ -568,7 +568,7 @@ bool SDRPlayInput::applySettings(const SDRPlaySettings& settings, const QList<QS
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/sdrplayv3/sdrplayv3input.cpp
+++ b/plugins/samplesource/sdrplayv3/sdrplayv3input.cpp
@@ -693,7 +693,7 @@ bool SDRPlayV3Input::applySettings(const SDRPlayV3Settings& settings, const QLis
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/sigmffileinput/sigmffileinput.cpp
+++ b/plugins/samplesource/sigmffileinput/sigmffileinput.cpp
@@ -836,7 +836,7 @@ bool SigMFFileInput::applySettings(const SigMFFileInputSettings& settings, const
         openFileStreams(settings.m_fileName);
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/testsource/testsourceinput.cpp
+++ b/plugins/samplesource/testsource/testsourceinput.cpp
@@ -405,7 +405,7 @@ bool TestSourceInput::applySettings(const TestSourceSettings& settings, const QL
         }
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||

--- a/plugins/samplesource/xtrxinput/xtrxinput.cpp
+++ b/plugins/samplesource/xtrxinput/xtrxinput.cpp
@@ -1007,7 +1007,7 @@ bool XTRXInput::applySettings(const XTRXInputSettings& settings, const QList<QSt
         forceNCOFrequency = true;
     }
 
-    if (settingsKeys.contains("useReverseAPI"))
+    if (settings.m_useReverseAPI)
     {
         bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
             settingsKeys.contains("reverseAPIAddress") ||


### PR DESCRIPTION
Most plugins that use reverse API to PATCH settings updates to remote server only do so when `useReverseAPI` is toggled, but not when the relevant settings are being updated. So lets fix the precondition to use the `m_useReverseAPI` flag instead.

Fixes #2065.