### PR TITLE
Use new find_package(CUDA Toolkit)

### DIFF
--- a/sdrbase/CMakeLists.txt
+++ b/sdrbase/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 
 # CUDA Toolkit: https://developer.nvidia.com/cuda-downloads
 if (${VKFFT_BACKEND} EQUAL 1)
-    find_package(CUDA 9.0)
+    find_package(CUDAToolkit)    
     if(CUDA_FOUND)
         enable_language(CUDA)
         set(sdrbase_SOURCES


### PR DESCRIPTION
On current Ubuntu Noble, unable to compile against CUDA using default sdrbase/CMakeLists.txt due to unsupported find_package(CUDA 9.0).

Instead use:
https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html

See suggestions at:
https://stackoverflow.com/questions/68475502/c-with-cuda-project-in-cmake-gives-error-nvlink-fatal-could-not-open-input

