### PR TITLE
Fix/map feature

### DIFF
--- a/plugins/feature/map/data/transmitters.csv
+++ b/plugins/feature/map/data/transmitters.csv
@@ -1834,7 +1834,7 @@ FM,Heart (Morecambe Bay) Windermere WINDERMERE,Heart (Morecambe Bay),102300000,5
 FM,Heart Hertfordshire Hertford Cole Green,Heart Hertfordshire,106900000,51.787539,-0.135924,71,0.25,,
 FM,Heart Hertfordshire Hitchin and Letchworth Letchworth - Briar Patch Lane,Heart Hertfordshire,106900000,51.967745,-0.241566,97,0.05,,
 FM,Heart Hertfordshire Stevenage Old Knebworth,Heart Hertfordshire,106700000,51.872155,-0.211306,121,0.1,,
-FM,Heartland FM Pitlochry and Aberfeldy Fàire Mhòr,Heartland FM,97500000,56.705122,-3.646339,480,0.2,,
+FM,Heartland FM Pitlochry and Aberfeldy FÃ ire MhÃ²r,Heartland FM,97500000,56.705122,-3.646339,480,0.2,,
 FM,Heritage CR Manchester South Manchester - Duffield Court,Heritage CR,90600000,53.463992,-2.241562,36,0.05,,
 FM,Hermitage FM Coalville Coalville - Hoo Ash Farm,Hermitage FM,99200000,52.731179,-1.396357,161,0.025,,
 FM,Hitmix Radio Newcastle Under Lyme Alsagers Bank (High Lane),Hitmix Radio,107500000,53.029744,-2.282367,212,0.025,,
@@ -1942,9 +1942,9 @@ FM,Mix 92.6 St Albans St Albans - St Peters Church),Mix 92.6,92600000,51.755459,
 FM,MKFM Bletchley Bletchley - MK Stadium,MKFM,102100000,52.009052,-0.734754,77,0.05,,
 FM,MKFM Milton Keynes Milton Keynes - Saxon Gate,MKFM,106300000,52.043319,-0.761199,111,0.05,,
 FM,MKFM Wolverton Wolverton - Stratford Road,MKFM,95000000,52.06252,-0.818579,79,0.05,,
-FM,MônFM Anglesey Amlwch Nebo,MônFM,102500000,53.390547,-4.301313,160,0.2,,
-FM,MônFM Anglesey Gwalchmai,MônFM,102100000,53.263035,-4.416069,97,0.1,,
-FM,MônFM Anglesey Penmynydd,MônFM,96800000,53.248889,-4.228493,102,0.2,,
+FM,MÃ´nFM Anglesey Amlwch Nebo,MÃ´nFM,102500000,53.390547,-4.301313,160,0.2,,
+FM,MÃ´nFM Anglesey Gwalchmai,MÃ´nFM,102100000,53.263035,-4.416069,97,0.1,,
+FM,MÃ´nFM Anglesey Penmynydd,MÃ´nFM,96800000,53.248889,-4.228493,102,0.2,,
 FM,Moonbeamers Drive-in Billericay Barleylands Craft Village,Moonbeamers Drive-in,106800000,51.600426,0.445999,25,5e-05,,
 FM,Moorlands Radio Biddulph Biddulph Moor - Rails Farm,Moorlands Radio,103700000,53.123677,-2.127723,328,0.0253,,
 FM,Moorlands Radio Leek Leek - Stockwell Villas,Moorlands Radio,97300000,53.107922,-2.024009,187,0.025,,
@@ -1979,7 +1979,7 @@ FM,Nation's Easy Radio Portsmouth Fort Southwick,Nation's Easy Radio,107400000,5
 FM,Nation's Easy Radio Swansea Kilvey Hill,Nation's Easy Radio,102100000,51.62891,-3.919745,193,1,,
 FM,Nations Radio Poole Poole - West Howe,Nations Radio,106600000,50.757093,-1.938987,65,0.25,,
 FM,Nevis Radio Skye/Mallaig Cnoc Malagan,Nevis Radio,102300000,57.103288,-5.874998,185,0.8,,
-FM,Nevis Radio Fort William Creag a' Chàil,Nevis Radio,96600000,56.827212,-5.054422,269,0.3,,
+FM,Nevis Radio Fort William Creag a' ChÃ il,Nevis Radio,96600000,56.827212,-5.054422,269,0.3,,
 FM,Nevis Radio Loch Leven Glenachulish,Nevis Radio,102400000,56.681764,-5.211986,255,0.8,,
 FM,Nevis Radio Glencoe,Nevis Radio,97000000,56.623839,-4.836427,680,0.2,,
 FM,New Style Radio 98.7 FM Birmingham Birmingham - Cambridge Tower,New Style Radio 98.7 FM,98700000,52.480787,-1.909401,137,0.016,,
@@ -2055,7 +2055,7 @@ FM,Radio Essex Southend SOUTHEND TE,Radio Essex,105100000,51.540835,0.698653,33,
 FM,Radio Exe Exeter Exeter (St Thomas),Radio Exe,107300000,50.719122,-3.562148,102,1,,
 FM,Radio Faza 97.1 FM Nottingham Mapperley,Radio Faza 97.1 FM,97100000,52.979731,-1.133451,125,0.05,,
 FM,Radio Gibraltar Plus  Upper Rock,Radio Gibraltar Plus,100500000,36.133162,-5.345733,400,0.2,,
-FM,Radio Glangwili Carmarthen Glangwili General Hospital,Radio Glangwili,87700000,51.868925,-4.28613,24,5e-05,,
+FM,Radio Glangwili Carmarthen Glangwili GeneralÂ Hospital,Radio Glangwili,87700000,51.868925,-4.28613,24,5e-05,,
 FM,Radio Hartlepool Hartlepool,Radio Hartlepool,102400000,54.686616,-1.216936,12,0.025,,
 FM,Radio Ikhlas Derby Normanton,Radio Ikhlas,107800000,52.906966,-1.502458,95,0.025,,
 FM,Radio Jackie Kingston Tolworth Tower,Radio Jackie,107800000,51.379884,-0.281001,29,0.4,,
@@ -2083,7 +2083,7 @@ FM,Radio Saltire Tranent,Radio Saltire,107200000,55.94425,-2.954051,86,0.025,,
 FM,Radio Sangam Huddersfield Huddersfield - Royal Infirmary,Radio Sangam,107900000,53.655545,-1.815067,187,0.02,,
 FM,Radio Scarborough Scarborough Oliver's Mount B,Radio Scarborough,107600000,54.267627,-0.404944,151,0.025,,
 FM,Radio Skye Skye & Lochalsh Portree,Radio Skye,106200000,57.41693,-6.193925,51,0.03,,
-FM,Radio Skye Skye & Lochalsh Sabhal Mòr Ostaig,Radio Skye,106200000,57.086557,-5.881012,42,0.1,,
+FM,Radio Skye Skye & Lochalsh Sabhal MÃ²r Ostaig,Radio Skye,106200000,57.086557,-5.881012,42,0.1,,
 FM,Radio Skye Skye & Lochalsh Skriaig,Radio Skye,102700000,57.38642,-6.24289,390,3.65,,
 FM,Radio Skye Skye & Lochalsh Staffin - caravan & camping site,Radio Skye,107200000,57.62189,-6.196103,88,0.1,,
 FM,Radio St Austell Bay St Austell St Austell RFC,Radio St Austell Bay,105600000,50.32788,-4.777309,90,0.025,,
@@ -2096,7 +2096,7 @@ FM,Radio Wyvern Worcester Worcester - Perry Wood School,Radio Wyvern,106700000,5
 FM,Radio X London Crystal Palace,Radio X,104900000,51.424161,-0.074944,110,1.9,,
 FM,Radio X Manchester Manchester - City Tower,Radio X,97700000,53.480177,-2.23864,43,0.5,,
 FM,Radio2Funky Leicester Leicester - Granby Street,Radio2Funky,95000000,52.632511,-1.128357,67,0.025,,
