### PR TITLE
Fix heap-use-after-free

### DIFF
--- a/plugins/samplesink/audiooutput/audiooutput.cpp
+++ b/plugins/samplesink/audiooutput/audiooutput.cpp
@@ -218,7 +218,6 @@ void AudioOutput::applySettings(const AudioOutputSettings& settings, const QList
         m_audioDeviceIndex = audioDeviceManager->getOutputDeviceIndex(settings.m_deviceName);
         //qDebug("AMDemod::applySettings: audioDeviceName: %s audioDeviceIndex: %d", qPrintable(settings.m_audioDeviceName), audioDeviceIndex);
         audioDeviceManager->removeAudioSink(&m_audioFifo);
-        audioDeviceManager->addAudioSink(&m_audioFifo, getInputMessageQueue(), m_audioDeviceIndex);
         m_sampleRate = audioDeviceManager->getOutputSampleRate(m_audioDeviceIndex);
         forwardChange = true;
     }

--- a/plugins/samplesource/audioinput/audioinput.cpp
+++ b/plugins/samplesource/audioinput/audioinput.cpp
@@ -251,7 +251,6 @@ void AudioInput::applySettings(const AudioInputSettings& settings, QList<QString
         }
 
         audioDeviceManager->removeAudioSource(&m_fifo);
-        audioDeviceManager->addAudioSource(&m_fifo, getInputMessageQueue(), m_audioDeviceIndex);
         m_sampleRate = audioDeviceManager->getInputSampleRate(m_audioDeviceIndex);
         qDebug("AudioInput::applySettings: audioDeviceName: %s audioDeviceIndex: %d sampleRate: %d",
             qPrintable(settings.m_deviceName), m_audioDeviceIndex, m_sampleRate);


### PR DESCRIPTION
This PR fixes issue #2059 but breaks the device pulldown because when changing the current device it doesn't add the new one.

AddressSanitizer: heap-use-after-free /home/sdrangel/sdrbase/audio/audiofifo.cpp:80 in AudioFifo::write(unsigned char const*, unsigned int) AddressSanitizer: heap-use-after-free /home/sdrangel/sdrbase/audio/audiofifo.h:49 in AudioFifo::fill() const

I tested the audio input with my radio and a websdr and the audio output only with the loudspeakers.

