### PR TITLE
Explain that GPS is not the only means to get the position of the station

### DIFF
--- a/sdrbase/maincore.cpp
+++ b/sdrbase/maincore.cpp
@@ -360,6 +360,7 @@ void MainCore::initPosition()
     m_positionSource = QGeoPositionInfoSource::createDefaultSource(this);
     if (m_positionSource)
     {
+        qDebug() << "MainCore::initPosition: Using position source" << m_positionSource->sourceName();
         connect(m_positionSource, &QGeoPositionInfoSource::positionUpdated, this, &MainCore::positionUpdated);
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         connect(m_positionSource, &QGeoPositionInfoSource::updateTimeout, this, &MainCore::positionUpdateTimeout);

--- a/sdrgui/gui/myposdialog.ui
+++ b/sdrgui/gui/myposdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>324</width>
-    <height>201</height>
+    <height>219</height>
    </rect>
   </property>
   <property name="font">
@@ -119,14 +119,14 @@
       <item row="4" column="0">
        <widget class="QLabel" name="autoUpdatePositionLabel">
         <property name="text">
-         <string>Auto-update from GPS</string>
+         <string>Auto-update position</string>
         </property>
        </widget>
       </item>
       <item row="1" column="2">
        <widget class="QToolButton" name="gps">
         <property name="toolTip">
-         <string>Set position using GPS (if available)</string>
+         <string>Set position now using GPS (or other means if available)</string>
         </property>
         <property name="text">
          <string/>


### PR DESCRIPTION
As written in #2107, the position can change also for a fixed computer, depending on the provider used, which isn't always a GPS (see https://doc.qt.io/qt-5/qtpositioning-index.html)

This PR:
* prints a debug message with the position provider in use (it was useful for me to understand who was providing a position that change unexpectedly, it is geoclue2 in my case on Linux)
* changes a label and a tooltip to tell that GPS is not the only source of information; since I was confused by the "satellite" button and by the auto-update checkbox, I added the word "now" to the tooltip.

The height of the dialog is updated automatically by Qt Creator.