-FM,Raidió Fáilte Belfast Belfast - Divis Flats,Raidió Fáilte,107100000,54.599944,-5.942214,14,0.29,,
+FM,RaidiÃ³ FÃ¡ilte Belfast Belfast - Divis Flats,RaidiÃ³ FÃ¡ilte,107100000,54.599944,-5.942214,14,0.29,,
 FM,Rainbow Radio SE_London Crystal Palace,Rainbow Radio,92400000,51.424161,-0.074944,110,0.03,,
 FM,Red Kite Radio Haddenham and Thame Haddenham,Red Kite Radio,107200000,51.769341,-0.914507,71,0.04,,
 FM,Redroad FM Rother Valley Wales Sheffield,Redroad FM,102400000,53.338861,-1.284487,119,0.025,,
@@ -3476,33 +3476,33 @@ DAB,Wolv'ton & Shrop 3702,Wolv'ton & Shrop,218640000,52.878444,-3.091941,305,0.6
 DAB,Wolv'ton & Shrop 3708,Wolv'ton & Shrop,218640000,52.547739,-2.115424,225,0.6,37,08
 DAB,Wolv'ton & Shrop 3709,Wolv'ton & Shrop,218640000,52.670935,-2.550228,396,1.95447,37,09
 DAB,Wolv'ton & Shrop 3711,Wolv'ton & Shrop,218640000,52.496364,-2.048417,267,4,37,11
-DAB,Marseille intermédiaire 1 2310,Marseille intermédiaire 1,195936000,43.3878,5.41167,66,10,17,0a
-DAB,Marseille intermédiaire 1 2302,Marseille intermédiaire 1,195936000,43.5272,5.40194,25,3.5,17,02
-DAB,Marseille intermédiaire 2 2410,Marseille intermédiaire 2,188928000,43.3839,5.42556,148,10,18,0a
-DAB,Nice intermédiaire 2 1704,Nice intermédiaire 2,220352000,43.7217,7.32083,56,6,11,04
+DAB,Marseille intermÃ©diaire 1 2310,Marseille intermÃ©diaire 1,195936000,43.3878,5.41167,66,10,17,0a
+DAB,Marseille intermÃ©diaire 1 2302,Marseille intermÃ©diaire 1,195936000,43.5272,5.40194,25,3.5,17,02
+DAB,Marseille intermÃ©diaire 2 2410,Marseille intermÃ©diaire 2,188928000,43.3839,5.42556,148,10,18,0a
+DAB,Nice intermÃ©diaire 2 1704,Nice intermÃ©diaire 2,220352000,43.7217,7.32083,56,6,11,04
 DAB,Nice local 2 0404,Nice local 2,208064000,43.7675,7.29556,30,12,04,04
-DAB,Paris intermédiaire 1 1210,Paris intermédiaire 1,181936000,48.8853,2.42222,144,8,0c,0a
+DAB,Paris intermÃ©diaire 1 1210,Paris intermÃ©diaire 1,181936000,48.8853,2.42222,144,8,0c,0a
 DAB,Paris local 2 2610,Paris local 2,204640000,48.8853,2.42222,144,8,1a,0a
 DAB,Paris local 1 2210,Paris local 1,202928000,48.8872,2.34167,48,4,16,0a
 DAB,Marseille local 3 0710,Marseille local 3,201072000,43.3878,5.41167,66,10,07,0a
 DAB,Marseille local 2 1110,Marseille local 2,199360000,43.3892,5.4125,45,4,0b,0a
 DAB,Paris local 3 2710,Paris local 3,216928000,48.8853,2.42222,144,4,1b,0a
-DAB,Nice étendu 1 3104,Nice étendu 1,216928000,43.7142,7.30722,18,10,1f,04
+DAB,Nice Ã©tendu 1 3104,Nice Ã©tendu 1,216928000,43.7142,7.30722,18,10,1f,04
 DAB,Nice local 3 0604,Nice local 3,201072000,43.7217,7.32083,38,2,06,04
 DAB,Lille local 1 0510,Lille local 1,192352000,50.6556,3.03056,70,7,05,0a
 DAB,Douai-Lens local 1 2701,Douai-Lens local 1,222064000,50.4336,2.6075,30,4,1b,01
-DAB,Lille étendu 1 0010,Lille étendu 1,195936000,50.6425,3.12389,143,4,00,0a
+DAB,Lille Ã©tendu 1 0010,Lille Ã©tendu 1,195936000,50.6425,3.12389,143,4,00,0a
 DAB,Calais-Boulogne-sur-Mer local 1 0102,Calais-Boulogne-sur-Mer local 1,176640000,50.9506,1.89083,63,3,01,02
 DAB,Dunkerque local 1 0303,Dunkerque local 1,201072000,51.0331,2.35889,55,3,03,03
 DAB,Valenciennes local 1 2204,Valenciennes local 1,188928000,50.3394,3.57389,46,8,16,04
 DAB,Lille local 2 0610,Lille local 2,194064000,50.6425,3.12389,143,4,06,0a
 DAB,Marseille local 2 1101,Marseille local 2,199360000,43.3586,5.57444,22,2,0b,01
-DAB,Lyon étendu 1 1710,Lyon étendu 1,181936000,45.8225,4.82083,32,13,11,0a
-DAB,Lyon étendu 1 1704,Lyon étendu 1,181936000,45.965,4.70361,19,2.1,11,04
+DAB,Lyon Ã©tendu 1 1710,Lyon Ã©tendu 1,181936000,45.8225,4.82083,32,13,11,0a
+DAB,Lyon Ã©tendu 1 1704,Lyon Ã©tendu 1,181936000,45.965,4.70361,19,2.1,11,04
 DAB,Strasbourg local 2 0910,Strasbourg local 2,192352000,48.5867,7.74111,90,2.5,09,0a
-DAB,Strasbourg étendu 1 6710,Strasbourg étendu 1,187072000,48.5867,7.74111,90,4,43,0a
-DAB,Strasbourg étendu 1 6701,Strasbourg étendu 1,187072000,48.0767,7.32667,40,1.2,43,01
-DAB,Strasbourg étendu 1 6702,Strasbourg étendu 1,187072000,47.7344,7.34556,15,2.5,43,02
+DAB,Strasbourg Ã©tendu 1 6710,Strasbourg Ã©tendu 1,187072000,48.5867,7.74111,90,4,43,0a
+DAB,Strasbourg Ã©tendu 1 6701,Strasbourg Ã©tendu 1,187072000,48.0767,7.32667,40,1.2,43,01
+DAB,Strasbourg Ã©tendu 1 6702,Strasbourg Ã©tendu 1,187072000,47.7344,7.34556,15,2.5,43,02
 DAB,Colmar local 1 1801,Colmar local 1,220352000,48.0786,7.33444,56,1,12,01
 DAB,Mulhouse local 1 1302,Mulhouse local 1,222064000,47.7503,7.31472,55,4,0d,02
 DAB,Bourg-en-Bresse local 1 1601,Bourg-en-Bresse local 1,187072000,46.1917,5.33833,32,1.5,10,01
@@ -3514,150 +3514,150 @@ DAB,Nantes local 1 1710,Nantes local 1,190640000,47.2447,-1.60833,125,6,11,0a
 DAB,La Roche-sur-Yon local 1 1902,La Roche-sur-Yon local 1,202928000,46.6892,-1.43722,47,6,13,02
 DAB,Saint-Nazaire local 1 1401,Saint-Nazaire local 1,201072000,47.3253,-2.40639,63,3,0e,01
 DAB,Saint-Nazaire local 1 1403,Saint-Nazaire local 1,201072000,47.1914,-2.07667,32,3,0e,03
