### PR TITLE
Fix tooltips

### DIFF
--- a/plugins/channelrx/demodendoftrain/endoftraindemodgui.ui
+++ b/plugins/channelrx/demodendoftrain/endoftraindemodgui.ui
@@ -628,7 +628,7 @@
     <item>
      <widget class="QTableWidget" name="packets">
       <property name="toolTip">
-       <string/>
+       <string>Received packets</string>
       </property>
       <property name="editTriggers">
        <set>QAbstractItemView::NoEditTriggers</set>

--- a/plugins/channelrx/demodfreedv/freedvdemodgui.ui
+++ b/plugins/channelrx/demodfreedv/freedvdemodgui.ui
@@ -255,7 +255,7 @@
          </font>
         </property>
         <property name="toolTip">
-         <string>Channel power</string>
+         <string>Level meter (dB) top trace: average, bottom trace: instantaneous peak, tip: peak hold</string>
         </property>
        </widget>
       </item>

--- a/plugins/channelrx/demodm17/m17demodgui.ui
+++ b/plugins/channelrx/demodm17/m17demodgui.ui
@@ -841,7 +841,7 @@
       </property>
       <widget class="QWidget" name="settingsTab">
        <property name="toolTip">
-        <string>Dgital Settings</string>
+        <string>Digital settings</string>
        </property>
        <attribute name="icon">
         <iconset resource="../../../sdrgui/resources/res.qrc">

--- a/plugins/channelrx/demodssb/ssbdemodgui.ui
+++ b/plugins/channelrx/demodssb/ssbdemodgui.ui
@@ -215,7 +215,7 @@
         <item>
          <widget class="QPushButton" name="flipSidebands">
           <property name="toolTip">
-           <string>Flip sideband in SSB mode (LSB-&gt;USB or USB-&gt;LSB)</string>
+           <string>Flip sidebands in SSB mode (LSB-&gt;USB or USB-&gt;LSB)</string>
           </property>
           <property name="text">
            <string/>

--- a/plugins/channelrx/demodwfm/wfmdemodgui.ui
+++ b/plugins/channelrx/demodwfm/wfmdemodgui.ui
@@ -200,7 +200,7 @@
          </font>
         </property>
         <property name="toolTip">
-         <string>channelPowerMeterUnits</string>
+         <string>Level meter (dB) top trace: average, bottom trace: instantaneous peak, tip: peak hold</string>
         </property>
        </widget>
       </item>

--- a/plugins/channelrx/noisefigure/noisefiguregui.ui
+++ b/plugins/channelrx/noisefigure/noisefiguregui.ui
@@ -887,7 +887,7 @@
        </size>
       </property>
       <property name="toolTip">
-       <string/>
+       <string>Chart</string>
       </property>
      </widget>
     </item>

--- a/plugins/channelrx/radioastronomy/radioastronomygui.ui
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.ui
@@ -2138,7 +2138,7 @@ This should be 2.73K when pointing at the sky</string>
        </size>
       </property>
       <property name="toolTip">
-       <string/>
+       <string>Spectrum chart</string>
       </property>
      </widget>
     </item>
@@ -3768,7 +3768,7 @@ This should be close to the expected difference in power between hot and cold ca
        </size>
       </property>
       <property name="toolTip">
-       <string/>
+       <string>Power chart</string>
       </property>
      </widget>
     </item>
@@ -4915,7 +4915,7 @@ This should be close to the expected difference in power between hot and cold ca
     <item>
      <widget class="QTableWidget" name="powerTable">
       <property name="toolTip">
-       <string/>
+       <string>Power table</string>
       </property>
       <property name="editTriggers">
        <set>QAbstractItemView::NoEditTriggers</set>

--- a/plugins/channelrx/radioastronomy/radioastronomygui.ui
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.ui
@@ -889,7 +889,7 @@ This should be 2.73K when pointing at the sky</string>
       <item>
        <widget class="QDoubleSpinBox" name="tempAir">
         <property name="toolTip">
