### PR TITLE
Morse feature: Fix for Qt6 and Windows.

### DIFF
--- a/plugins/feature/morsedecoder/morsedecoderworker.cpp
+++ b/plugins/feature/morsedecoder/morsedecoderworker.cpp
@@ -188,7 +188,7 @@ int MorseDecoderWorker::processBuffer(QByteArray& bytesBuffer)
         std::for_each(
             dst.begin(),
             dst.end(),
-            [&](const uint8_t c) { text.append(c); }
+            [&](const uint8_t c) { text.append((char) c); }
         );
 
         const GGMorse::Statistics& stats = m_ggMorse->getStatistics();


### PR DESCRIPTION
Add cast in moredecoderworker.cpp to fix Qt6 build.

I've also added a pull request to GGMorse to fix the build on Windows. See: https://github.com/f4exb/ggmorse/pull/1
