### PR TITLE
Fix typos in ChannelAnalyzer settings

### DIFF
--- a/plugins/channelrx/chanalyzer/chanalyzer.cpp
+++ b/plugins/channelrx/chanalyzer/chanalyzer.cpp
@@ -380,13 +380,13 @@ void ChannelAnalyzer::webapiUpdateChannelSettings(
         const QStringList& channelSettingsKeys,
         SWGSDRangel::SWGChannelSettings& response)
 {
-    if (channelSettingsKeys.contains("frequency")) {
+    if (channelSettingsKeys.contains("inputFrequencyOffset")) {
         settings.m_inputFrequencyOffset = response.getChannelAnalyzerSettings()->getFrequency();
     }
-    if (channelSettingsKeys.contains("downSample")) {
+    if (channelSettingsKeys.contains("rationalDownSample ")) {
         settings.m_rationalDownSample = response.getChannelAnalyzerSettings()->getDownSample() != 0;
     }
-    if (channelSettingsKeys.contains("downSampleRate")) {
+    if (channelSettingsKeys.contains("rationalDownSamplerRate")) {
         settings.m_rationalDownSamplerRate = response.getChannelAnalyzerSettings()->getDownSampleRate();
     }
     if (channelSettingsKeys.contains("bandwidth")) {
@@ -639,13 +639,13 @@ void ChannelAnalyzer::webapiFormatChannelSettings(
 
     // transfer data that has been modified. When force is on transfer all data except reverse API data
 
-    if (channelSettingsKeys.contains("frequency") || force) {
+    if (channelSettingsKeys.contains("inputFrequencyOffset") || force) {
         swgChannelAnalyzerSettings->setFrequency(settings.m_inputFrequencyOffset);
     }
-    if (channelSettingsKeys.contains("downSample")) {
+    if (channelSettingsKeys.contains("rationalDownSample")) {
         swgChannelAnalyzerSettings->setDownSample(settings.m_rationalDownSample ? 1 : 0);
     }
-    if (channelSettingsKeys.contains("downSampleRate")) {
+    if (channelSettingsKeys.contains("rationalDownSamplerRate")) {
         swgChannelAnalyzerSettings->setDownSampleRate(settings.m_rationalDownSamplerRate);
     }
     if (channelSettingsKeys.contains("bandwidth")) {

--- a/swagger/sdrangel/code/qt5/client/SWGChannelAnalyzerSettings.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGChannelAnalyzerSettings.cpp
@@ -210,11 +210,11 @@ SWGChannelAnalyzerSettings::fromJson(QString &json) {
 
 void
 SWGChannelAnalyzerSettings::fromJsonObject(QJsonObject &pJson) {
-    ::SWGSDRangel::setValue(&frequency, pJson["frequency"], "qint32", "");
+    ::SWGSDRangel::setValue(&frequency, pJson["inputFrequencyOffset"], "qint32", "");
     
-    ::SWGSDRangel::setValue(&down_sample, pJson["downSample"], "qint32", "");
+    ::SWGSDRangel::setValue(&down_sample, pJson["rationalDownSample"], "qint32", "");
     
-    ::SWGSDRangel::setValue(&down_sample_rate, pJson["downSampleRate"], "qint32", "");
+    ::SWGSDRangel::setValue(&down_sample_rate, pJson["rationalDownSamplerRate"], "qint32", "");
     
     ::SWGSDRangel::setValue(&bandwidth, pJson["bandwidth"], "qint32", "");
     
@@ -285,13 +285,13 @@ QJsonObject*
 SWGChannelAnalyzerSettings::asJsonObject() {
     QJsonObject* obj = new QJsonObject();
     if(m_frequency_isSet){
-        obj->insert("frequency", QJsonValue(frequency));
+        obj->insert("inputFrequencyOffset", QJsonValue(frequency));
     }
     if(m_down_sample_isSet){
-        obj->insert("downSample", QJsonValue(down_sample));
+        obj->insert("rationalDownSample", QJsonValue(down_sample));
     }
     if(m_down_sample_rate_isSet){
-        obj->insert("downSampleRate", QJsonValue(down_sample_rate));
+        obj->insert("rationalDownSamplerRate", QJsonValue(down_sample_rate));
     }
     if(m_bandwidth_isSet){
         obj->insert("bandwidth", QJsonValue(bandwidth));


### PR DESCRIPTION
With this fix, corresponding settings updates are now properly communicated via reverse API.