-DAB,Nantes étendu 1 0801,Nantes étendu 1,180064000,47.3253,-2.40639,63,2,08,01
-DAB,Nantes étendu 1 0810,Nantes étendu 1,180064000,47.2447,-1.60833,125,9,08,0a
+DAB,Nantes Ã©tendu 1 0801,Nantes Ã©tendu 1,180064000,47.3253,-2.40639,63,2,08,01
+DAB,Nantes Ã©tendu 1 0810,Nantes Ã©tendu 1,180064000,47.2447,-1.60833,125,9,08,0a
 DAB,Nantes local 2 2010,Nantes local 2,223936000,47.2236,-1.615,98,4,14,0a
-DAB,Rouen étendu 1 1610,Rouen étendu 1,209936000,49.4428,1.03306,66,10,10,0a
-DAB,Rouen étendu 1 1601,Rouen étendu 1,209936000,49.5047,0.139722,49,10,10,01
+DAB,Rouen Ã©tendu 1 1610,Rouen Ã©tendu 1,209936000,49.4428,1.03306,66,10,10,0a
+DAB,Rouen Ã©tendu 1 1601,Rouen Ã©tendu 1,209936000,49.5047,0.139722,49,10,10,01
 DAB,Rouen local 1 0410,Rouen local 1,206352000,49.4472,1.13667,63,6,04,0a
 DAB,Rouen local 2 2310,Rouen local 2,213360000,49.4472,1.13667,63,6,17,0a
 DAB,Le Havre local 1 2901,Le Havre local 1,215072000,49.5072,0.0894444,30,4,1d,01
-DAB,Paris intermédiaire 2 1310,Paris intermédiaire 2,187072000,48.8853,2.42222,144,8,0d,0a
-DAB,Mâcon local 1 1401,Mâcon local 1,195936000,46.3517,4.78333,32,1.8,0e,01
-DAB,Bordeaux étendu 1 1310,Bordeaux étendu 1,199360000,44.8203,-0.505556,163,6,0d,0a
-DAB,Bordeaux étendu 1 1301,Bordeaux étendu 1,199360000,44.4328,0.07,37,4,0d,01
+DAB,Paris intermÃ©diaire 2 1310,Paris intermÃ©diaire 2,187072000,48.8853,2.42222,144,8,0d,0a
+DAB,MÃ¢con local 1 1401,MÃ¢con local 1,195936000,46.3517,4.78333,32,1.8,0e,01
+DAB,Bordeaux Ã©tendu 1 1310,Bordeaux Ã©tendu 1,199360000,44.8203,-0.505556,163,6,0d,0a
+DAB,Bordeaux Ã©tendu 1 1301,Bordeaux Ã©tendu 1,199360000,44.4328,0.07,37,4,0d,01
 DAB,Bordeaux local 1 3010,Bordeaux local 1,188928000,44.8719,-0.515278,78,10,1e,0a
 DAB,Bordeaux local 1 3010,Bordeaux local 1,188928000,44.8614,-0.558611,35,2,1e,0a
 DAB,Bordeaux local 2 3110,Bordeaux local 2,197648000,44.8203,-0.505556,163,4,1f,0a
 DAB,Arcachon local 1 2501,Arcachon local 1,220352000,44.6469,-1.16361,91,4,19,01
-DAB,Toulouse étendu 1 1810,Toulouse étendu 1,183648000,43.5589,1.44639,27,10,12,0a
-DAB,Toulouse étendu 1 0301,Toulouse étendu 1,183648000,43.9875,1.35917,34,5,03,01
+DAB,Toulouse Ã©tendu 1 1810,Toulouse Ã©tendu 1,183648000,43.5589,1.44639,27,10,12,0a
+DAB,Toulouse Ã©tendu 1 0301,Toulouse Ã©tendu 1,183648000,43.9875,1.35917,34,5,03,01
 DAB,Toulouse local 1 3010,Toulouse local 1,192352000,43.6058,1.46722,20,6,1e,0a
 DAB,Toulouse local 2 3110,Toulouse local 2,199360000,43.5589,1.44639,27,5,1f,0a
