### PR TITLE
Frequency scanner: Add scan results to channel report. Add run action to API. Add HF ATC.

### DIFF
--- a/plugins/channelrx/freqscanner/freqscanner.h
+++ b/plugins/channelrx/freqscanner/freqscanner.h
@@ -341,6 +341,11 @@ public:
             SWGSDRangel::SWGChannelReport& response,
             QString& errorMessage);
 
+    virtual int webapiActionsPost(
+            const QStringList& channelActionsKeys,
+            SWGSDRangel::SWGChannelActions& query,
+            QString& errorMessage);
+
     static void webapiFormatChannelSettings(
             SWGSDRangel::SWGChannelSettings& response,
             const FreqScannerSettings& settings);
@@ -388,6 +393,7 @@ private:
     qint64 m_stepStartFrequency;
     qint64 m_stepStopFrequency;
     QList<MsgScanResult::ScanResult> m_scanResults;
+    QList<MsgScanResult::ScanResult> m_scanResultsForReport;
 
     enum State {
         IDLE,

--- a/plugins/channelrx/freqscanner/freqscanneraddrangedialog.cpp
+++ b/plugins/channelrx/freqscanner/freqscanneraddrangedialog.cpp
@@ -91,6 +91,19 @@ void FreqScannerAddRangeDialog::accept()
         };
         m_frequencies.append(FRS_GMRSFreqs);
     }
+    else if (ui->preset->currentText() == "HF ATC")
+    {
+        static const QList<qint64> hfFreqs = {
+            2872000, 2890000, 2899000, 2971000,
+            3016000, 3446000, 3476000, 3491000,
+            4675000, 5598000, 5616000, 5649000,
+            6547000, 6595000, 6622000, 6667000,
+            8831000, 8864000, 8879000, 8891000,
+            8906000, 10021000, 11336000, 13291000,
+            13306000, 17946000
+        };
+        m_frequencies.append(hfFreqs);
+    }
     else
     {
         qint64 start = ui->start->getValue();
@@ -148,6 +161,10 @@ void FreqScannerAddRangeDialog::on_preset_currentTextChanged(const QString& text
         enableManAdjust = false;
     }
     else if (text == "FRS-GMRS")
+    {
+        enableManAdjust = false;
+    }
+    else if (text == "HF ATC")
     {
         enableManAdjust = false;
     }

--- a/plugins/channelrx/freqscanner/freqscanneraddrangedialog.ui
+++ b/plugins/channelrx/freqscanner/freqscanneraddrangedialog.ui
@@ -198,6 +198,11 @@
           <string>FRS-GMRS</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>HF ATC</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item row="0" column="0">
@@ -232,7 +237,6 @@
  </customwidgets>
  <resources>
   <include location="../../../sdrgui/resources/res.qrc"/>
-  <include location="../demodapt/icons.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/plugins/channelrx/freqscanner/freqscannergui.cpp
+++ b/plugins/channelrx/freqscanner/freqscannergui.cpp
@@ -204,6 +204,16 @@ bool FreqScannerGUI::handleMessage(const Message& message)
 
         return true;
     }
+    else if (FreqScanner::MsgStartScan::match(message))
+    {
+        ui->startStop->doToggle(true);
+        return true;
+    }
+    else if (FreqScanner::MsgStopScan::match(message))
+    {
+        ui->startStop->doToggle(false);
+        return true;
+    }
     return false;
 }
 
@@ -609,7 +619,7 @@ void FreqScannerGUI::enterEvent(EnterEventType* event)
     ChannelGUI::enterEvent(event);
 }
 
