### PR TITLE
Remove extra margins from some dialogs

### DIFF
--- a/sdrgui/gui/configurationsdialog.ui
+++ b/sdrgui/gui/configurationsdialog.ui
@@ -23,6 +23,18 @@
    <item>
     <widget class="QWidget" name="widget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <widget class="QLabel" name="description">
         <property name="text">

--- a/sdrgui/gui/featurepresetsdialog.ui
+++ b/sdrgui/gui/featurepresetsdialog.ui
@@ -35,6 +35,18 @@
       </sizepolicy>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <widget class="QTreeWidget" name="presetsTree">
         <property name="indentation">

--- a/sdrgui/gui/pluginpresetsdialog.ui
+++ b/sdrgui/gui/pluginpresetsdialog.ui
@@ -35,6 +35,18 @@
       </sizepolicy>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <widget class="QTreeWidget" name="presetsTree">
         <property name="indentation">


### PR DESCRIPTION
This PR aligns the left and right sides of QTreeWidget to the buttons below it, similar to other dialogs.

Before this PR:
![image](https://github.com/f4exb/sdrangel/assets/1055635/117eded9-b7d1-4758-b709-83b71bca5d9e)
![image](https://github.com/f4exb/sdrangel/assets/1055635/462e2f66-d32e-4330-acbb-4e7fb90581e4)
![image](https://github.com/f4exb/sdrangel/assets/1055635/b4b4a683-3fdb-4d21-b2ca-0e231f50b7f2)

After this PR:
![image](https://github.com/f4exb/sdrangel/assets/1055635/a5921560-a7d5-4bd2-94cb-3ef6e899c03d)
![image](https://github.com/f4exb/sdrangel/assets/1055635/b94ae2d5-c3e4-4340-9c7f-08a08daa7daa)
![image](https://github.com/f4exb/sdrangel/assets/1055635/a1742c82-bfa1-4967-aa13-5af20964f293)

They become more similar to this:
![image](https://github.com/f4exb/sdrangel/assets/1055635/7dc6aadf-537d-43a2-ab00-00d22521b137)