-DAB,métropole métropolitain 1 6708,métropole métropolitain 1,188928000,45.3156,4.74611,15,2.6,43,08
-DAB,métropole métropolitain 1 6706,métropole métropolitain 1,188928000,44.9642,4.80083,25,10,43,06
-DAB,métropole métropolitain 1 2701,métropole métropolitain 1,192352000,43.3586,5.57444,27,2.6,1b,01
-DAB,métropole métropolitain 1 0604,métropole métropolitain 1,208064000,47.1456,4.66167,52,2.6,06,04
-DAB,métropole métropolitain 1 0601,métropole métropolitain 1,208064000,47.0347,4.81389,42,4,06,01
-DAB,métropole métropolitain 1 0610,métropole métropolitain 1,208064000,47.3003,4.99056,29,5,06,0a
-DAB,métropole métropolitain 1 0605,métropole métropolitain 1,208064000,47.485,4.1575,32,1.7,06,05
-DAB,métropole métropolitain 1 0606,métropole métropolitain 1,208064000,47.335,4.81083,21,2.6,06,06
-DAB,métropole métropolitain 1 0607,métropole métropolitain 1,208064000,47.3469,4.45889,45,1.7,06,07
-DAB,métropole métropolitain 1 0407,métropole métropolitain 1,211648000,44.6131,4.77917,26,3.6,04,07
-DAB,métropole métropolitain 1 0402,métropole métropolitain 1,211648000,44.1814,4.66222,47,4,04,02
-DAB,métropole métropolitain 1 1404,métropole métropolitain 1,185360000,48.0333,3.00278,78,1.5,0e,04
-DAB,métropole métropolitain 1 1910,métropole métropolitain 1,188928000,45.8225,4.82083,34,13,13,0a
-DAB,métropole métropolitain 1 6705,métropole métropolitain 1,188928000,45.5325,4.80861,45,3.4,43,05
-DAB,métropole métropolitain 1 0602,métropole métropolitain 1,208064000,46.7364,4.665,27,6.5,06,02
-DAB,métropole métropolitain 1 1903,métropole métropolitain 1,188928000,46.2817,4.68056,76,10,13,03
-DAB,métropole métropolitain 1 1101,métropole métropolitain 1,185360000,48.88,2.28389,167,10,0b,01
-DAB,métropole métropolitain 1 1110,métropole métropolitain 1,185360000,48.8675,2.41528,139,14,0b,0a
-DAB,métropole métropolitain 1 1403,métropole métropolitain 1,185360000,48.1647,2.88139,38,1.8,0e,03
-DAB,métropole métropolitain 1 1410,métropole métropolitain 1,185360000,48.4267,2.71083,46,5.6,0e,0a
-DAB,métropole métropolitain 1 6702,métropole métropolitain 1,194064000,48.2911,2.68194,28,1.7,43,02
-DAB,métropole métropolitain 1 0405,métropole métropolitain 1,211648000,43.97,4.85972,88,4,04,05
-DAB,métropole métropolitain 1 0608,métropole métropolitain 1,208064000,47.5394,3.89389,20,5,06,08
-DAB,métropole métropolitain 1 1010,métropole métropolitain 1,208064000,47.8406,3.66639,101,7,0a,0a
-DAB,métropole métropolitain 1 1401,métropole métropolitain 1,185360000,48.6,2.44278,86,3,0e,01
-DAB,métropole métropolitain 1 1402,métropole métropolitain 1,185360000,48.4783,2.42417,93,6,0e,02
-DAB,métropole métropolitain 2 0808,métropole métropolitain 2,190640000,45.3156,4.74611,15,2.6,08,08
-DAB,métropole métropolitain 2 0806,métropole métropolitain 2,190640000,44.9642,4.80083,25,5,08,06
-DAB,métropole métropolitain 2 2807,métropole métropolitain 2,197648000,43.6319,5.09611,23,1.9,1c,07
-DAB,métropole métropolitain 2 2808,métropole métropolitain 2,197648000,43.5403,5.23833,14,2,1c,08
-DAB,métropole métropolitain 2 0010,métropole métropolitain 2,206352000,47.1456,4.66167,52,2.6,00,0a
-DAB,métropole métropolitain 2 1310,métropole métropolitain 2,206352000,47.0347,4.81389,42,4,0d,0a
-DAB,métropole métropolitain 2 0001,métropole métropolitain 2,206352000,47.485,4.1575,32,1.7,00,01
-DAB,métropole métropolitain 2 0002,métropole métropolitain 2,206352000,47.3469,4.45889,45,1.7,00,02
-DAB,métropole métropolitain 2 0607,métropole métropolitain 2,213360000,44.6131,4.77917,26,4,06,07
-DAB,métropole métropolitain 2 0602,métropole métropolitain 2,213360000,44.1814,4.66222,47,4,06,02
-DAB,métropole métropolitain 2 0504,métropole métropolitain 2,199360000,48.0333,3.00278,78,4,05,04
-DAB,métropole métropolitain 2 2010,métropole métropolitain 2,190640000,45.8225,4.82083,34,10,14,0a
-DAB,métropole métropolitain 2 0805,métropole métropolitain 2,190640000,45.5325,4.80861,45,10,08,05
-DAB,métropole métropolitain 2 2004,métropole métropolitain 2,190640000,45.965,4.70361,19,10,14,04
-DAB,métropole métropolitain 2 1302,métropole métropolitain 2,206352000,46.7364,4.665,27,6.5,0d,02
-DAB,métropole métropolitain 2 0101,métropole métropolitain 2,199360000,46.3517,4.78333,32,5,01,01
-DAB,métropole métropolitain 2 1301,métropole métropolitain 2,206352000,46.5656,4.87639,29,5,0d,01
-DAB,métropole métropolitain 2 0501,métropole métropolitain 2,199360000,48.88,2.28389,167,10,05,01
-DAB,métropole métropolitain 2 0510,métropole métropolitain 2,199360000,48.8675,2.41528,139,14,05,0a
-DAB,métropole métropolitain 2 0505,métropole métropolitain 2,199360000,48.1647,2.88139,38,14,05,05
-DAB,métropole métropolitain 2 0506,métropole métropolitain 2,199360000,48.4286,2.54028,36,1.7,05,06
-DAB,métropole métropolitain 2 0507,métropole métropolitain 2,199360000,48.2911,2.68194,28,1.7,05,07
-DAB,métropole métropolitain 2 0605,métropole métropolitain 2,213360000,43.97,4.85972,88,4.2,06,05
-DAB,métropole métropolitain 2 0606,métropole métropolitain 2,213360000,43.8036,5.04694,39,4.2,06,06
-DAB,métropole métropolitain 2 0003,métropole métropolitain 2,206352000,47.5394,3.89389,20,2.6,00,03
-DAB,métropole métropolitain 2 0004,métropole métropolitain 2,206352000,47.8406,3.66639,101,7,00,04
-DAB,métropole métropolitain 2 0503,métropole métropolitain 2,199360000,48.6286,2.42806,52,7,05,03
-DAB,Dijon étendu 1 0410,Dijon étendu 1,204640000,47.3003,4.99056,29,7.5,04,0a
-DAB,Dijon étendu 1 0402,Dijon étendu 1,204640000,46.7364,4.665,27,6.5,04,02
-DAB,Avignon étendu 1 2505,Avignon étendu 1,208064000,43.97,4.85972,88,7.7,19,05
-DAB,Avignon étendu 1 2502,Avignon étendu 1,208064000,44.1814,4.66222,47,6,19,02
-DAB,Paris étendu 1 0701,Paris étendu 1,218640000,48.88,2.28389,167,10,07,01
-DAB,Paris étendu 1 0710,Paris étendu 1,218640000,48.8675,2.41528,139,14,07,0a
+DAB,mÃ©tropole mÃ©tropolitain 1 6708,mÃ©tropole mÃ©tropolitain 1,188928000,45.3156,4.74611,15,2.6,43,08
+DAB,mÃ©tropole mÃ©tropolitain 1 6706,mÃ©tropole mÃ©tropolitain 1,188928000,44.9642,4.80083,25,10,43,06
+DAB,mÃ©tropole mÃ©tropolitain 1 2701,mÃ©tropole mÃ©tropolitain 1,192352000,43.3586,5.57444,27,2.6,1b,01
+DAB,mÃ©tropole mÃ©tropolitain 1 0604,mÃ©tropole mÃ©tropolitain 1,208064000,47.1456,4.66167,52,2.6,06,04
+DAB,mÃ©tropole mÃ©tropolitain 1 0601,mÃ©tropole mÃ©tropolitain 1,208064000,47.0347,4.81389,42,4,06,01
+DAB,mÃ©tropole mÃ©tropolitain 1 0610,mÃ©tropole mÃ©tropolitain 1,208064000,47.3003,4.99056,29,5,06,0a
+DAB,mÃ©tropole mÃ©tropolitain 1 0605,mÃ©tropole mÃ©tropolitain 1,208064000,47.485,4.1575,32,1.7,06,05
+DAB,mÃ©tropole mÃ©tropolitain 1 0606,mÃ©tropole mÃ©tropolitain 1,208064000,47.335,4.81083,21,2.6,06,06
+DAB,mÃ©tropole mÃ©tropolitain 1 0607,mÃ©tropole mÃ©tropolitain 1,208064000,47.3469,4.45889,45,1.7,06,07
+DAB,mÃ©tropole mÃ©tropolitain 1 0407,mÃ©tropole mÃ©tropolitain 1,211648000,44.6131,4.77917,26,3.6,04,07
+DAB,mÃ©tropole mÃ©tropolitain 1 0402,mÃ©tropole mÃ©tropolitain 1,211648000,44.1814,4.66222,47,4,04,02
+DAB,mÃ©tropole mÃ©tropolitain 1 1404,mÃ©tropole mÃ©tropolitain 1,185360000,48.0333,3.00278,78,1.5,0e,04
+DAB,mÃ©tropole mÃ©tropolitain 1 1910,mÃ©tropole mÃ©tropolitain 1,188928000,45.8225,4.82083,34,13,13,0a
+DAB,mÃ©tropole mÃ©tropolitain 1 6705,mÃ©tropole mÃ©tropolitain 1,188928000,45.5325,4.80861,45,3.4,43,05
+DAB,mÃ©tropole mÃ©tropolitain 1 0602,mÃ©tropole mÃ©tropolitain 1,208064000,46.7364,4.665,27,6.5,06,02
+DAB,mÃ©tropole mÃ©tropolitain 1 1903,mÃ©tropole mÃ©tropolitain 1,188928000,46.2817,4.68056,76,10,13,03
+DAB,mÃ©tropole mÃ©tropolitain 1 1101,mÃ©tropole mÃ©tropolitain 1,185360000,48.88,2.28389,167,10,0b,01
+DAB,mÃ©tropole mÃ©tropolitain 1 1110,mÃ©tropole mÃ©tropolitain 1,185360000,48.8675,2.41528,139,14,0b,0a
+DAB,mÃ©tropole mÃ©tropolitain 1 1403,mÃ©tropole mÃ©tropolitain 1,185360000,48.1647,2.88139,38,1.8,0e,03
+DAB,mÃ©tropole mÃ©tropolitain 1 1410,mÃ©tropole mÃ©tropolitain 1,185360000,48.4267,2.71083,46,5.6,0e,0a
+DAB,mÃ©tropole mÃ©tropolitain 1 6702,mÃ©tropole mÃ©tropolitain 1,194064000,48.2911,2.68194,28,1.7,43,02
+DAB,mÃ©tropole mÃ©tropolitain 1 0405,mÃ©tropole mÃ©tropolitain 1,211648000,43.97,4.85972,88,4,04,05
+DAB,mÃ©tropole mÃ©tropolitain 1 0608,mÃ©tropole mÃ©tropolitain 1,208064000,47.5394,3.89389,20,5,06,08
+DAB,mÃ©tropole mÃ©tropolitain 1 1010,mÃ©tropole mÃ©tropolitain 1,208064000,47.8406,3.66639,101,7,0a,0a
+DAB,mÃ©tropole mÃ©tropolitain 1 1401,mÃ©tropole mÃ©tropolitain 1,185360000,48.6,2.44278,86,3,0e,01
+DAB,mÃ©tropole mÃ©tropolitain 1 1402,mÃ©tropole mÃ©tropolitain 1,185360000,48.4783,2.42417,93,6,0e,02
+DAB,mÃ©tropole mÃ©tropolitain 2 0808,mÃ©tropole mÃ©tropolitain 2,190640000,45.3156,4.74611,15,2.6,08,08
+DAB,mÃ©tropole mÃ©tropolitain 2 0806,mÃ©tropole mÃ©tropolitain 2,190640000,44.9642,4.80083,25,5,08,06
+DAB,mÃ©tropole mÃ©tropolitain 2 2807,mÃ©tropole mÃ©tropolitain 2,197648000,43.6319,5.09611,23,1.9,1c,07
+DAB,mÃ©tropole mÃ©tropolitain 2 2808,mÃ©tropole mÃ©tropolitain 2,197648000,43.5403,5.23833,14,2,1c,08
+DAB,mÃ©tropole mÃ©tropolitain 2 0010,mÃ©tropole mÃ©tropolitain 2,206352000,47.1456,4.66167,52,2.6,00,0a
+DAB,mÃ©tropole mÃ©tropolitain 2 1310,mÃ©tropole mÃ©tropolitain 2,206352000,47.0347,4.81389,42,4,0d,0a
+DAB,mÃ©tropole mÃ©tropolitain 2 0001,mÃ©tropole mÃ©tropolitain 2,206352000,47.485,4.1575,32,1.7,00,01
+DAB,mÃ©tropole mÃ©tropolitain 2 0002,mÃ©tropole mÃ©tropolitain 2,206352000,47.3469,4.45889,45,1.7,00,02
+DAB,mÃ©tropole mÃ©tropolitain 2 0607,mÃ©tropole mÃ©tropolitain 2,213360000,44.6131,4.77917,26,4,06,07
+DAB,mÃ©tropole mÃ©tropolitain 2 0602,mÃ©tropole mÃ©tropolitain 2,213360000,44.1814,4.66222,47,4,06,02
+DAB,mÃ©tropole mÃ©tropolitain 2 0504,mÃ©tropole mÃ©tropolitain 2,199360000,48.0333,3.00278,78,4,05,04
+DAB,mÃ©tropole mÃ©tropolitain 2 2010,mÃ©tropole mÃ©tropolitain 2,190640000,45.8225,4.82083,34,10,14,0a
+DAB,mÃ©tropole mÃ©tropolitain 2 0805,mÃ©tropole mÃ©tropolitain 2,190640000,45.5325,4.80861,45,10,08,05
+DAB,mÃ©tropole mÃ©tropolitain 2 2004,mÃ©tropole mÃ©tropolitain 2,190640000,45.965,4.70361,19,10,14,04
+DAB,mÃ©tropole mÃ©tropolitain 2 1302,mÃ©tropole mÃ©tropolitain 2,206352000,46.7364,4.665,27,6.5,0d,02
+DAB,mÃ©tropole mÃ©tropolitain 2 0101,mÃ©tropole mÃ©tropolitain 2,199360000,46.3517,4.78333,32,5,01,01
+DAB,mÃ©tropole mÃ©tropolitain 2 1301,mÃ©tropole mÃ©tropolitain 2,206352000,46.5656,4.87639,29,5,0d,01
+DAB,mÃ©tropole mÃ©tropolitain 2 0501,mÃ©tropole mÃ©tropolitain 2,199360000,48.88,2.28389,167,10,05,01
+DAB,mÃ©tropole mÃ©tropolitain 2 0510,mÃ©tropole mÃ©tropolitain 2,199360000,48.8675,2.41528,139,14,05,0a
+DAB,mÃ©tropole mÃ©tropolitain 2 0505,mÃ©tropole mÃ©tropolitain 2,199360000,48.1647,2.88139,38,14,05,05
+DAB,mÃ©tropole mÃ©tropolitain 2 0506,mÃ©tropole mÃ©tropolitain 2,199360000,48.4286,2.54028,36,1.7,05,06
+DAB,mÃ©tropole mÃ©tropolitain 2 0507,mÃ©tropole mÃ©tropolitain 2,199360000,48.2911,2.68194,28,1.7,05,07
+DAB,mÃ©tropole mÃ©tropolitain 2 0605,mÃ©tropole mÃ©tropolitain 2,213360000,43.97,4.85972,88,4.2,06,05
+DAB,mÃ©tropole mÃ©tropolitain 2 0606,mÃ©tropole mÃ©tropolitain 2,213360000,43.8036,5.04694,39,4.2,06,06
+DAB,mÃ©tropole mÃ©tropolitain 2 0003,mÃ©tropole mÃ©tropolitain 2,206352000,47.5394,3.89389,20,2.6,00,03
+DAB,mÃ©tropole mÃ©tropolitain 2 0004,mÃ©tropole mÃ©tropolitain 2,206352000,47.8406,3.66639,101,7,00,04
+DAB,mÃ©tropole mÃ©tropolitain 2 0503,mÃ©tropole mÃ©tropolitain 2,199360000,48.6286,2.42806,52,7,05,03
+DAB,Dijon Ã©tendu 1 0410,Dijon Ã©tendu 1,204640000,47.3003,4.99056,29,7.5,04,0a
+DAB,Dijon Ã©tendu 1 0402,Dijon Ã©tendu 1,204640000,46.7364,4.665,27,6.5,04,02
+DAB,Avignon Ã©tendu 1 2505,Avignon Ã©tendu 1,208064000,43.97,4.85972,88,7.7,19,05
+DAB,Avignon Ã©tendu 1 2502,Avignon Ã©tendu 1,208064000,44.1814,4.66222,47,6,19,02
+DAB,Paris Ã©tendu 1 0701,Paris Ã©tendu 1,218640000,48.88,2.28389,167,10,07,01
+DAB,Paris Ã©tendu 1 0710,Paris Ã©tendu 1,218640000,48.8675,2.41528,139,14,07,0a
 DAB,Avignon local 1 3605,Avignon local 1,178352000,43.97,4.85972,88,4.6,24,05
 DAB,Dijon local 1 6710,Dijon local 1,218640000,47.315,4.98667,27,7.7,43,0a
