### PR TITLE
Fix build failure when Qt Location is not available

### DIFF
--- a/plugins/feature/CMakeLists.txt
+++ b/plugins/feature/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
 endif()
 
 # WebEngine on Qt5, WebEngineCore on Qt6
-if(ENABLE_FEATURE_SKYMAP AND Qt${QT_DEFAULT_MAJOR_VERSION}WebEngine_FOUND OR Qt${QT_DEFAULT_MAJOR_VERSION}WebEngineCore_FOUND)
+if(ENABLE_FEATURE_SKYMAP AND (Qt${QT_DEFAULT_MAJOR_VERSION}WebEngine_FOUND OR Qt${QT_DEFAULT_MAJOR_VERSION}WebEngineCore_FOUND) AND Qt${QT_DEFAULT_MAJOR_VERSION}Location_FOUND)
     add_subdirectory(skymap)
 endif()
 


### PR DESCRIPTION
When Qt Location is not available, cmake prints
```
-- Not building map (ENABLE_FEATURE_MAP=ON Qt6Quick_FOUND=1 Qt6QuickWidgets_FOUND=1 Qt6Positioning_FOUND=1 Qt6Location_FOUND=0)
[...]
CMake Error at plugins/feature/skymap/CMakeLists.txt:74 (target_link_libraries):
  Target "featureskymap" links to:

    Qt::Location

  but the target was not found.  Possible reasons include:
```

(I'm using Debian testing and at this time in not yet available for Qt 6, it's available in experimental.

The existing test was wrong in the part that checked for WebEngine/WebEngineCore the because precedence is from left to right (https://cmake.org/cmake/help/latest/command/if.html#and) and it didn't check for Qt Location.
In the top level CMakeLists.txt Qt Location is optional.