-void FreqScannerGUI::on_startStop_clicked(bool checked)
+void FreqScannerGUI::on_startStop_toggled(bool checked)
 {
     if (checked)
     {
@@ -1080,7 +1090,7 @@ void FreqScannerGUI::makeUIConnections()
     QObject::connect(ui->priority, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &FreqScannerGUI::on_priority_currentIndexChanged);
     QObject::connect(ui->measurement, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &FreqScannerGUI::on_measurement_currentIndexChanged);
     QObject::connect(ui->mode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &FreqScannerGUI::on_mode_currentIndexChanged);
-    QObject::connect(ui->startStop, &ButtonSwitch::clicked, this, &FreqScannerGUI::on_startStop_clicked);
+    QObject::connect(ui->startStop, &ButtonSwitch::toggled, this, &FreqScannerGUI::on_startStop_toggled);
     QObject::connect(ui->table, &QTableWidget::cellChanged, this, &FreqScannerGUI::on_table_cellChanged);
     QObject::connect(ui->addSingle, &QToolButton::clicked, this, &FreqScannerGUI::on_addSingle_clicked);
     QObject::connect(ui->addRange, &QToolButton::clicked, this, &FreqScannerGUI::on_addRange_clicked);

--- a/plugins/channelrx/freqscanner/freqscannergui.h
+++ b/plugins/channelrx/freqscanner/freqscannergui.h
@@ -140,7 +140,7 @@ private slots:
     void table_sectionResized(int logicalIndex, int oldSize, int newSize);
     void columnSelectMenu(QPoint pos);
     void columnSelectMenuChecked(bool checked = false);
-    void on_startStop_clicked(bool checked = false);
+    void on_startStop_toggled(bool checked = false);
     void on_addSingle_clicked();
     void on_addRange_clicked();
     void on_remove_clicked();

--- a/plugins/channelrx/freqscanner/readme.md
+++ b/plugins/channelrx/freqscanner/readme.md
@@ -140,3 +140,15 @@ Moves the selected rows the the frequency table (14).
 <h3>21: Clear Active Count</h3>
 
 Press to reset the value in the Active Count column to 0 for all rows.
+
+<h2>API</h2>
+
+Full details of the API can be found in the Swagger documentation. Below are a few examples.
+
+To run a frequency scan:
+
+    curl -X POST "http://127.0.0.1:8091/sdrangel/deviceset/0/channel/0/actions" -d '{  "channelType": "FreqScanner",  "direction": 0,  "originatorDeviceSetIndex": 0,  "originatorChannelIndex": 0,  "FreqScannerActions": { "run": 1 }}'
+
+To get the results of the last scan:
+
+   curl -X GET "http://127.0.0.1:8091/sdrangel/deviceset/0/channel/0/report"

--- a/sdrbase/resources/webapi/doc/html2/index.html
+++ b/sdrbase/resources/webapi/doc/html2/index.html
@@ -7278,6 +7278,10 @@ margin-bottom: 20px;
     "channelSampleRate" : {
       "type" : "integer"
     },
+    "scanState" : {
+      "type" : "integer",
+      "description" : "(IDLE=0, START_SCAN=1, SCANNING=2, WAIT_FOR_END_TX=3, WAIT_FOR_RETRANSMISSION=4)"
+    },
     "channelState" : {
       "type" : "array",
       "items" : {
@@ -59115,7 +59119,7 @@ except ApiException as e:
           </div>
           <div id="generator">
             <div class="content">
-              Generated 2024-06-21T10:02:32.986+02:00
+              Generated 2024-06-21T11:03:53.536+02:00
             </div>
           </div>
       </div>

--- a/sdrbase/resources/webapi/doc/html2/index.html
+++ b/sdrbase/resources/webapi/doc/html2/index.html
@@ -3598,6 +3598,9 @@ margin-bottom: 20px;
     "FileSourceActions" : {
       "$ref" : "#/definitions/FileSourceActions"
     },
+    "FreqScannerActions" : {
+      "$ref" : "#/definitions/FreqScannerActions"
+    },
     "IEEE_802_15_4_ModActions" : {
       "$ref" : "#/definitions/IEEE_802_15_4_ModActions"
     },
@@ -7222,6 +7225,28 @@ margin-bottom: 20px;
   },
   "description" : "FreeDVMod"
 };
+            defs.FreqScannerActions = {
+  "properties" : {
+    "run" : {
+      "type" : "integer",
+      "description" : "Set the plugin running state\n  * 0 - idle\n  * 1 - run\n"
+    }
+  },
+  "description" : "Frequency Scanner actions"
+};
+            defs.FreqScannerChannelState = {
+  "properties" : {
+    "frequency" : {
+      "type" : "integer",
+      "description" : "Channel centre frequency in Hz"
+    },
+    "power" : {
+      "type" : "number",
+      "format" : "float",
+      "description" : "Channel power in dB"
+    }
+  }
+};
             defs.FreqScannerFrequency = {
   "properties" : {
     "frequency" : {
@@ -7252,6 +7277,12 @@ margin-bottom: 20px;
   "properties" : {
     "channelSampleRate" : {
       "type" : "integer"
+    },
+    "channelState" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/FreqScannerChannelState"
+      }
     }
   },
   "description" : "FreqScanner"
@@ -59084,7 +59115,7 @@ except ApiException as e:
           </div>
           <div id="generator">
             <div class="content">
-              Generated 2024-06-18T10:11:11.522+02:00
+              Generated 2024-06-21T10:02:32.986+02:00
             </div>
           </div>
       </div>

--- a/sdrbase/resources/webapi/doc/swagger/include/ChannelActions.yaml
+++ b/sdrbase/resources/webapi/doc/swagger/include/ChannelActions.yaml
@@ -25,6 +25,8 @@ ChannelActions:
       $ref: "/doc/swagger/include/FileSink.yaml#/FileSinkActions"
     FileSourceActions:
       $ref: "/doc/swagger/include/FileSource.yaml#/FileSourceActions"
+    FreqScannerActions:
+      $ref: "/doc/swagger/include/FreqScanner.yaml#/FreqScannerActions"
     IEEE_802_15_4_ModActions:
       $ref: "/doc/swagger/include/IEEE_802_15_4_Mod.yaml#/IEEE_802_15_4_ModActions"
     PacketModActions:

--- a/sdrbase/resources/webapi/doc/swagger/include/FreqScanner.yaml
+++ b/sdrbase/resources/webapi/doc/swagger/include/FreqScanner.yaml
@@ -59,6 +59,20 @@ FreqScannerReport:
   properties:
     channelSampleRate:
       type: integer
+    channelState:
+      type: array
+      items:
+        $ref: "/doc/swagger/include/FreqScanner.yaml#/FreqScannerChannelState"
+
+FreqScannerChannelState:
+  properties:
+    frequency:
+      description: "Channel centre frequency in Hz"
+      type: integer
+    power:
+      description: "Channel power in dB"
+      type: number
+      format: float
 
 FreqScannerFrequency:
   properties:
@@ -77,3 +91,13 @@ FreqScannerFrequency:
       type: string
     squelch:
       type: string
+
+FreqScannerActions:
+  description: "Frequency Scanner actions"
+  properties:
+    run:
+      type: integer
+      description: >
+        Set the plugin running state
+          * 0 - idle
+          * 1 - run

--- a/sdrbase/resources/webapi/doc/swagger/include/FreqScanner.yaml
+++ b/sdrbase/resources/webapi/doc/swagger/include/FreqScanner.yaml
@@ -59,6 +59,9 @@ FreqScannerReport:
   properties:
     channelSampleRate:
       type: integer
+    scanState:
+      description: (IDLE=0, START_SCAN=1, SCANNING=2, WAIT_FOR_END_TX=3, WAIT_FOR_RETRANSMISSION=4)
+      type: integer
     channelState:
       type: array
       items:

--- a/sdrbase/webapi/webapirequestmapper.cpp
+++ b/sdrbase/webapi/webapirequestmapper.cpp
@@ -4821,6 +4821,11 @@ bool WebAPIRequestMapper::getChannelActions(
             channelActions->setFileSourceActions(new SWGSDRangel::SWGFileSourceActions());
             channelActions->getFileSourceActions()->fromJsonObject(actionsJsonObject);
         }
+        else if (channelActionsKey == "FreqScannerActions")
+        {
+            channelActions->setFreqScannerActions(new SWGSDRangel::SWGFreqScannerActions());
+            channelActions->getFreqScannerActions()->fromJsonObject(actionsJsonObject);
+        }
         else if (channelActionsKey == "IEEE_802_15_4_ModActions")
         {
             channelActions->setIeee802154ModActions(new SWGSDRangel::SWGIEEE_802_15_4_ModActions());
@@ -5629,6 +5634,7 @@ void WebAPIRequestMapper::resetChannelActions(SWGSDRangel::SWGChannelActions& ch
     channelActions.setAptDemodActions(nullptr);
     channelActions.setChannelType(nullptr);
     channelActions.setFileSourceActions(nullptr);
+    channelActions.setFreqScannerActions(nullptr);
     channelActions.setIeee802154ModActions(nullptr);
     channelActions.setPacketModActions(nullptr);
     channelActions.setPsk31ModActions(nullptr);

--- a/sdrbase/webapi/webapiutils.cpp
+++ b/sdrbase/webapi/webapiutils.cpp
@@ -216,6 +216,7 @@ const QMap<QString, QString> WebAPIUtils::m_channelTypeToActionsKey = {
     {"APTDemod", "APTDemodActions"},
     {"FileSink", "FileSinkActions"},
     {"FileSource", "FileSourceActions"},
+    {"FreqScanner", "FreqScannerActions"},
     {"SigMFFileSink", "SigMFFileSinkActions"},
     {"IEEE_802_15_4_Mod", "IEEE_802_15_4_ModActions"},
     {"RadioAstronomy", "RadioAstronomyActions"},

--- a/swagger/sdrangel/api/swagger/include/ChannelActions.yaml
+++ b/swagger/sdrangel/api/swagger/include/ChannelActions.yaml
@@ -25,6 +25,8 @@ ChannelActions:
       $ref: "http://swgserver:8081/api/swagger/include/FileSink.yaml#/FileSinkActions"
     FileSourceActions:
       $ref: "http://swgserver:8081/api/swagger/include/FileSource.yaml#/FileSourceActions"
+    FreqScannerActions:
+      $ref: "http://swgserver:8081/api/swagger/include/FreqScanner.yaml#/FreqScannerActions"
     IEEE_802_15_4_ModActions:
       $ref: "http://swgserver:8081/api/swagger/include/IEEE_802_15_4_Mod.yaml#/IEEE_802_15_4_ModActions"
     PacketModActions:

--- a/swagger/sdrangel/api/swagger/include/FreqScanner.yaml
+++ b/swagger/sdrangel/api/swagger/include/FreqScanner.yaml
@@ -59,6 +59,20 @@ FreqScannerReport:
   properties:
     channelSampleRate:
       type: integer
+    channelState:
+      type: array
+      items:
+        $ref: "http://swgserver:8081/api/swagger/include/FreqScanner.yaml#/FreqScannerChannelState"
+
+FreqScannerChannelState:
+  properties:
+    frequency:
+      description: "Channel centre frequency in Hz"
+      type: integer
+    power:
+      description: "Channel power in dB"
+      type: number
+      format: float
 
 FreqScannerFrequency:
   properties:
@@ -77,3 +91,13 @@ FreqScannerFrequency:
       type: string
     squelch:
       type: string
+
+FreqScannerActions:
+  description: "Frequency Scanner actions"
+  properties:
+    run:
+      type: integer
+      description: >
+        Set the plugin running state
+          * 0 - idle
+          * 1 - run

--- a/swagger/sdrangel/api/swagger/include/FreqScanner.yaml
+++ b/swagger/sdrangel/api/swagger/include/FreqScanner.yaml
@@ -59,6 +59,9 @@ FreqScannerReport:
   properties:
     channelSampleRate:
       type: integer
+    scanState:
+      description: (IDLE=0, START_SCAN=1, SCANNING=2, WAIT_FOR_END_TX=3, WAIT_FOR_RETRANSMISSION=4)
+      type: integer
     channelState:
       type: array
       items:

--- a/swagger/sdrangel/code/html2/index.html
+++ b/swagger/sdrangel/code/html2/index.html
@@ -7278,6 +7278,10 @@ margin-bottom: 20px;
     "channelSampleRate" : {
       "type" : "integer"
     },
+    "scanState" : {
+      "type" : "integer",
+      "description" : "(IDLE=0, START_SCAN=1, SCANNING=2, WAIT_FOR_END_TX=3, WAIT_FOR_RETRANSMISSION=4)"
+    },
     "channelState" : {
       "type" : "array",
       "items" : {
@@ -59115,7 +59119,7 @@ except ApiException as e:
           </div>
           <div id="generator">
             <div class="content">
-              Generated 2024-06-21T10:02:32.986+02:00
+              Generated 2024-06-21T11:03:53.536+02:00
             </div>
           </div>
       </div>

--- a/swagger/sdrangel/code/html2/index.html
+++ b/swagger/sdrangel/code/html2/index.html
@@ -3598,6 +3598,9 @@ margin-bottom: 20px;
     "FileSourceActions" : {
       "$ref" : "#/definitions/FileSourceActions"
     },
+    "FreqScannerActions" : {
+      "$ref" : "#/definitions/FreqScannerActions"
+    },
     "IEEE_802_15_4_ModActions" : {
       "$ref" : "#/definitions/IEEE_802_15_4_ModActions"
     },
@@ -7222,6 +7225,28 @@ margin-bottom: 20px;
   },
   "description" : "FreeDVMod"
 };
+            defs.FreqScannerActions = {
+  "properties" : {
+    "run" : {
+      "type" : "integer",
+      "description" : "Set the plugin running state\n  * 0 - idle\n  * 1 - run\n"
+    }
+  },
+  "description" : "Frequency Scanner actions"
+};
+            defs.FreqScannerChannelState = {
+  "properties" : {
+    "frequency" : {
+      "type" : "integer",
+      "description" : "Channel centre frequency in Hz"
+    },
+    "power" : {
+      "type" : "number",
+      "format" : "float",
+      "description" : "Channel power in dB"
+    }
+  }
+};
             defs.FreqScannerFrequency = {
   "properties" : {
     "frequency" : {
@@ -7252,6 +7277,12 @@ margin-bottom: 20px;
   "properties" : {
     "channelSampleRate" : {
       "type" : "integer"
+    },
+    "channelState" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/FreqScannerChannelState"
+      }
     }
   },
   "description" : "FreqScanner"
@@ -59084,7 +59115,7 @@ except ApiException as e:
           </div>
           <div id="generator">
             <div class="content">
-              Generated 2024-06-18T10:11:11.522+02:00
+              Generated 2024-06-21T10:02:32.986+02:00
             </div>
           </div>
       </div>

--- a/swagger/sdrangel/code/qt5/client/SWGChannelActions.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGChannelActions.cpp
@@ -44,6 +44,8 @@ SWGChannelActions::SWGChannelActions() {
     m_file_sink_actions_isSet = false;
     file_source_actions = nullptr;
     m_file_source_actions_isSet = false;
+    freq_scanner_actions = nullptr;
+    m_freq_scanner_actions_isSet = false;
     ieee_802_15_4_mod_actions = nullptr;
     m_ieee_802_15_4_mod_actions_isSet = false;
     packet_mod_actions = nullptr;
@@ -80,6 +82,8 @@ SWGChannelActions::init() {
     m_file_sink_actions_isSet = false;
     file_source_actions = new SWGFileSourceActions();
     m_file_source_actions_isSet = false;
+    freq_scanner_actions = new SWGFreqScannerActions();
+    m_freq_scanner_actions_isSet = false;
     ieee_802_15_4_mod_actions = new SWGIEEE_802_15_4_ModActions();
     m_ieee_802_15_4_mod_actions_isSet = false;
     packet_mod_actions = new SWGPacketModActions();
@@ -113,6 +117,9 @@ SWGChannelActions::cleanup() {
     }
     if(file_source_actions != nullptr) { 
         delete file_source_actions;
+    }
+    if(freq_scanner_actions != nullptr) { 
+        delete freq_scanner_actions;
     }
     if(ieee_802_15_4_mod_actions != nullptr) { 
         delete ieee_802_15_4_mod_actions;
@@ -160,6 +167,8 @@ SWGChannelActions::fromJsonObject(QJsonObject &pJson) {
     ::SWGSDRangel::setValue(&file_sink_actions, pJson["FileSinkActions"], "SWGFileSinkActions", "SWGFileSinkActions");
     
     ::SWGSDRangel::setValue(&file_source_actions, pJson["FileSourceActions"], "SWGFileSourceActions", "SWGFileSourceActions");
+    
+    ::SWGSDRangel::setValue(&freq_scanner_actions, pJson["FreqScannerActions"], "SWGFreqScannerActions", "SWGFreqScannerActions");
     
     ::SWGSDRangel::setValue(&ieee_802_15_4_mod_actions, pJson["IEEE_802_15_4_ModActions"], "SWGIEEE_802_15_4_ModActions", "SWGIEEE_802_15_4_ModActions");
     
@@ -212,6 +221,9 @@ SWGChannelActions::asJsonObject() {
     }
     if((file_source_actions != nullptr) && (file_source_actions->isSet())){
         toJsonValue(QString("FileSourceActions"), file_source_actions, obj, QString("SWGFileSourceActions"));
+    }
+    if((freq_scanner_actions != nullptr) && (freq_scanner_actions->isSet())){
+        toJsonValue(QString("FreqScannerActions"), freq_scanner_actions, obj, QString("SWGFreqScannerActions"));
     }
     if((ieee_802_15_4_mod_actions != nullptr) && (ieee_802_15_4_mod_actions->isSet())){
         toJsonValue(QString("IEEE_802_15_4_ModActions"), ieee_802_15_4_mod_actions, obj, QString("SWGIEEE_802_15_4_ModActions"));
@@ -315,6 +327,16 @@ SWGChannelActions::setFileSourceActions(SWGFileSourceActions* file_source_action
     this->m_file_source_actions_isSet = true;
 }
 
+SWGFreqScannerActions*
+SWGChannelActions::getFreqScannerActions() {
+    return freq_scanner_actions;
+}
+void
+SWGChannelActions::setFreqScannerActions(SWGFreqScannerActions* freq_scanner_actions) {
+    this->freq_scanner_actions = freq_scanner_actions;
+    this->m_freq_scanner_actions_isSet = true;
+}
+
 SWGIEEE_802_15_4_ModActions*
 SWGChannelActions::getIeee802154ModActions() {
     return ieee_802_15_4_mod_actions;
@@ -402,6 +424,9 @@ SWGChannelActions::isSet(){
             isObjectUpdated = true; break;
         }
         if(file_source_actions && file_source_actions->isSet()){
+            isObjectUpdated = true; break;
+        }
+        if(freq_scanner_actions && freq_scanner_actions->isSet()){
             isObjectUpdated = true; break;
         }
         if(ieee_802_15_4_mod_actions && ieee_802_15_4_mod_actions->isSet()){

--- a/swagger/sdrangel/code/qt5/client/SWGChannelActions.h
+++ b/swagger/sdrangel/code/qt5/client/SWGChannelActions.h
@@ -26,6 +26,7 @@
 #include "SWGAPTDemodActions.h"
 #include "SWGFileSinkActions.h"
 #include "SWGFileSourceActions.h"
+#include "SWGFreqScannerActions.h"
 #include "SWGIEEE_802_15_4_ModActions.h"
 #include "SWGPSK31ModActions.h"
 #include "SWGPacketModActions.h"
@@ -76,6 +77,9 @@ public:
     SWGFileSourceActions* getFileSourceActions();
     void setFileSourceActions(SWGFileSourceActions* file_source_actions);
 
+    SWGFreqScannerActions* getFreqScannerActions();
+    void setFreqScannerActions(SWGFreqScannerActions* freq_scanner_actions);
+
     SWGIEEE_802_15_4_ModActions* getIeee802154ModActions();
     void setIeee802154ModActions(SWGIEEE_802_15_4_ModActions* ieee_802_15_4_mod_actions);
 
@@ -121,6 +125,9 @@ private:
 
     SWGFileSourceActions* file_source_actions;
     bool m_file_source_actions_isSet;
+
+    SWGFreqScannerActions* freq_scanner_actions;
+    bool m_freq_scanner_actions_isSet;
 
     SWGIEEE_802_15_4_ModActions* ieee_802_15_4_mod_actions;
     bool m_ieee_802_15_4_mod_actions_isSet;

--- a/swagger/sdrangel/code/qt5/client/SWGFreqScannerActions.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGFreqScannerActions.cpp
@@ -11,7 +11,7 @@
  */
 
 
-#include "SWGFreqScannerReport.h"
+#include "SWGFreqScannerActions.h"
 
 #include "SWGHelpers.h"
 
@@ -22,44 +22,33 @@
 
 namespace SWGSDRangel {
 
-SWGFreqScannerReport::SWGFreqScannerReport(QString* json) {
+SWGFreqScannerActions::SWGFreqScannerActions(QString* json) {
     init();
     this->fromJson(*json);
 }
 
-SWGFreqScannerReport::SWGFreqScannerReport() {
-    channel_sample_rate = 0;
-    m_channel_sample_rate_isSet = false;
-    channel_state = nullptr;
-    m_channel_state_isSet = false;
+SWGFreqScannerActions::SWGFreqScannerActions() {
+    run = 0;
+    m_run_isSet = false;
 }
 
-SWGFreqScannerReport::~SWGFreqScannerReport() {
+SWGFreqScannerActions::~SWGFreqScannerActions() {
     this->cleanup();
 }
 
 void
-SWGFreqScannerReport::init() {
-    channel_sample_rate = 0;
-    m_channel_sample_rate_isSet = false;
-    channel_state = new QList<SWGFreqScannerChannelState*>();
-    m_channel_state_isSet = false;
+SWGFreqScannerActions::init() {
+    run = 0;
+    m_run_isSet = false;
 }
 
 void
-SWGFreqScannerReport::cleanup() {
+SWGFreqScannerActions::cleanup() {
 
-    if(channel_state != nullptr) { 
-        auto arr = channel_state;
-        for(auto o: *arr) { 
-            delete o;
-        }
-        delete channel_state;
-    }
 }
 
-SWGFreqScannerReport*
-SWGFreqScannerReport::fromJson(QString &json) {
+SWGFreqScannerActions*
+SWGFreqScannerActions::fromJson(QString &json) {
     QByteArray array (json.toStdString().c_str());
     QJsonDocument doc = QJsonDocument::fromJson(array);
     QJsonObject jsonObject = doc.object();
@@ -68,15 +57,13 @@ SWGFreqScannerReport::fromJson(QString &json) {
 }
 
 void
-SWGFreqScannerReport::fromJsonObject(QJsonObject &pJson) {
-    ::SWGSDRangel::setValue(&channel_sample_rate, pJson["channelSampleRate"], "qint32", "");
+SWGFreqScannerActions::fromJsonObject(QJsonObject &pJson) {
+    ::SWGSDRangel::setValue(&run, pJson["run"], "qint32", "");
     
-    
-    ::SWGSDRangel::setValue(&channel_state, pJson["channelState"], "QList", "SWGFreqScannerChannelState");
 }
 
 QString
-SWGFreqScannerReport::asJson ()
+SWGFreqScannerActions::asJson ()
 {
     QJsonObject* obj = this->asJsonObject();
 
@@ -87,47 +74,31 @@ SWGFreqScannerReport::asJson ()
 }
 
 QJsonObject*
-SWGFreqScannerReport::asJsonObject() {
+SWGFreqScannerActions::asJsonObject() {
     QJsonObject* obj = new QJsonObject();
-    if(m_channel_sample_rate_isSet){
-        obj->insert("channelSampleRate", QJsonValue(channel_sample_rate));
-    }
-    if(channel_state && channel_state->size() > 0){
-        toJsonArray((QList<void*>*)channel_state, obj, "channelState", "SWGFreqScannerChannelState");
+    if(m_run_isSet){
+        obj->insert("run", QJsonValue(run));
     }
 
     return obj;
 }
 
 qint32
-SWGFreqScannerReport::getChannelSampleRate() {
-    return channel_sample_rate;
+SWGFreqScannerActions::getRun() {
+    return run;
 }
 void
-SWGFreqScannerReport::setChannelSampleRate(qint32 channel_sample_rate) {
-    this->channel_sample_rate = channel_sample_rate;
-    this->m_channel_sample_rate_isSet = true;
-}
-
-QList<SWGFreqScannerChannelState*>*
-SWGFreqScannerReport::getChannelState() {
-    return channel_state;
-}
-void
-SWGFreqScannerReport::setChannelState(QList<SWGFreqScannerChannelState*>* channel_state) {
-    this->channel_state = channel_state;
-    this->m_channel_state_isSet = true;
+SWGFreqScannerActions::setRun(qint32 run) {
+    this->run = run;
+    this->m_run_isSet = true;
 }
 
 
 bool
-SWGFreqScannerReport::isSet(){
+SWGFreqScannerActions::isSet(){
     bool isObjectUpdated = false;
     do{
-        if(m_channel_sample_rate_isSet){
-            isObjectUpdated = true; break;
-        }
-        if(channel_state && (channel_state->size() > 0)){
+        if(m_run_isSet){
             isObjectUpdated = true; break;
         }
     }while(false);

--- a/swagger/sdrangel/code/qt5/client/SWGFreqScannerActions.h
+++ b/swagger/sdrangel/code/qt5/client/SWGFreqScannerActions.h
@@ -11,56 +11,48 @@
  */
 
 /*
- * SWGFreqScannerReport.h
+ * SWGFreqScannerActions.h
  *
- * FreqScanner
+ * Frequency Scanner actions
  */
 
-#ifndef SWGFreqScannerReport_H_
-#define SWGFreqScannerReport_H_
+#ifndef SWGFreqScannerActions_H_
+#define SWGFreqScannerActions_H_
 
 #include <QJsonObject>
 
 
-#include "SWGFreqScannerChannelState.h"
-#include <QList>
 
 #include "SWGObject.h"
 #include "export.h"
 
 namespace SWGSDRangel {
 
-class SWG_API SWGFreqScannerReport: public SWGObject {
+class SWG_API SWGFreqScannerActions: public SWGObject {
 public:
-    SWGFreqScannerReport();
-    SWGFreqScannerReport(QString* json);
-    virtual ~SWGFreqScannerReport();
+    SWGFreqScannerActions();
+    SWGFreqScannerActions(QString* json);
+    virtual ~SWGFreqScannerActions();
     void init();
     void cleanup();
 
     virtual QString asJson () override;
     virtual QJsonObject* asJsonObject() override;
     virtual void fromJsonObject(QJsonObject &json) override;
-    virtual SWGFreqScannerReport* fromJson(QString &jsonString) override;
+    virtual SWGFreqScannerActions* fromJson(QString &jsonString) override;
 
-    qint32 getChannelSampleRate();
-    void setChannelSampleRate(qint32 channel_sample_rate);
-
-    QList<SWGFreqScannerChannelState*>* getChannelState();
-    void setChannelState(QList<SWGFreqScannerChannelState*>* channel_state);
+    qint32 getRun();
+    void setRun(qint32 run);
 
 
     virtual bool isSet() override;
 
 private:
-    qint32 channel_sample_rate;
-    bool m_channel_sample_rate_isSet;
-
-    QList<SWGFreqScannerChannelState*>* channel_state;
-    bool m_channel_state_isSet;
+    qint32 run;
+    bool m_run_isSet;
 
 };
 
 }
 
-#endif /* SWGFreqScannerReport_H_ */
+#endif /* SWGFreqScannerActions_H_ */

--- a/swagger/sdrangel/code/qt5/client/SWGFreqScannerChannelState.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGFreqScannerChannelState.cpp
@@ -11,7 +11,7 @@
  */
 
 
-#include "SWGFreqScannerReport.h"
+#include "SWGFreqScannerChannelState.h"
 
 #include "SWGHelpers.h"
 
@@ -22,44 +22,38 @@
 
 namespace SWGSDRangel {
 
-SWGFreqScannerReport::SWGFreqScannerReport(QString* json) {
+SWGFreqScannerChannelState::SWGFreqScannerChannelState(QString* json) {
     init();
     this->fromJson(*json);
 }
 
-SWGFreqScannerReport::SWGFreqScannerReport() {
-    channel_sample_rate = 0;
-    m_channel_sample_rate_isSet = false;
-    channel_state = nullptr;
-    m_channel_state_isSet = false;
+SWGFreqScannerChannelState::SWGFreqScannerChannelState() {
+    frequency = 0;
+    m_frequency_isSet = false;
+    power = 0.0f;
+    m_power_isSet = false;
 }
 
-SWGFreqScannerReport::~SWGFreqScannerReport() {
+SWGFreqScannerChannelState::~SWGFreqScannerChannelState() {
     this->cleanup();
 }
 
 void
-SWGFreqScannerReport::init() {
-    channel_sample_rate = 0;
-    m_channel_sample_rate_isSet = false;
-    channel_state = new QList<SWGFreqScannerChannelState*>();
-    m_channel_state_isSet = false;
+SWGFreqScannerChannelState::init() {
+    frequency = 0;
+    m_frequency_isSet = false;
+    power = 0.0f;
+    m_power_isSet = false;
 }
 
 void
-SWGFreqScannerReport::cleanup() {
+SWGFreqScannerChannelState::cleanup() {
 
-    if(channel_state != nullptr) { 
-        auto arr = channel_state;
-        for(auto o: *arr) { 
-            delete o;
-        }
-        delete channel_state;
-    }
+
 }
 
-SWGFreqScannerReport*
-SWGFreqScannerReport::fromJson(QString &json) {
+SWGFreqScannerChannelState*
+SWGFreqScannerChannelState::fromJson(QString &json) {
     QByteArray array (json.toStdString().c_str());
     QJsonDocument doc = QJsonDocument::fromJson(array);
     QJsonObject jsonObject = doc.object();
@@ -68,15 +62,15 @@ SWGFreqScannerReport::fromJson(QString &json) {
 }
 
 void
-SWGFreqScannerReport::fromJsonObject(QJsonObject &pJson) {
-    ::SWGSDRangel::setValue(&channel_sample_rate, pJson["channelSampleRate"], "qint32", "");
+SWGFreqScannerChannelState::fromJsonObject(QJsonObject &pJson) {
+    ::SWGSDRangel::setValue(&frequency, pJson["frequency"], "qint32", "");
     
+    ::SWGSDRangel::setValue(&power, pJson["power"], "float", "");
     
-    ::SWGSDRangel::setValue(&channel_state, pJson["channelState"], "QList", "SWGFreqScannerChannelState");
 }
 
 QString
-SWGFreqScannerReport::asJson ()
+SWGFreqScannerChannelState::asJson ()
 {
     QJsonObject* obj = this->asJsonObject();
 
@@ -87,47 +81,47 @@ SWGFreqScannerReport::asJson ()
 }
 
 QJsonObject*
-SWGFreqScannerReport::asJsonObject() {
+SWGFreqScannerChannelState::asJsonObject() {
     QJsonObject* obj = new QJsonObject();
-    if(m_channel_sample_rate_isSet){
-        obj->insert("channelSampleRate", QJsonValue(channel_sample_rate));
+    if(m_frequency_isSet){
+        obj->insert("frequency", QJsonValue(frequency));
     }
-    if(channel_state && channel_state->size() > 0){
-        toJsonArray((QList<void*>*)channel_state, obj, "channelState", "SWGFreqScannerChannelState");
+    if(m_power_isSet){
+        obj->insert("power", QJsonValue(power));
     }
 
     return obj;
 }
 
 qint32
-SWGFreqScannerReport::getChannelSampleRate() {
-    return channel_sample_rate;
+SWGFreqScannerChannelState::getFrequency() {
+    return frequency;
 }
 void
-SWGFreqScannerReport::setChannelSampleRate(qint32 channel_sample_rate) {
-    this->channel_sample_rate = channel_sample_rate;
-    this->m_channel_sample_rate_isSet = true;
+SWGFreqScannerChannelState::setFrequency(qint32 frequency) {
+    this->frequency = frequency;
+    this->m_frequency_isSet = true;
 }
 
-QList<SWGFreqScannerChannelState*>*
-SWGFreqScannerReport::getChannelState() {
-    return channel_state;
+float
+SWGFreqScannerChannelState::getPower() {
+    return power;
 }
 void
-SWGFreqScannerReport::setChannelState(QList<SWGFreqScannerChannelState*>* channel_state) {
-    this->channel_state = channel_state;
-    this->m_channel_state_isSet = true;
+SWGFreqScannerChannelState::setPower(float power) {
+    this->power = power;
+    this->m_power_isSet = true;
 }
 
 
 bool
-SWGFreqScannerReport::isSet(){
+SWGFreqScannerChannelState::isSet(){
     bool isObjectUpdated = false;
     do{
-        if(m_channel_sample_rate_isSet){
+        if(m_frequency_isSet){
             isObjectUpdated = true; break;
         }
-        if(channel_state && (channel_state->size() > 0)){
+        if(m_power_isSet){
             isObjectUpdated = true; break;
         }
     }while(false);

--- a/swagger/sdrangel/code/qt5/client/SWGFreqScannerChannelState.h
+++ b/swagger/sdrangel/code/qt5/client/SWGFreqScannerChannelState.h
@@ -11,56 +11,54 @@
  */
 
 /*
- * SWGFreqScannerReport.h
+ * SWGFreqScannerChannelState.h
  *
- * FreqScanner
+ * 
  */
 
-#ifndef SWGFreqScannerReport_H_
-#define SWGFreqScannerReport_H_
+#ifndef SWGFreqScannerChannelState_H_
+#define SWGFreqScannerChannelState_H_
 
 #include <QJsonObject>
 
 
-#include "SWGFreqScannerChannelState.h"
-#include <QList>
 
 #include "SWGObject.h"
 #include "export.h"
 
 namespace SWGSDRangel {
 
-class SWG_API SWGFreqScannerReport: public SWGObject {
+class SWG_API SWGFreqScannerChannelState: public SWGObject {
 public:
-    SWGFreqScannerReport();
-    SWGFreqScannerReport(QString* json);
-    virtual ~SWGFreqScannerReport();
+    SWGFreqScannerChannelState();
+    SWGFreqScannerChannelState(QString* json);
+    virtual ~SWGFreqScannerChannelState();
     void init();
     void cleanup();
 
     virtual QString asJson () override;
     virtual QJsonObject* asJsonObject() override;
     virtual void fromJsonObject(QJsonObject &json) override;
-    virtual SWGFreqScannerReport* fromJson(QString &jsonString) override;
+    virtual SWGFreqScannerChannelState* fromJson(QString &jsonString) override;
 
-    qint32 getChannelSampleRate();
-    void setChannelSampleRate(qint32 channel_sample_rate);
+    qint32 getFrequency();
+    void setFrequency(qint32 frequency);
 
-    QList<SWGFreqScannerChannelState*>* getChannelState();
-    void setChannelState(QList<SWGFreqScannerChannelState*>* channel_state);
+    float getPower();
+    void setPower(float power);
 
 
     virtual bool isSet() override;
 
 private:
-    qint32 channel_sample_rate;
-    bool m_channel_sample_rate_isSet;
+    qint32 frequency;
+    bool m_frequency_isSet;
 
-    QList<SWGFreqScannerChannelState*>* channel_state;
-    bool m_channel_state_isSet;
+    float power;
+    bool m_power_isSet;
 
 };
 
 }
 
-#endif /* SWGFreqScannerReport_H_ */
+#endif /* SWGFreqScannerChannelState_H_ */

--- a/swagger/sdrangel/code/qt5/client/SWGFreqScannerReport.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGFreqScannerReport.cpp
@@ -30,6 +30,8 @@ SWGFreqScannerReport::SWGFreqScannerReport(QString* json) {
 SWGFreqScannerReport::SWGFreqScannerReport() {
     channel_sample_rate = 0;
     m_channel_sample_rate_isSet = false;
+    scan_state = 0;
+    m_scan_state_isSet = false;
     channel_state = nullptr;
     m_channel_state_isSet = false;
 }
@@ -42,12 +44,15 @@ void
 SWGFreqScannerReport::init() {
     channel_sample_rate = 0;
     m_channel_sample_rate_isSet = false;
+    scan_state = 0;
+    m_scan_state_isSet = false;
     channel_state = new QList<SWGFreqScannerChannelState*>();
     m_channel_state_isSet = false;
 }
 
 void
 SWGFreqScannerReport::cleanup() {
+
 
     if(channel_state != nullptr) { 
         auto arr = channel_state;
@@ -71,6 +76,8 @@ void
 SWGFreqScannerReport::fromJsonObject(QJsonObject &pJson) {
     ::SWGSDRangel::setValue(&channel_sample_rate, pJson["channelSampleRate"], "qint32", "");
     
+    ::SWGSDRangel::setValue(&scan_state, pJson["scanState"], "qint32", "");
+    
     
     ::SWGSDRangel::setValue(&channel_state, pJson["channelState"], "QList", "SWGFreqScannerChannelState");
 }
@@ -92,6 +99,9 @@ SWGFreqScannerReport::asJsonObject() {
     if(m_channel_sample_rate_isSet){
         obj->insert("channelSampleRate", QJsonValue(channel_sample_rate));
     }
+    if(m_scan_state_isSet){
+        obj->insert("scanState", QJsonValue(scan_state));
+    }
     if(channel_state && channel_state->size() > 0){
         toJsonArray((QList<void*>*)channel_state, obj, "channelState", "SWGFreqScannerChannelState");
     }
@@ -107,6 +117,16 @@ void
 SWGFreqScannerReport::setChannelSampleRate(qint32 channel_sample_rate) {
     this->channel_sample_rate = channel_sample_rate;
     this->m_channel_sample_rate_isSet = true;
+}
+
+qint32
+SWGFreqScannerReport::getScanState() {
+    return scan_state;
+}
+void
+SWGFreqScannerReport::setScanState(qint32 scan_state) {
+    this->scan_state = scan_state;
+    this->m_scan_state_isSet = true;
 }
 
 QList<SWGFreqScannerChannelState*>*
@@ -125,6 +145,9 @@ SWGFreqScannerReport::isSet(){
     bool isObjectUpdated = false;
     do{
         if(m_channel_sample_rate_isSet){
+            isObjectUpdated = true; break;
+        }
+        if(m_scan_state_isSet){
             isObjectUpdated = true; break;
         }
         if(channel_state && (channel_state->size() > 0)){

--- a/swagger/sdrangel/code/qt5/client/SWGFreqScannerReport.h
+++ b/swagger/sdrangel/code/qt5/client/SWGFreqScannerReport.h
@@ -46,6 +46,9 @@ public:
     qint32 getChannelSampleRate();
     void setChannelSampleRate(qint32 channel_sample_rate);
 
+    qint32 getScanState();
+    void setScanState(qint32 scan_state);
+
     QList<SWGFreqScannerChannelState*>* getChannelState();
     void setChannelState(QList<SWGFreqScannerChannelState*>* channel_state);
 
@@ -55,6 +58,9 @@ public:
 private:
     qint32 channel_sample_rate;
     bool m_channel_sample_rate_isSet;
+
+    qint32 scan_state;
+    bool m_scan_state_isSet;
 
     QList<SWGFreqScannerChannelState*>* channel_state;
     bool m_channel_state_isSet;

--- a/swagger/sdrangel/code/qt5/client/SWGModelFactory.h
+++ b/swagger/sdrangel/code/qt5/client/SWGModelFactory.h
@@ -157,6 +157,8 @@
 #include "SWGFreeDVDemodSettings.h"
 #include "SWGFreeDVModReport.h"
 #include "SWGFreeDVModSettings.h"
+#include "SWGFreqScannerActions.h"
+#include "SWGFreqScannerChannelState.h"
 #include "SWGFreqScannerFrequency.h"
 #include "SWGFreqScannerReport.h"
 #include "SWGFreqScannerSettings.h"
@@ -1099,6 +1101,16 @@ namespace SWGSDRangel {
     }
     if(QString("SWGFreeDVModSettings").compare(type) == 0) {
       SWGFreeDVModSettings *obj = new SWGFreeDVModSettings();
+      obj->init();
+      return obj;
+    }
+    if(QString("SWGFreqScannerActions").compare(type) == 0) {
+      SWGFreqScannerActions *obj = new SWGFreqScannerActions();
+      obj->init();
+      return obj;
+    }
+    if(QString("SWGFreqScannerChannelState").compare(type) == 0) {
+      SWGFreqScannerChannelState *obj = new SWGFreqScannerChannelState();
       obj->init();
       return obj;
     }


### PR DESCRIPTION
Some updates for the Frequency Scanner for #2108.

- Add scan results to channel report.
- Add current scan state to channel report.
- Add run action to API to start/stop a scan.

Also, add HF ATC as a channel range preset.