### PR TITLE
Do not save the settings twice

### DIFF
--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -319,7 +319,6 @@ MainWindow::~MainWindow()
 	qDebug() << "MainWindow::~MainWindow";
 
     m_statusTimer.stop();
-    m_mainCore->m_settings.save();
     m_apiServer->stop();
     delete m_apiServer;
     delete m_requestMapper;


### PR DESCRIPTION
This PR removes a call to m_settings.save() in the destructor of MainWindow because the same call is made when handling the close event which happens just before the call to the destructor when terminating Sdrangel normally, as noted in #2107. When killing Sdrangel with Ctrl+C or similar, neither `closeEvent` nor `~MainWindow` are called so the settings aren't saved anyway.