-DAB,Lille étendu 1 0001,Lille étendu 1,195936000,50.4186,2.65944,74,10.5,00,01
+DAB,Lille Ã©tendu 1 0001,Lille Ã©tendu 1,195936000,50.4186,2.65944,74,10.5,00,01
 DAB,Lyon local 1 2410,Lyon local 1,218640000,45.8181,4.90667,56,7,18,0a
-DAB,Marseille étendu 1 3210,Marseille étendu 1,176640000,43.3839,5.42556,106,10,20,0a
-DAB,Marseille étendu 1 3201,Marseille étendu 1,176640000,43.2747,5.30833,27,4,20,01
-DAB,Paris intermédiaire 2 1301,Paris intermédiaire 2,187072000,48.8025,2.20444,103,10,0d,01
-DAB,Nice intermédiaire 1 1004,Nice intermédiaire 1,218640000,43.7217,7.32083,53,8,0a,04
-DAB,Nice intermédiaire 1 1005,Nice intermédiaire 1,218640000,43.5783,7.03556,45,4,0a,05
-DAB,métropole métropolitain 1 2710,métropole métropolitain 1,192352000,43.3892,5.4125,71,20,1b,0a
+DAB,Marseille Ã©tendu 1 3210,Marseille Ã©tendu 1,176640000,43.3839,5.42556,106,10,20,0a
+DAB,Marseille Ã©tendu 1 3201,Marseille Ã©tendu 1,176640000,43.2747,5.30833,27,4,20,01
+DAB,Paris intermÃ©diaire 2 1301,Paris intermÃ©diaire 2,187072000,48.8025,2.20444,103,10,0d,01
+DAB,Nice intermÃ©diaire 1 1004,Nice intermÃ©diaire 1,218640000,43.7217,7.32083,53,8,0a,04
+DAB,Nice intermÃ©diaire 1 1005,Nice intermÃ©diaire 1,218640000,43.5783,7.03556,45,4,0a,05
+DAB,mÃ©tropole mÃ©tropolitain 1 2710,mÃ©tropole mÃ©tropolitain 1,192352000,43.3892,5.4125,71,20,1b,0a
 DAB,Toulon local 1 0010,Toulon local 1,220352000,43.0531,5.84556,72,4,00,0a
