### PR TITLE
sdrplayv3: use SDRPLAY_MAX_DEVICES in enumOriginDevices()

### DIFF
--- a/plugins/samplesource/sdrplayv3/sdrplayv3plugin.cpp
+++ b/plugins/samplesource/sdrplayv3/sdrplayv3plugin.cpp
@@ -96,7 +96,7 @@ void SDRPlayV3Plugin::enumOriginDevices(QStringList& listedHwIds, OriginDevices&
     sdrplay_api_LockDeviceApi();
 
     sdrplay_api_ErrT err;
-    sdrplay_api_DeviceT devs[6];
+    sdrplay_api_DeviceT devs[SDRPLAY_MAX_DEVICES];
     unsigned int count;
     if ((err = sdrplay_api_GetDevices(devs, &count, sizeof(devs) / sizeof(sdrplay_api_DeviceT))) == sdrplay_api_Success)
     {


### PR DESCRIPTION
Hi,

SDRPLAY_MAX_DEVICES is used in the API and also already in sdrplayv3input.h. Make it consistent.

Best,
Simon