### PR TITLE
Highlight the current workspace and device in their dialogs

### DIFF
--- a/sdrgui/channel/channelgui.cpp
+++ b/sdrgui/channel/channelgui.cpp
@@ -299,7 +299,7 @@ void ChannelGUI::showHelp()
 void ChannelGUI::openMoveToWorkspaceDialog()
 {
     int numberOfWorkspaces = MainWindow::getInstance()->getNumberOfWorkspaces();
-    WorkspaceSelectionDialog dialog(numberOfWorkspaces, this);
+    WorkspaceSelectionDialog dialog(numberOfWorkspaces, getWorkspaceIndex(), this);
     dialog.exec();
 
     if (dialog.hasChanged()) {

--- a/sdrgui/device/devicegui.cpp
+++ b/sdrgui/device/devicegui.cpp
@@ -370,7 +370,7 @@ void DeviceGUI::showHelp()
 void DeviceGUI::openMoveToWorkspaceDialog()
 {
     int numberOfWorkspaces = MainWindow::getInstance()->getNumberOfWorkspaces();
-    WorkspaceSelectionDialog dialog(numberOfWorkspaces, this);
+    WorkspaceSelectionDialog dialog(numberOfWorkspaces, getWorkspaceIndex(), this);
     dialog.exec();
 
     if (dialog.hasChanged()) {

--- a/sdrgui/feature/featuregui.cpp
+++ b/sdrgui/feature/featuregui.cpp
@@ -250,7 +250,7 @@ void FeatureGUI::showHelp()
 void FeatureGUI::openMoveToWorkspaceDialog()
 {
     int numberOfWorkspaces = MainWindow::getInstance()->getNumberOfWorkspaces();
-    WorkspaceSelectionDialog dialog(numberOfWorkspaces, this);
+    WorkspaceSelectionDialog dialog(numberOfWorkspaces, getWorkspaceIndex(), this);
     dialog.exec();
 
     if (dialog.hasChanged()) {

--- a/sdrgui/gui/devicesetselectiondialog.cpp
+++ b/sdrgui/gui/devicesetselectiondialog.cpp
@@ -52,6 +52,7 @@ DeviceSetSelectionDialog::DeviceSetSelectionDialog(std::vector<DeviceUISet*>& de
             m_deviceSetIndexes.push_back(i);
         }
     }
+    selectIndex(channelDeviceSetIndex);
 }
 
 DeviceSetSelectionDialog::~DeviceSetSelectionDialog()
@@ -64,4 +65,15 @@ void DeviceSetSelectionDialog::accept()
     m_selectedDeviceSetIndex = m_deviceSetIndexes[ui->workspaceList->currentRow()];
     m_hasChanged = true;
     QDialog::accept();
+}
+
+void DeviceSetSelectionDialog::selectIndex(int channelDeviceSetIndex)
+{
+    for (int i = 0; i < (int) m_deviceSetIndexes.size(); i++)
+    {
+        if (channelDeviceSetIndex == m_deviceSetIndexes[i]) {
+            ui->workspaceList->setCurrentRow(i);
+            break;
+        }
+    }
 }

--- a/sdrgui/gui/devicesetselectiondialog.h
+++ b/sdrgui/gui/devicesetselectiondialog.h
@@ -40,6 +40,7 @@ public:
 
     bool hasChanged() const { return m_hasChanged; }
     int getSelectedIndex() const { return m_selectedDeviceSetIndex; }
+    void selectIndex(int channelDeviceSetIndex);
 
 private:
     Ui::WorkspaceSelectionDialog *ui;

--- a/sdrgui/gui/workspaceselectiondialog.cpp
+++ b/sdrgui/gui/workspaceselectiondialog.cpp
@@ -23,7 +23,7 @@
 #include "workspaceselectiondialog.h"
 #include "ui_workspaceselectiondialog.h"
 
-WorkspaceSelectionDialog::WorkspaceSelectionDialog(int numberOfWorkspaces, QWidget *parent) :
+WorkspaceSelectionDialog::WorkspaceSelectionDialog(int numberOfWorkspaces, int workspaceIndex, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::WorkspaceSelectionDialog),
     m_numberOfWorkspaces(numberOfWorkspaces),
@@ -34,6 +34,7 @@ WorkspaceSelectionDialog::WorkspaceSelectionDialog(int numberOfWorkspaces, QWidg
     for (int i = 0; i < m_numberOfWorkspaces; i++) {
         ui->workspaceList->addItem(tr("W:%1").arg(i));
     }
+    ui->workspaceList->setCurrentRow(workspaceIndex);
 }
 
 WorkspaceSelectionDialog::~WorkspaceSelectionDialog()

--- a/sdrgui/gui/workspaceselectiondialog.h
+++ b/sdrgui/gui/workspaceselectiondialog.h
@@ -33,7 +33,7 @@ class SDRGUI_API WorkspaceSelectionDialog : public QDialog
 {
     Q_OBJECT
 public:
-    explicit WorkspaceSelectionDialog(int numberOfWorkspaces, QWidget *parent = nullptr);
+    explicit WorkspaceSelectionDialog(int numberOfWorkspaces, int workspaceIndex, QWidget *parent = nullptr);
     ~WorkspaceSelectionDialog();
 
     bool hasChanged() const { return m_hasChanged; }

--- a/sdrgui/mainspectrum/mainspectrumgui.cpp
+++ b/sdrgui/mainspectrum/mainspectrumgui.cpp
@@ -257,7 +257,7 @@ void MainSpectrumGUI::showHelp()
 void MainSpectrumGUI::openMoveToWorkspaceDialog()
 {
     int numberOfWorkspaces = MainWindow::getInstance()->getNumberOfWorkspaces();
-    WorkspaceSelectionDialog dialog(numberOfWorkspaces, this);
+    WorkspaceSelectionDialog dialog(numberOfWorkspaces, getWorkspaceIndex(), this);
     dialog.exec();
 
     if (dialog.hasChanged()) {


### PR DESCRIPTION
This PR proposes two changes:
* when opening the workspace selection dialog, select the current workspace in the list of workspaces 
* when opening the device selection dialog, select the current device in the list of devices