-DAB,Toulon étendu 1 2610,Toulon étendu 1,202928000,43.0531,5.84556,72,10,1a,0a
-DAB,Toulon étendu 1 2601,Toulon étendu 1,202928000,43.3686,5.99194,49,4.8,1a,01
-DAB,Toulon étendu 1 2602,Toulon étendu 1,202928000,43.2814,6.29417,70,4.8,1a,02
-DAB,Toulon étendu 1 2603,Toulon étendu 1,202928000,43.1033,6.34889,22,5,1a,03
-DAB,métropole métropolitain 2 2810,métropole métropolitain 2,197648000,43.3892,5.4125,71,20,1c,0a
-DAB,Orléans local 1 2310,Orléans local 1,178352000,47.9433,1.9275,89,6.4,17,0a
+DAB,Toulon Ã©tendu 1 2610,Toulon Ã©tendu 1,202928000,43.0531,5.84556,72,10,1a,0a
+DAB,Toulon Ã©tendu 1 2601,Toulon Ã©tendu 1,202928000,43.3686,5.99194,49,4.8,1a,01
+DAB,Toulon Ã©tendu 1 2602,Toulon Ã©tendu 1,202928000,43.2814,6.29417,70,4.8,1a,02
+DAB,Toulon Ã©tendu 1 2603,Toulon Ã©tendu 1,202928000,43.1033,6.34889,22,5,1a,03
+DAB,mÃ©tropole mÃ©tropolitain 2 2810,mÃ©tropole mÃ©tropolitain 2,197648000,43.3892,5.4125,71,20,1c,0a
+DAB,OrlÃ©ans local 1 2310,OrlÃ©ans local 1,178352000,47.9433,1.9275,89,6.4,17,0a
 DAB,Poitiers local 1 1410,Poitiers local 1,192352000,46.5628,0.348889,74,8.2,0e,0a
 DAB,Tours local 1 2610,Tours local 1,204640000,47.4144,0.684722,52,9.4,1a,0a
-DAB,Saint-Étienne étendu 1 0510,Saint-Étienne étendu 1,185360000,45.4006,4.38778,62,10,05,0a
-DAB,Saint-Étienne étendu 1 0501,Saint-Étienne étendu 1,185360000,45.9844,3.91944,21,5,05,01
-DAB,Nice intermédiaire 2 1705,Nice intermédiaire 2,220352000,43.5783,7.03556,46,4,11,05
-DAB,Nice intermédiaire 2 1706,Nice intermédiaire 2,220352000,43.6611,6.9175,17,3.5,11,06
+DAB,Saint-Ã‰tienne Ã©tendu 1 0510,Saint-Ã‰tienne Ã©tendu 1,185360000,45.4006,4.38778,62,10,05,0a
+DAB,Saint-Ã‰tienne Ã©tendu 1 0501,Saint-Ã‰tienne Ã©tendu 1,185360000,45.9844,3.91944,21,5,05,01
+DAB,Nice intermÃ©diaire 2 1705,Nice intermÃ©diaire 2,220352000,43.5783,7.03556,46,4,11,05
+DAB,Nice intermÃ©diaire 2 1706,Nice intermÃ©diaire 2,220352000,43.6611,6.9175,17,3.5,11,06
 DAB,Nice local 2 0405,Nice local 2,208064000,43.5783,7.03556,46,4,04,05
 DAB,Nice local 2 0404,Nice local 2,208064000,43.7217,7.32083,54,5,04,04
-DAB,Paris intermédiaire 1 1201,Paris intermédiaire 1,181936000,48.8025,2.20444,103,10,0c,01
+DAB,Paris intermÃ©diaire 1 1201,Paris intermÃ©diaire 1,181936000,48.8025,2.20444,103,10,0c,01
 DAB,Lille local 1 0505,Lille local 1,192352000,50.6897,3.1825,78,0.4,05,05
-DAB,Annecy étendu 1 1801,Annecy étendu 1,192352000,45.9164,6.17222,32,4,12,01
-DAB,Annecy étendu 1 1002,Annecy étendu 1,192352000,46.1453,6.18861,24,4,0a,02
-DAB,Annecy étendu 1 1803,Annecy étendu 1,192352000,45.66,5.82139,32,4,12,03
+DAB,Annecy Ã©tendu 1 1801,Annecy Ã©tendu 1,192352000,45.9164,6.17222,32,4,12,01
+DAB,Annecy Ã©tendu 1 1002,Annecy Ã©tendu 1,192352000,46.1453,6.18861,24,4,0a,02
+DAB,Annecy Ã©tendu 1 1803,Annecy Ã©tendu 1,192352000,45.66,5.82139,32,4,12,03
 DAB,Annemasse local 1 3402,Annemasse local 1,194064000,46.1681,6.21806,23,3,22,02
-DAB,Chambéry local 1 2103,Chambéry local 1,187072000,45.6633,5.82222,18,5,15,03
+DAB,ChambÃ©ry local 1 2103,ChambÃ©ry local 1,187072000,45.6633,5.82222,18,5,15,03
 DAB,Grenoble local 1 2601,Grenoble local 1,206352000,45.1508,5.665,37,6.7,1a,01
 DAB,Grenoble local 1 2602,Grenoble local 1,206352000,45.2603,5.54611,33,3.5,1a,02
-DAB,Saint-Étienne local 1 3610,Saint-Étienne local 1,195936000,45.4,4.39389,22,8.6,24,0a
-DAB,Orléans étendu 1 0810,Orléans étendu 1,209936000,47.9433,1.9275,88,9,08,0a
-DAB,Orléans étendu 1 0801,Orléans étendu 1,209936000,47.6083,1.30306,58,3,08,01
-DAB,Orléans étendu 1 0802,Orléans étendu 1,209936000,47.9983,2.74194,49,4,08,02
-DAB,Poitiers étendu 1 0110,Poitiers étendu 1,206352000,46.5914,0.3475,61,6,01,0a
-DAB,Poitiers étendu 1 0101,Poitiers étendu 1,206352000,46.9047,0.526389,70,5.5,01,01
-DAB,Poitiers étendu 1 0102,Poitiers étendu 1,206352000,46.3489,-0.430556,82,4,01,02
-DAB,Tours étendu 1 2710,Tours étendu 1,185360000,47.4058,0.724167,36,10,1b,0a
-DAB,Tours étendu 1 2701,Tours étendu 1,185360000,46.9644,0.684444,27,1.7,1b,01
-DAB,Tours étendu 1 2702,Tours étendu 1,185360000,47.1361,0.228333,20,2.6,1b,02
+DAB,Saint-Ã‰tienne local 1 3610,Saint-Ã‰tienne local 1,195936000,45.4,4.39389,22,8.6,24,0a
+DAB,OrlÃ©ans Ã©tendu 1 0810,OrlÃ©ans Ã©tendu 1,209936000,47.9433,1.9275,88,9,08,0a
+DAB,OrlÃ©ans Ã©tendu 1 0801,OrlÃ©ans Ã©tendu 1,209936000,47.6083,1.30306,58,3,08,01
+DAB,OrlÃ©ans Ã©tendu 1 0802,OrlÃ©ans Ã©tendu 1,209936000,47.9983,2.74194,49,4,08,02
+DAB,Poitiers Ã©tendu 1 0110,Poitiers Ã©tendu 1,206352000,46.5914,0.3475,61,6,01,0a
+DAB,Poitiers Ã©tendu 1 0101,Poitiers Ã©tendu 1,206352000,46.9047,0.526389,70,5.5,01,01
+DAB,Poitiers Ã©tendu 1 0102,Poitiers Ã©tendu 1,206352000,46.3489,-0.430556,82,4,01,02
+DAB,Tours Ã©tendu 1 2710,Tours Ã©tendu 1,185360000,47.4058,0.724167,36,10,1b,0a
+DAB,Tours Ã©tendu 1 2701,Tours Ã©tendu 1,185360000,46.9644,0.684444,27,1.7,1b,01
+DAB,Tours Ã©tendu 1 2702,Tours Ã©tendu 1,185360000,47.1361,0.228333,20,2.6,1b,02
 DAB,Annecy local 1 3101,Annecy local 1,222064000,45.9161,6.16944,25,8,1f,01
