### PR TITLE
 Fix audio glitches in the DAB plugin

### DIFF
--- a/plugins/channelrx/demoddab/dabdemodsink.cpp
+++ b/plugins/channelrx/demoddab/dabdemodsink.cpp
@@ -366,7 +366,7 @@ void DABDemodSink::tii(int tii)
     }
 }
 
-static int16_t scale(int16_t sample, float factor)
+static int16_t scale(Real sample, float factor)
 {
     int32_t prod = (int32_t)(((int32_t)sample) * factor);
     prod = std::min(prod, 32767);

--- a/plugins/channelrx/demoddab/dabdemodsink.cpp
+++ b/plugins/channelrx/demoddab/dabdemodsink.cpp
@@ -403,7 +403,12 @@ void DABDemodSink::audio(int16_t *buffer, int size, int samplerate, bool stereo)
             ci.real(0.0f);
             ci.imag(0.0f);
         }
-        if (m_audioInterpolatorDistance < 1.0f) // interpolate
+
+        if (m_audioInterpolatorDistance == 1.0f)
+        {
+            processOneAudioSample(ci);
+        }
+        else if (m_audioInterpolatorDistance < 1.0f) // interpolate
         {
             while (!m_audioInterpolator.interpolate(&m_audioInterpolatorDistanceRemain, ci, &ca))
             {


### PR DESCRIPTION
The glitches were generated by an int16 integer overflow.

The issue appeared when the audio was near or at the saturation level.
When the input audio signal is saturated, the polyphase filter based interpolation/decimation functions tend to increase the samples values and then make them pass the int16 limits. The int16 sample scale() parameter defeat the min/max limitation.

This fix removes the intermediate int16 type conversion by using the Complex Real type.

fixes https://github.com/f4exb/sdrangel/issues/1978

Also : The audio signal is not decimated anymore if not needed.