-         <string>Surface air temperature in degrees celsius</string>
+         <string>Surface air temperature in degrees Celsius</string>
         </property>
         <property name="decimals">
          <number>0</number>

--- a/plugins/channelrx/radioclock/radioclockgui.ui
+++ b/plugins/channelrx/radioclock/radioclockgui.ui
@@ -593,7 +593,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Demodulator status</string>
+         <string>Daylight savings time status</string>
         </property>
         <property name="text">
          <string/>

--- a/plugins/channeltx/filesource/filesourcegui.ui
+++ b/plugins/channeltx/filesource/filesourcegui.ui
@@ -541,7 +541,7 @@
       <item>
        <widget class="ButtonSwitch" name="playLoop">
         <property name="toolTip">
-         <string>Play in a loop</string>
+         <string>Play file in a loop</string>
         </property>
         <property name="text">
          <string/>

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_modtxsettingsdialog.ui
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_modtxsettingsdialog.ui
@@ -49,7 +49,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="modulation">
         <property name="toolTip">
-         <string>Modulaton type.</string>
+         <string>Modulation type</string>
         </property>
         <item>
          <property name="text">

--- a/plugins/channeltx/modpacket/packetmodtxsettingsdialog.ui
+++ b/plugins/channeltx/modpacket/packetmodtxsettingsdialog.ui
@@ -150,7 +150,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="modulation">
         <property name="toolTip">
-         <string>Modulaton type.</string>
+         <string>Modulation type</string>
         </property>
         <item>
          <property name="text">

--- a/plugins/feature/antennatools/antennatoolsgui.ui
+++ b/plugins/feature/antennatools/antennatoolsgui.ui
@@ -74,6 +74,9 @@
          <height>0</height>
         </size>
        </property>
+       <property name="toolTip">
+        <string>Source for frequency value</string>
+       </property>
        <item>
         <property name="text">
          <string>MHz</string>
@@ -271,7 +274,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string/>
+        <string>Source for frequency value</string>
        </property>
        <item>
         <property name="text">

--- a/plugins/feature/demodanalyzer/demodanalyzergui.ui
+++ b/plugins/feature/demodanalyzer/demodanalyzergui.ui
@@ -302,7 +302,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Silence time (s) before recording is stopoed. 0 for continuous recording.</string>
+         <string>Silence time (s) before recording is stopped. 0 for continuous recording.</string>
         </property>
         <property name="minimum">
          <number>0</number>
@@ -330,7 +330,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Silence time (s) before recording is stopoed</string>
+         <string>Silence time (s) before recording is stopped</string>
         </property>
         <property name="text">
          <string>10.0</string>

--- a/plugins/feature/map/mapbeacondialog.ui
+++ b/plugins/feature/map/mapbeacondialog.ui
@@ -112,7 +112,7 @@
       <item>
        <widget class="QTableWidget" name="beacons">
         <property name="toolTip">
-         <string/>
+         <string>Displays which beacon is transmitting on which frequency</string>
         </property>
         <column>
          <property name="text">

--- a/plugins/feature/map/mapradiotimedialog.ui
+++ b/plugins/feature/map/mapradiotimedialog.ui
@@ -46,7 +46,7 @@
       <item>
        <widget class="QTableWidget" name="transmitters">
         <property name="toolTip">
-         <string/>
+         <string>Transmitters table</string>
         </property>
         <column>
          <property name="text">

--- a/plugins/samplemimo/audiocatsiso/audiocatsisocatdialog.ui
+++ b/plugins/samplemimo/audiocatsiso/audiocatsisocatdialog.ui
@@ -29,7 +29,7 @@
       <item row="1" column="3">
        <widget class="QComboBox" name="stopBits">
         <property name="toolTip">
-         <string>Modulaton type.</string>
+         <string>Number of stop bits</string>
         </property>
         <item>
          <property name="text">
@@ -46,7 +46,7 @@
       <item row="0" column="3">
        <widget class="QComboBox" name="handshake">
         <property name="toolTip">
