### PR TITLE
Fix crash when quitting sdrangel when the SID window is open

### DIFF
--- a/plugins/feature/sid/sidgui.cpp
+++ b/plugins/feature/sid/sidgui.cpp
@@ -292,7 +292,11 @@ SIDGUI::~SIDGUI()
     clearFromMap();
 
     delete m_goesXRay;
-    delete m_solarDynamicsObservatory;
+    if (m_solarDynamicsObservatory)
+    {
+        delete m_player;
+        delete m_solarDynamicsObservatory;
+    }
     delete ui;
 }
 


### PR DESCRIPTION
Fixes a stack exhaustion that happens in some machines/compiler combinations.

Fixes #2119.

I'm adding a `if (m_solarDynamicsObservatory)` as in the constructor. 