### PR TITLE
Improve indication of API server address

### DIFF
--- a/sdrbase/webapi/webapiserver.cpp
+++ b/sdrbase/webapi/webapiserver.cpp
@@ -44,7 +44,7 @@ void WebAPIServer::start()
     if (!m_listener)
     {
         m_listener = new qtwebapp::HttpListener(m_settings, m_requestMapper, qApp);
-        qInfo("WebAPIServer::start: starting web API server at http://%s:%d", qPrintable(m_settings.host), m_settings.port);
+        qInfo("WebAPIServer::start: starting web API server at http://%s:%d", qPrintable(m_settings.host.isEmpty() ? "0.0.0.0" : m_settings.host), m_settings.port);
     }
 }
 
@@ -54,7 +54,7 @@ void WebAPIServer::stop()
     {
         delete m_listener;
         m_listener = 0;
-        qInfo("WebAPIServer::stop: stopped web API server at http://%s:%d", qPrintable(m_settings.host), m_settings.port);
+        qInfo("WebAPIServer::stop: stopped web API server at http://%s:%d", qPrintable(m_settings.host.isEmpty() ? "0.0.0.0" : m_settings.host), m_settings.port);
     }
 }
 

--- a/sdrgui/gui/aboutdialog.cpp
+++ b/sdrgui/gui/aboutdialog.cpp
@@ -32,7 +32,7 @@ AboutDialog::AboutDialog(const QString& apiHost, int apiPort, const MainSettings
 	ui->dspBits->setText(QString("DSP Rx %1 bits Tx %2 bits").arg(SDR_RX_SAMP_SZ).arg(SDR_TX_SAMP_SZ));
 	ui->pid->setText(QString("PID: %1").arg(qApp->applicationPid()));
 	QString apiUrl = QString("http://%1:%2/").arg(apiHost).arg(apiPort);
-	ui->restApiUrl->setText(QString("REST API documentation: <a href=\"%1\">%2</a>").arg(apiUrl).arg(apiUrl));
+	ui->restApiUrl->setText(QString("REST API server and documentation: <a href=\"%1\">%2</a>").arg(apiUrl).arg(apiUrl));
 	ui->restApiUrl->setOpenExternalLinks(true);
 	ui->settingsFile->setText(QString("Settings: %1").arg(mainSettings.getFileLocation()));
 }

--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -3096,7 +3096,7 @@ void MainWindow::loadDefaultPreset(const QString& pluginId, SerializableInterfac
 
 void MainWindow::on_action_About_triggered()
 {
-	AboutDialog dlg(m_apiHost.isEmpty() ? "127.0.0.1" : m_apiHost, m_apiPort, m_mainCore->m_settings, this);
+	AboutDialog dlg(m_apiHost.isEmpty() ? "0.0.0.0" : m_apiHost, m_apiPort, m_mainCore->m_settings, this);
 	dlg.exec();
 }
 


### PR DESCRIPTION
The API server is accepting commands on port 8091 of all interfaces but the about dialog shows only 127.0.0.1:8091 and it is labeled as the address of the documentation:
![image](https://github.com/user-attachments/assets/652dc4f3-fe68-456e-974f-036bd6ef7fd9)
and the log messages print an empty string as address:
```
2024-07-20 20:57:50.191 (I) WebAPIServer::start: starting web API server at http://:8091
2024-07-20 20:59:07.028 (I) WebAPIServer::stop: stopped web API server at http://:8091
```
This PR tries to improve the information about the IP address in tha About dialog changing the label and using the address `0.0.0.0` as used in in `httplistener.cpp` and according to the documentation at https://doc.qt.io/qt-6/qhostaddress.html#toString which says that `QHostAddress::Any` is indicated with the address 0.0.0.0 even if it is listening on both IPv4 and IPv6.
![image](https://github.com/user-attachments/assets/b574bf71-005b-43f3-afab-9d7387ec0974)
```
2024-07-20 22:13:34.488 (I) WebAPIServer::start: starting web API server at http://0.0.0.0:8091
2024-07-20 22:14:06.499 (I) WebAPIServer::stop: stopped web API server at http://0.0.0.0:8091
```
The problem is that using `0.0.0.0` and `[::]` in Firefox and Chrome work in Linux but not in Windows.
On Linux all the following addresses open the pages of the API server:

1. http://127.0.0.1:8091/

1. [http://[::1]:8091/](http://[::1]:8091/)

1. [http://0.0.0.0:8091/](http://0.0.0.0:8091/)

1. [http://[::]:8091/](http://[::]:8091/)

plus any other address assigned to wired, wireless or virtual interfaces.
On Windows # 3 and # 4 give ERR_ADDRESS_INVALID.

An alternative would be print `0.0.0.0` in the log and `127.0.0.0` in the About dialog but adding something like "and other interfaces", maybe only on Windows.