-         <string>Modulaton type.</string>
+         <string>Handshake type</string>
         </property>
         <item>
          <property name="text">
@@ -68,7 +68,7 @@
       <item row="1" column="1">
        <widget class="QComboBox" name="dataBits">
         <property name="toolTip">
-         <string>Modulaton type.</string>
+         <string>Number of data bits</string>
         </property>
         <item>
          <property name="text">
@@ -106,7 +106,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="baudRate">
         <property name="toolTip">
-         <string>Modulaton type.</string>
+         <string>Baud rate</string>
         </property>
         <item>
          <property name="text">
@@ -169,7 +169,7 @@
       <item row="1" column="3">
        <widget class="QComboBox" name="rtsHigh">
         <property name="toolTip">
-         <string>Modulaton type.</string>
+         <string>Level of RTS that triggers PTT when CAT method is set to RTS</string>
         </property>
         <item>
          <property name="text">
@@ -186,7 +186,7 @@
       <item row="1" column="1">
        <widget class="QComboBox" name="dtrHigh">
         <property name="toolTip">
-         <string>Modulaton type.</string>
+         <string>Level of DTR that triggers PTT when CAT method is set to DTR</string>
         </property>
         <item>
          <property name="text">
@@ -217,7 +217,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="pttMethod">
         <property name="toolTip">
-         <string>Modulaton type.</string>
+         <string>PTT method</string>
         </property>
         <item>
          <property name="text">

--- a/plugins/samplemimo/limesdrmimo/limesdrmimogui.ui
+++ b/plugins/samplemimo/limesdrmimo/limesdrmimogui.ui
@@ -739,7 +739,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Analog lowpass filer bandwidth (kHz)</string>
+        <string>Analog lowpass filter bandwidth (kHz)</string>
        </property>
       </widget>
      </item>
@@ -797,7 +797,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Digital FIR lowpass filers bandwidth (kHz)</string>
+        <string>Digital FIR lowpass filters bandwidth (kHz)</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplemimo/plutosdrmimo/plutosdrmimogui.ui
+++ b/plugins/samplemimo/plutosdrmimo/plutosdrmimogui.ui
@@ -857,7 +857,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Analog lowpass filer bandwidth (kHz)</string>
+        <string>Analog lowpass filter bandwidth (kHz)</string>
        </property>
       </widget>
      </item>
@@ -919,7 +919,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Digital FIR lowpass filers bandwidth (kHz) @ ~-6dB</string>
+        <string>Digital FIR lowpass filters bandwidth (kHz) @ ~-6dB</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplemimo/xtrxmimo/xtrxmimogui.ui
+++ b/plugins/samplemimo/xtrxmimo/xtrxmimogui.ui
@@ -744,7 +744,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Analog lowpass filer bandwidth (kHz)</string>
+        <string>Analog lowpass filter bandwidth (kHz)</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplesink/limesdroutput/limesdroutputgui.ui
+++ b/plugins/samplesink/limesdroutput/limesdroutputgui.ui
@@ -552,7 +552,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Analog lowpass filer bandwidth (kHz)</string>
+        <string>Analog lowpass filter bandwidth (kHz)</string>
        </property>
       </widget>
      </item>
@@ -610,7 +610,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Digital FIR lowpass filers bandwidth (kHz)</string>
+        <string>Digital FIR lowpass filters bandwidth (kHz)</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplesink/plutosdroutput/plutosdroutputgui.ui
+++ b/plugins/samplesink/plutosdroutput/plutosdroutputgui.ui
@@ -496,7 +496,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Analog lowpass filer bandwidth (kHz)</string>
+        <string>Analog lowpass filter bandwidth (kHz)</string>
        </property>
       </widget>
      </item>
