### PR TITLE
Rename some input devices for consistency

### DIFF
--- a/plugins/samplesource/aaroniartsainput/aaroniartsainputplugin.cpp
+++ b/plugins/samplesource/aaroniartsainput/aaroniartsainputplugin.cpp
@@ -65,7 +65,7 @@ void AaroniaRTSAInputPlugin::enumOriginDevices(QStringList& listedHwIds, OriginD
     }
 
     originDevices.append(OriginDevice(
-        "AaroniaRTSA",
+        "AaroniaRTSAInput",
         m_hardwareID,
         QString(),
         0,

--- a/plugins/samplesource/audioinput/audioinputplugin.cpp
+++ b/plugins/samplesource/audioinput/audioinputplugin.cpp
@@ -67,7 +67,7 @@ void AudioInputPlugin::enumOriginDevices(QStringList& listedHwIds, OriginDevices
     // but I thought it makes it simpler to switch between inputs
     // if they are in the AudioInput GUI
     originDevices.append(OriginDevice(
-        "Audio",
+        "AudioInput",
         m_hardwareID,
         "0",
         0,


### PR DESCRIPTION
Many other device pairs have names ending with Input/Output:
    "AaroniaRTSA",
    "AaroniaRTSAOutput",
    "Android SDR Driver",
    "AudioCATSISO",
    "Audio",
    "AudioOutput",
    "FileInput",
    "FileOutput",
    "KiwiSDR",
    "LocalInput",
    "LocalOutput",
    "RemoteInput",
    "RemoteOutput",
    "RemoteTCPInput",
    "SigMFFileInput",
    "TestMI",
    "TestMOSync",
    "TestSink",
    "TestSource",
