### PR TITLE
Fix/sid memleaks

### DIFF
--- a/plugins/feature/sid/sidgui.cpp
+++ b/plugins/feature/sid/sidgui.cpp
@@ -300,15 +300,18 @@ SIDGUI::~SIDGUI()
     disconnectDataUpdates();
     if (m_grb) {
         disconnect(m_grb, &GRB::dataUpdated, this, &SIDGUI::grbDataUpdated);
+        delete m_grb;
     }
     if (m_stix) {
         disconnect(m_stix, &STIX::dataUpdated, this, &SIDGUI::stixDataUpdated);
+        delete m_stix;
     }
     m_statusTimer.stop();
 
     clearFromMap();
 
     delete m_goesXRay;
+    delete m_solarDynamicsObservatory;
     delete ui;
 }
 

--- a/plugins/feature/sid/sidgui.cpp
+++ b/plugins/feature/sid/sidgui.cpp
@@ -284,28 +284,9 @@ SIDGUI::SIDGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *featur
 
 SIDGUI::~SIDGUI()
 {
-    QObject::disconnect(ui->chartSplitter, &QSplitter::splitterMoved, this, &SIDGUI::chartSplitterMoved);
-    QObject::disconnect(ui->sdoSplitter, &QSplitter::splitterMoved, this, &SIDGUI::sdoSplitterMoved);
+    delete m_grb;
+    delete m_stix;
 
-    QObject::disconnect(&m_availableFeatureHandler,
-        &AvailableChannelOrFeatureHandler::channelsOrFeaturesChanged,
-        this,
-        &SIDGUI::featuresChanged
-    );
-    QObject::disconnect(&m_availableChannelHandler,
-        &AvailableChannelOrFeatureHandler::channelsOrFeaturesChanged,
-        this,
-        &SIDGUI::channelsChanged
-    );
-    disconnectDataUpdates();
-    if (m_grb) {
-        disconnect(m_grb, &GRB::dataUpdated, this, &SIDGUI::grbDataUpdated);
-        delete m_grb;
-    }
-    if (m_stix) {
-        disconnect(m_stix, &STIX::dataUpdated, this, &SIDGUI::stixDataUpdated);
-        delete m_stix;
-    }
     m_statusTimer.stop();
 
     clearFromMap();


### PR DESCRIPTION
This PR deletes some objects and removes some `disconnect()` that shouldn't be needed since all the objects that would receive the signals are destroyed.

Should I use `deleteLater()` instead?