@@ -558,7 +558,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Digital FIR lowpass filers bandwidth (kHz) @ ~-6dB</string>
+        <string>Digital FIR lowpass filters bandwidth (kHz) @ ~-6dB</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplesink/usrpoutput/usrpoutputgui.ui
+++ b/plugins/samplesink/usrpoutput/usrpoutputgui.ui
@@ -574,7 +574,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Analog lowpass filer bandwidth (kHz)</string>
+        <string>Analog lowpass filter bandwidth (kHz)</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplesink/xtrxoutput/xtrxoutputgui.ui
+++ b/plugins/samplesink/xtrxoutput/xtrxoutputgui.ui
@@ -558,7 +558,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Analog lowpass filer bandwidth (kHz)</string>
+        <string>Analog lowpass filter bandwidth (kHz)</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplesource/airspyhf/airspyhfgui.ui
+++ b/plugins/samplesource/airspyhf/airspyhfgui.ui
@@ -217,7 +217,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Rest LO ppm correction</string>
+        <string>Reset LO ppm correction</string>
        </property>
        <property name="text">
         <string>R</string>

--- a/plugins/samplesource/fileinput/fileinputgui.ui
+++ b/plugins/samplesource/fileinput/fileinputgui.ui
@@ -374,7 +374,7 @@
      <item>
       <widget class="ButtonSwitch" name="playLoop">
        <property name="toolTip">
-        <string>Play in a loop</string>
+        <string>Play file in a loop</string>
        </property>
        <property name="text">
         <string/>

--- a/plugins/samplesource/fileinput/fileinputgui.ui
+++ b/plugins/samplesource/fileinput/fileinputgui.ui
@@ -134,6 +134,9 @@
          <bold>false</bold>
         </font>
        </property>
+       <property name="toolTip">
+        <string>Record center frequency in Hz</string>
+       </property>
        <property name="text">
         <string>10,000,000,000</string>
        </property>

--- a/plugins/samplesource/limesdrinput/limesdrinputgui.ui
+++ b/plugins/samplesource/limesdrinput/limesdrinputgui.ui
@@ -569,7 +569,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Analog lowpass filer bandwidth (kHz)</string>
+        <string>Analog lowpass filter bandwidth (kHz)</string>
        </property>
       </widget>
      </item>
@@ -627,7 +627,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Digital FIR lowpass filers bandwidth (kHz)</string>
+        <string>Digital FIR lowpass filters bandwidth (kHz)</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplesource/perseus/perseusgui.ui
+++ b/plugins/samplesource/perseus/perseusgui.ui
@@ -220,7 +220,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Rest LO ppm correction</string>
+        <string>Reset LO ppm correction</string>
        </property>
        <property name="text">
         <string>R</string>

--- a/plugins/samplesource/plutosdrinput/plutosdrinputgui.ui
+++ b/plugins/samplesource/plutosdrinput/plutosdrinputgui.ui
@@ -672,7 +672,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Analog lowpass filer bandwidth (kHz)</string>
+        <string>Analog lowpass filter bandwidth (kHz)</string>
        </property>
       </widget>
      </item>
@@ -734,7 +734,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Digital FIR lowpass filers bandwidth (kHz) @ ~-6dB</string>
+        <string>Digital FIR lowpass filters bandwidth (kHz) @ ~-6dB</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplesource/remoteinput/remoteinputgui.ui
+++ b/plugins/samplesource/remoteinput/remoteinputgui.ui
@@ -212,7 +212,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Remote device center ferquency in kHz</string>
+        <string>Remote device center frequency in kHz</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplesource/usrpinput/usrpinputgui.ui
+++ b/plugins/samplesource/usrpinput/usrpinputgui.ui
@@ -622,7 +622,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Analog lowpass filer bandwidth (kHz)</string>
+        <string>Analog lowpass filter bandwidth (kHz)</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplesource/xtrxinput/xtrxinputgui.ui
+++ b/plugins/samplesource/xtrxinput/xtrxinputgui.ui
@@ -578,7 +578,7 @@
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
        <property name="toolTip">
-        <string>Analog lowpass filer bandwidth (kHz)</string>
+        <string>Analog lowpass filter bandwidth (kHz)</string>
        </property>
       </widget>
      </item>