-DAB,Grenoble étendu 1 0301,Grenoble étendu 1,180064000,45.1508,5.665,37,6.7,03,01
-DAB,Grenoble étendu 1 0302,Grenoble étendu 1,180064000,45.2603,5.54611,33,3.5,03,02
-DAB,Grenoble étendu 1 0303,Grenoble étendu 1,180064000,45.5578,5.45361,12,2.6,03,03
+DAB,Grenoble Ã©tendu 1 0301,Grenoble Ã©tendu 1,180064000,45.1508,5.665,37,6.7,03,01
+DAB,Grenoble Ã©tendu 1 0302,Grenoble Ã©tendu 1,180064000,45.2603,5.54611,33,3.5,03,02
+DAB,Grenoble Ã©tendu 1 0303,Grenoble Ã©tendu 1,180064000,45.5578,5.45361,12,2.6,03,03
 DAB,Valenciennes local 1 2206,Valenciennes local 1,188928000,50.2675,3.92194,46,9.5,16,06
-DAB,Nice étendu 1 3105,Nice étendu 1,216928000,43.5694,7.035,48,3.5,1f,05
-DAB,Nice étendu 1 3106,Nice étendu 1,216928000,43.4328,6.81167,24,4,1f,06
-DAB,Besançon local 1 2410,Besançon local 1,202928000,47.2422,6.08361,79,3,18,0a
-DAB,métropole métropolitain 1 2702,métropole métropolitain 1,192352000,43.8386,5.03028,13,1.7,1b,02
-DAB,métropole métropolitain 1 0410,métropole métropolitain 1,211648000,43.8247,4.34083,73,5,04,0a
-DAB,métropole métropolitain 1 1904,métropole métropolitain 1,188928000,45.7983,4.70361,20,0.1,13,04
-DAB,Montpellier étendu 1 0802,Montpellier étendu 1,220352000,43.1642,2.97306,24,3.3,08,02
-DAB,Montpellier étendu 1 0801,Montpellier étendu 1,220352000,43.3631,3.22917,27,3.3,08,01
-DAB,Montpellier étendu 1 0810,Montpellier étendu 1,220352000,43.5242,3.64444,65,3.5,08,0a
-DAB,Nîmes étendu 1 1701,Nîmes étendu 1,209936000,44.1164,4.05944,14,5,11,01
+DAB,Nice Ã©tendu 1 3105,Nice Ã©tendu 1,216928000,43.5694,7.035,48,3.5,1f,05
+DAB,Nice Ã©tendu 1 3106,Nice Ã©tendu 1,216928000,43.4328,6.81167,24,4,1f,06
+DAB,BesanÃ§on local 1 2410,BesanÃ§on local 1,202928000,47.2422,6.08361,79,3,18,0a
+DAB,mÃ©tropole mÃ©tropolitain 1 2702,mÃ©tropole mÃ©tropolitain 1,192352000,43.8386,5.03028,13,1.7,1b,02
+DAB,mÃ©tropole mÃ©tropolitain 1 0410,mÃ©tropole mÃ©tropolitain 1,211648000,43.8247,4.34083,73,5,04,0a
+DAB,mÃ©tropole mÃ©tropolitain 1 1904,mÃ©tropole mÃ©tropolitain 1,188928000,45.7983,4.70361,20,0.1,13,04
+DAB,Montpellier Ã©tendu 1 0802,Montpellier Ã©tendu 1,220352000,43.1642,2.97306,24,3.3,08,02
+DAB,Montpellier Ã©tendu 1 0801,Montpellier Ã©tendu 1,220352000,43.3631,3.22917,27,3.3,08,01
+DAB,Montpellier Ã©tendu 1 0810,Montpellier Ã©tendu 1,220352000,43.5242,3.64444,65,3.5,08,0a
+DAB,NÃ®mes Ã©tendu 1 1701,NÃ®mes Ã©tendu 1,209936000,44.1164,4.05944,14,5,11,01
 DAB,Perpignan local 1 0310,Perpignan local 1,216928000,42.7681,2.77917,26,5,03,0a
-DAB,métropole métropolitain 2 2809,métropole métropolitain 2,197648000,43.3586,5.57444,27,2.6,1c,09
-DAB,métropole métropolitain 2 1303,métropole métropolitain 2,206352000,47.3003,4.99056,29,5,0d,03
-DAB,métropole métropolitain 2 0005,métropole métropolitain 2,206352000,47.335,4.81083,22,2.6,00,05
-DAB,Amiens étendu 1 0810,Amiens étendu 1,0,49.8597,2.28222,,0,08,0a
+DAB,mÃ©tropole mÃ©tropolitain 2 2809,mÃ©tropole mÃ©tropolitain 2,197648000,43.3586,5.57444,27,2.6,1c,09
+DAB,mÃ©tropole mÃ©tropolitain 2 1303,mÃ©tropole mÃ©tropolitain 2,206352000,47.3003,4.99056,29,5,0d,03
+DAB,mÃ©tropole mÃ©tropolitain 2 0005,mÃ©tropole mÃ©tropolitain 2,206352000,47.335,4.81083,22,2.6,00,05
+DAB,Amiens Ã©tendu 1 0810,Amiens Ã©tendu 1,0,49.8597,2.28222,,0,08,0a
 DAB,Amiens local 1 3010,Amiens local 1,0,49.8597,2.28222,,0,1e,0a
-DAB,Besançon étendu 1 1202,Besançon étendu 1,180064000,46.6519,5.58222,36,2.6,0c,02
-DAB,Besançon étendu 1 1203,Besançon étendu 1,180064000,47.1169,5.47,35,2.6,0c,03
+DAB,BesanÃ§on Ã©tendu 1 1202,BesanÃ§on Ã©tendu 1,180064000,46.6519,5.58222,36,2.6,0c,02
+DAB,BesanÃ§on Ã©tendu 1 1203,BesanÃ§on Ã©tendu 1,180064000,47.1169,5.47,35,2.6,0c,03
 DAB,Annemasse local 1 3404,Annemasse local 1,194064000,46.2908,5.98528,11,8.7,22,04

--- a/plugins/feature/map/map.qrc
+++ b/plugins/feature/map/map.qrc
@@ -25,6 +25,7 @@
     <file>map/heliport.png</file>
     <file>map/waypoint.png</file>
     <file>map/map3d.html</file>
+    <file>data/transmitters.csv</file>
   </qresource>
   <qresource prefix="/">
     <file>Cesium/Cesium.js</file>

--- a/plugins/feature/map/mapsettings.h
+++ b/plugins/feature/map/mapsettings.h
@@ -26,6 +26,8 @@
 #include <QHash>
 #include <QRegularExpression>
 
