### PR TITLE
Android fixes

### DIFF
--- a/plugins/channelrx/demodapt/aptdemodgui.cpp
+++ b/plugins/channelrx/demodapt/aptdemodgui.cpp
@@ -504,9 +504,18 @@ void APTDemodGUI::on_saveImage_clicked()
         QStringList fileNames = fileDialog.selectedFiles();
         if (fileNames.size() > 0)
         {
-            qDebug() << "APT: Saving image to " << fileNames;
-            if (!m_image.save(fileNames[0])) {
-                QMessageBox::critical(this, "APT Demodulator", QString("Failed to save image to %1").arg(fileNames[0]));
+            QFileInfo fileInfo(fileNames[0]);
+
+            if (fileInfo.suffix() != "")
+            {
+                qDebug() << "APT: Saving image to " << fileNames;
+                if (!m_image.save(fileNames[0])) {
+                    QMessageBox::critical(this, "APT Demodulator", QString("Failed to save image to %1").arg(fileNames[0]));
+                }
+            }
+            else
+            {
+                QMessageBox::critical(this, "APT Demodulator", QString("Please specify a filename with an extension such as .png or .jpg"));
             }
         }
     }

--- a/sdrgui/gui/configurationsdialog.cpp
+++ b/sdrgui/gui/configurationsdialog.cpp
@@ -375,11 +375,14 @@ void ConfigurationsDialog::on_configurationExport_clicked()
 
 			if (fileName != "")
 			{
+#ifndef ANDROID
+                // Can't change filenames on Android
 				QFileInfo fileInfo(fileName);
 
 				if (fileInfo.suffix() != "cfgx") {
 					fileName += ".cfgx";
 				}
+#endif
 
 				QFile exportFile(fileName);
 

--- a/sdrgui/gui/devicesetpresetsdialog.cpp
+++ b/sdrgui/gui/devicesetpresetsdialog.cpp
@@ -297,11 +297,14 @@ void DeviceSetPresetsDialog::on_presetExport_clicked()
 
 			if (fileName != "")
 			{
+#ifndef ANDROID
+                // Can't change filenames on Android
 				QFileInfo fileInfo(fileName);
 
 				if (fileInfo.suffix() != "prex") {
 					fileName += ".prex";
 				}
+#endif
 
 				QFile exportFile(fileName);
 


### PR DESCRIPTION
In configuration dialogs, don't try to append filename suffix on Android, as we can only write to filename specified by user.
In APT Demod, check for filename suffix when saving image, as QImage::save() will fail without one.

For #2189.