--- a/sdrgui/gui/audiodialog.ui
+++ b/sdrgui/gui/audiodialog.ui
@@ -184,7 +184,7 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>Decimation</string>
+            <string>Decimation factor</string>
            </property>
            <item>
             <property name="text">

--- a/sdrgui/gui/audiodialog.ui
+++ b/sdrgui/gui/audiodialog.ui
@@ -463,7 +463,7 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>Silence time (s) before recording is stopoed. 0 for continuous recording.</string>
+            <string>Silence time (s) before recording is stopped. 0 for continuous recording.</string>
            </property>
            <property name="minimum">
             <number>0</number>
@@ -491,7 +491,7 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>Silence time (s) before recording is stopoed</string>
+            <string>Silence time (s) before recording is stopped</string>
            </property>
            <property name="text">
             <string>10.0</string>

--- a/sdrgui/gui/fftwisdomdialog.ui
+++ b/sdrgui/gui/fftwisdomdialog.ui
@@ -84,6 +84,9 @@
      </item>
      <item>
       <widget class="QComboBox" name="fftwMaxSize">
+       <property name="toolTip">
+        <string>FFT maximum size</string>
+       </property>
        <item>
         <property name="text">
          <string>128</string>

--- a/sdrgui/gui/fftwisdomdialog.ui
+++ b/sdrgui/gui/fftwisdomdialog.ui
@@ -41,7 +41,7 @@
      <item>
       <widget class="QLineEdit" name="executable">
        <property name="toolTip">
-        <string>Channel marker title</string>
+        <string>FFTW Wisdom program</string>
        </property>
       </widget>
      </item>
@@ -60,7 +60,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Open file</string>
+        <string>Choose file</string>
        </property>
        <property name="text">
         <string/>

--- a/sdrgui/gui/glscopegui.ui
+++ b/sdrgui/gui/glscopegui.ui
@@ -193,7 +193,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Display X and Y trances on top of each other</string>
+        <string>Display X and Y traces on top of each other</string>
        </property>
        <property name="text">
         <string>...</string>

--- a/sdrgui/gui/glscopegui.ui
+++ b/sdrgui/gui/glscopegui.ui
@@ -1115,7 +1115,7 @@ kS/s</string>
             </size>
            </property>
            <property name="toolTip">
-            <string>Vertical offset fine</string>
+            <string>Vertical offset exponent</string>
            </property>
            <property name="minimum">
             <number>-10</number>

--- a/sdrgui/gui/graphicsdialog.ui
+++ b/sdrgui/gui/graphicsdialog.ui
@@ -89,7 +89,7 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>Number of samples to use for mulitsampling anti-aliasing (MSAA) for spectrums
+           <string>Number of samples to use for multisampling anti-aliasing (MSAA) for spectrums
 
 Requires windows to be reopened to take effect</string>
           </property>
@@ -123,7 +123,7 @@ Requires windows to be reopened to take effect</string>
         <item row="1" column="0">
          <widget class="QLabel" name="mapMultisamplingLabel">
           <property name="toolTip">
-           <string>Number of samples to use for mulitsampling anti-aliasing (MSAA) for 2D maps
+           <string>Number of samples to use for multisampling anti-aliasing (MSAA) for 2D maps
 
 Requires windows to be reopened to take effect</string>
           </property>
@@ -135,7 +135,7 @@ Requires windows to be reopened to take effect</string>
         <item row="1" column="1">
          <widget class="QComboBox" name="mapMultisampling">
           <property name="toolTip">
-           <string>Number of samples to use for mulitsampling anti-aliasing (MSAA) for 2D Map
+           <string>Number of samples to use for multisampling anti-aliasing (MSAA) for 2D Map
 
 Requires windows to be reopened to take effect</string>
           </property>


### PR DESCRIPTION
This PS fixes some errors in tooltips, adds missing tooltips and changes some tooltips to be identical to others.

After this PR, all widgets should have a tooltip.

There may be some more tooltips to change to make them more uniform in this huge list of all 2609 tooltips: [tooltips.csv](https://github.com/user-attachments/files/15859943/tooltips.csv)