+#define MAX_FILTER_DISTANCE_KM 10000
+
 class Serializable;
 
 struct MapSettings

--- a/plugins/feature/map/mapsettingsdialog.cpp
+++ b/plugins/feature/map/mapsettingsdialog.cpp
@@ -52,6 +52,7 @@ MapItemSettingsGUI::MapItemSettingsGUI(QTableWidget *table, int row, MapSettings
     m_filterDistance->setValue(settings->m_filterDistance / 1000);
     m_filterDistance->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     m_filterDistance->setSpecialValueText(" ");
+    m_filterDistance->setCorrectionMode(QAbstractSpinBox::CorrectToNearestValue);
     table->setCellWidget(row, MapSettingsDialog::COL_2D_MIN_ZOOM, m_minZoom);
     table->setCellWidget(row, MapSettingsDialog::COL_3D_MIN_PIXELS, m_minPixels);
     table->setCellWidget(row, MapSettingsDialog::COL_3D_LABEL_SCALE, m_labelScale);

--- a/plugins/feature/map/mapsettingsdialog.cpp
+++ b/plugins/feature/map/mapsettingsdialog.cpp
@@ -87,7 +87,7 @@ MapSettingsDialog::MapSettingsDialog(MapSettings *settings, QWidget* parent) :
     QList<MapSettings::MapItemSettings *> itemSettings = m_settings->m_itemSettings.values();
     std::sort(itemSettings.begin(), itemSettings.end(),
         [](const MapSettings::MapItemSettings* a, const MapSettings::MapItemSettings* b) -> bool {
-            return a->m_group < b->m_group;
+            return a->m_group.compare(b->m_group, Qt::CaseInsensitive) < 0;
         });
     QListIterator<MapSettings::MapItemSettings *> itr(itemSettings);
     while (itr.hasNext())

--- a/plugins/feature/map/mapsettingsdialog.cpp
+++ b/plugins/feature/map/mapsettingsdialog.cpp
@@ -47,9 +47,15 @@ MapItemSettingsGUI::MapItemSettingsGUI(QTableWidget *table, int row, MapSettings
     m_labelScale->setRange(0.01, 10.0);
     m_labelScale->setValue(settings->m_3DLabelScale);
     m_labelScale->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    m_filterDistance = new QSpinBox(table);
+    m_filterDistance->setRange(0, MAX_FILTER_DISTANCE_KM);
+    m_filterDistance->setValue(settings->m_filterDistance / 1000);
+    m_filterDistance->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    m_filterDistance->setSpecialValueText(" ");
     table->setCellWidget(row, MapSettingsDialog::COL_2D_MIN_ZOOM, m_minZoom);
     table->setCellWidget(row, MapSettingsDialog::COL_3D_MIN_PIXELS, m_minPixels);
     table->setCellWidget(row, MapSettingsDialog::COL_3D_LABEL_SCALE, m_labelScale);
+    table->setCellWidget(row, MapSettingsDialog::COL_FILTER_DISTANCE, m_filterDistance);
 }
 
 MapSettingsDialog::MapSettingsDialog(MapSettings *settings, QWidget* parent) :
@@ -124,12 +130,6 @@ MapSettingsDialog::MapSettingsDialog(MapSettings *settings, QWidget* parent) :
 
         item = new QTableWidgetItem(itemSettings->m_filterName);
         ui->mapItemSettings->setItem(row, COL_FILTER_NAME, item);
-        item = new QTableWidgetItem();
-        if (itemSettings->m_filterDistance > 0) {
-            item->setText(QString::number(itemSettings->m_filterDistance / 1000));
-        }
-        ui->mapItemSettings->setItem(row, COL_FILTER_DISTANCE, item);
-        ui->mapItemSettings->item(row, COL_FILTER_DISTANCE)->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
 
         MapItemSettingsGUI *gui = new MapItemSettingsGUI(ui->mapItemSettings, row, itemSettings);
         m_mapItemSettingsGUIs.append(gui);
@@ -266,13 +266,7 @@ void MapSettingsDialog::accept()
         itemSettings->m_filterName = ui->mapItemSettings->item(row, COL_FILTER_NAME)->text();
         itemSettings->m_filterNameRE.setPattern(itemSettings->m_filterName);
         itemSettings->m_filterNameRE.optimize();
-        bool ok;
-        int filterDistance = ui->mapItemSettings->item(row, COL_FILTER_DISTANCE)->text().toInt(&ok);
-        if (ok && filterDistance > 0) {
-            itemSettings->m_filterDistance = filterDistance * 1000;
-        } else {
-            itemSettings->m_filterDistance = 0;
-        }
+        itemSettings->m_filterDistance = gui->m_filterDistance->value() * 1000;
     }
 
     QDialog::accept();

--- a/plugins/feature/map/mapsettingsdialog.cpp
+++ b/plugins/feature/map/mapsettingsdialog.cpp
@@ -37,13 +37,16 @@ MapItemSettingsGUI::MapItemSettingsGUI(QTableWidget *table, int row, MapSettings
     m_minZoom = new QSpinBox(table);
     m_minZoom->setRange(0, 15);
     m_minZoom->setValue(settings->m_2DMinZoom);
+    m_minZoom->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     m_minPixels = new QSpinBox(table);
     m_minPixels->setRange(0, 200);
     m_minPixels->setValue(settings->m_3DModelMinPixelSize);
+    m_minPixels->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     m_labelScale = new QDoubleSpinBox(table);
     m_labelScale->setDecimals(2);
     m_labelScale->setRange(0.01, 10.0);
     m_labelScale->setValue(settings->m_3DLabelScale);
+    m_labelScale->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     table->setCellWidget(row, MapSettingsDialog::COL_2D_MIN_ZOOM, m_minZoom);
     table->setCellWidget(row, MapSettingsDialog::COL_3D_MIN_PIXELS, m_minPixels);
     table->setCellWidget(row, MapSettingsDialog::COL_3D_LABEL_SCALE, m_labelScale);
@@ -126,6 +129,7 @@ MapSettingsDialog::MapSettingsDialog(MapSettings *settings, QWidget* parent) :
             item->setText(QString::number(itemSettings->m_filterDistance / 1000));
         }
         ui->mapItemSettings->setItem(row, COL_FILTER_DISTANCE, item);
+        ui->mapItemSettings->item(row, COL_FILTER_DISTANCE)->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
 
         MapItemSettingsGUI *gui = new MapItemSettingsGUI(ui->mapItemSettings, row, itemSettings);
         m_mapItemSettingsGUIs.append(gui);

--- a/plugins/feature/map/mapsettingsdialog.h
+++ b/plugins/feature/map/mapsettingsdialog.h
@@ -47,6 +47,7 @@ public:
     QSpinBox *m_minZoom;
     QSpinBox *m_minPixels;
     QDoubleSpinBox *m_labelScale;
+    QSpinBox *m_filterDistance;
 };
 
 class MapSettingsDialog : public QDialog {

--- a/plugins/feature/map/mapsettingsdialog.ui
+++ b/plugins/feature/map/mapsettingsdialog.ui
@@ -617,7 +617,6 @@
   <tabstop>cesiumIonAPIKey</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../sdrgui/resources/res.qrc"/>
   <include location="icons.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
This PR:

- adds the transmitters.csv file to the resources and converts its encoding from ISO-8859-1 to UTF-8 to show the accented letters
- modifies the table of map items settings
  - to right align all numeric cells
  - to use a QSpinBox for the "Filter Distance" cells
  - to do a case insensitive sorting of column containing the labels

For the  QSpinBox of "Filter Distance" I set a minimum value of zero and a maximum of 10000 km; I used `setSpecialValueText()` to replace the zero with one space so the the look of the table isn't too much different from before (we can't use an empty string or a nullptr because they disable the replacement).

The case sensitive sorting is needed otherwise "Airport" and "Airspace" were coming after APTdemod.