### PR TITLE
RTLSDR: Apply driver settings in RTLSDRThread

### DIFF
--- a/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
@@ -241,7 +241,7 @@ bool RTLSDRInput::start()
 
     qDebug("RTLSDRInput::start");
 
-	m_rtlSDRThread = new RTLSDRThread(m_dev, &m_sampleFifo, &m_replayBuffer, m_settings);
+    m_rtlSDRThread = new RTLSDRThread(m_dev, &m_sampleFifo, &m_replayBuffer, m_settings);
     connect(m_rtlSDRThread, &QThread::finished, m_rtlSDRThread, &QObject::deleteLater);
 	m_rtlSDRThread->startWork();
 	m_running = true;

--- a/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
@@ -343,7 +343,6 @@ void RTLSDRInput::setCenterFrequency(qint64 centerFrequency)
 
 bool RTLSDRInput::handleMessage(const Message& message)
 {
-    qDebug() << "RTLSDRInput::handleMessage";
     if (MsgConfigureRTLSDR::match(message))
     {
         auto& conf = (const MsgConfigureRTLSDR&) message;

--- a/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
@@ -92,7 +92,6 @@ RTLSDRInput::~RTLSDRInput()
     }
 
     closeDevice();
-    qDebug("RTLSDRInput::~RTLSDRInput: end");
 }
 
 void RTLSDRInput::destroy()
@@ -242,11 +241,8 @@ bool RTLSDRInput::start()
 
     qDebug("RTLSDRInput::start");
 
-	m_rtlSDRThread = new RTLSDRThread(m_dev, &m_sampleFifo, &m_replayBuffer);
-	m_rtlSDRThread->setSamplerate(m_settings.m_devSampleRate);
-	m_rtlSDRThread->setLog2Decimation(m_settings.m_log2Decim);
-	m_rtlSDRThread->setFcPos((int) m_settings.m_fcPos);
-    m_rtlSDRThread->setIQOrder(m_settings.m_iqOrder);
+	m_rtlSDRThread = new RTLSDRThread(m_dev, &m_sampleFifo, &m_replayBuffer, m_settings);
+    connect(m_rtlSDRThread, &QThread::finished, m_rtlSDRThread, &QObject::deleteLater);
 	m_rtlSDRThread->startWork();
 	m_running = true;
 
@@ -281,8 +277,7 @@ void RTLSDRInput::stop()
 	if (m_rtlSDRThread)
 	{
 		m_rtlSDRThread->stopWork();
-		delete m_rtlSDRThread;
-		m_rtlSDRThread = nullptr;
+		m_rtlSDRThread = nullptr; // Deleted automatically when thread finishes
 	}
 
 	m_running = false;
@@ -348,6 +343,7 @@ void RTLSDRInput::setCenterFrequency(qint64 centerFrequency)
 
 bool RTLSDRInput::handleMessage(const Message& message)
 {
+    qDebug() << "RTLSDRInput::handleMessage";
     if (MsgConfigureRTLSDR::match(message))
     {
         auto& conf = (const MsgConfigureRTLSDR&) message;
@@ -401,15 +397,6 @@ bool RTLSDRInput::applySettings(const RTLSDRSettings& settings, const QList<QStr
     qDebug() << "RTLSDRInput::applySettings: force: " << force << settings.getDebugString(settingsKeys, force);
     bool forwardChange = false;
 
-    if (settingsKeys.contains("agc") || force)
-    {
-        if (rtlsdr_set_agc_mode(m_dev, settings.m_agc ? 1 : 0) < 0) {
-            qCritical("RTLSDRInput::applySettings: could not set AGC mode %s", settings.m_agc ? "on" : "off");
-        } else {
-            qDebug("RTLSDRInput::applySettings: AGC mode %s", settings.m_agc ? "on" : "off");
-        }
-    }
-
     if (settingsKeys.contains("dcBlock") || settingsKeys.contains("iqImbalance") || force)
     {
         m_deviceAPI->configureCorrections(settings.m_dcBlock, settings.m_iqImbalance);
@@ -418,61 +405,11 @@ bool RTLSDRInput::applySettings(const RTLSDRSettings& settings, const QList<QStr
                 settings.m_iqImbalance ? "true" : "false");
     }
 
-    if ((m_dev != nullptr) && (settingsKeys.contains("loPpmCorrection") || force))
-    {
-        if (rtlsdr_set_freq_correction(m_dev, settings.m_loPpmCorrection) < 0) {
-            qCritical("RTLSDRInput::applySettings: could not set LO ppm correction: %d", settings.m_loPpmCorrection);
-        } else {
-            qDebug("RTLSDRInput::applySettings: LO ppm correction set to: %d", settings.m_loPpmCorrection);
-        }
-    }
-
     if (settingsKeys.contains("devSampleRate") || force)
     {
-        forwardChange = true;
-
-        if(m_dev != nullptr)
-        {
-            if( rtlsdr_set_sample_rate(m_dev, settings.m_devSampleRate) < 0)
-            {
-                qCritical("RTLSDRInput::applySettings: could not set sample rate: %d", settings.m_devSampleRate);
-            }
-            else
-            {
-                if (m_rtlSDRThread) {
-                    m_rtlSDRThread->setSamplerate(settings.m_devSampleRate);
-                }
-
-                qDebug("RTLSDRInput::applySettings: sample rate set to %d", settings.m_devSampleRate);
-            }
-            if (settings.m_devSampleRate != m_settings.m_devSampleRate) {
-                m_replayBuffer.clear();
-            }
+        if (settings.m_devSampleRate != m_settings.m_devSampleRate) {
+            m_replayBuffer.clear();
         }
-    }
-
-    if (settingsKeys.contains("log2Decim") || force)
-    {
-        forwardChange = true;
-
-        if (m_rtlSDRThread) {
-            m_rtlSDRThread->setLog2Decimation(settings.m_log2Decim);
-        }
-
-        qDebug("RTLSDRInput::applySettings: log2decim set to %d", settings.m_log2Decim);
-    }
-
-    if (settingsKeys.contains("fcPos") || force)
-    {
-        if (m_rtlSDRThread) {
-            m_rtlSDRThread->setFcPos((int) settings.m_fcPos);
-        }
-
-        qDebug() << "RTLSDRInput::applySettings: set fc pos (enum) to " << (int) settings.m_fcPos;
-    }
-
-    if (m_rtlSDRThread && (settingsKeys.contains("iqOrder") || force)) {
-        m_rtlSDRThread->setIQOrder(settings.m_iqOrder);
     }
 
     if (settingsKeys.contains("centerFrequency")
@@ -480,87 +417,10 @@ bool RTLSDRInput::applySettings(const RTLSDRSettings& settings, const QList<QStr
         || settingsKeys.contains("log2Decim")
         || settingsKeys.contains("devSampleRate")
         || settingsKeys.contains("transverterMode")
-        || settingsKeys.contains("transverterDeltaFrequency") || force)
+        || settingsKeys.contains("transverterDeltaFrequency")
+        || force)
     {
-        qint64 deviceCenterFrequency = DeviceSampleSource::calculateDeviceCenterFrequency(
-                settings.m_centerFrequency,
-                settings.m_transverterDeltaFrequency,
-                settings.m_log2Decim,
-                (DeviceSampleSource::fcPos_t) settings.m_fcPos,
-                settings.m_devSampleRate,
-                DeviceSampleSource::FrequencyShiftScheme::FSHIFT_STD,
-                settings.m_transverterMode);
-
         forwardChange = true;
-
-        if (m_dev != nullptr)
-        {
-            if (rtlsdr_set_center_freq(m_dev, (uint32_t) deviceCenterFrequency) != 0) {
-                qWarning("RTLSDRInput::applySettings: rtlsdr_set_center_freq(%lld) failed", deviceCenterFrequency);
-            } else {
-                qDebug("RTLSDRInput::applySettings: rtlsdr_set_center_freq(%lld)", deviceCenterFrequency);
-            }
-        }
-    }
-
-    if (settingsKeys.contains("noModMode") || force)
-    {
-        qDebug() << "RTLSDRInput::applySettings: set noModMode to " << settings.m_noModMode;
-
-        // Direct Modes: 0: off, 1: I, 2: Q, 3: NoMod.
-        if (settings.m_noModMode) {
-            set_ds_mode(3);
-        } else {
-            set_ds_mode(0);
-        }
-    }
-
-    if (settingsKeys.contains("rfBandwidth") || force)
-    {
-        m_settings.m_rfBandwidth = settings.m_rfBandwidth;
-
-        if (m_dev != nullptr)
-        {
-            if (rtlsdr_set_tuner_bandwidth( m_dev, m_settings.m_rfBandwidth) != 0) {
-                qCritical("RTLSDRInput::applySettings: could not set RF bandwidth to %u", m_settings.m_rfBandwidth);
-            } else {
-                qDebug() << "RTLSDRInput::applySettings: set RF bandwidth to " << m_settings.m_rfBandwidth;
-            }
-        }
-    }
-
-    // Reapply offset_tuning setting if bandwidth is changed, otherwise frequency response of filter looks wrong on E4000
-    if ((m_dev != nullptr) && (settingsKeys.contains("offsetTuning") || settingsKeys.contains("rfBandwidth") || force))
-    {
-        if (rtlsdr_set_offset_tuning(m_dev, m_settings.m_offsetTuning ? 0 : 1) != 0) {
-            qCritical("RTLSDRInput::applySettings: could not set offset tuning to %s", settings.m_offsetTuning ? "on" : "off");
-        } else {
-            qDebug("RTLSDRInput::applySettings: offset tuning set to %s", settings.m_offsetTuning ? "on" : "off");
-        }
-    }
-
-    if ((m_dev != nullptr) && (settingsKeys.contains("gain") || force))
-    {
-        // Nooelec E4000 SDRs appear to require tuner_gain_mode to be reset to manual before
-        // each call to set_tuner_gain, otherwise tuner AGC seems to be re-enabled
-        if (rtlsdr_set_tuner_gain_mode(m_dev, 1) < 0) {
-            qCritical("RTLSDRInput::applySettings: error setting tuner gain mode to manual");
-        }
-        qDebug() << "Set tuner gain " << settings.m_gain;
-        if (rtlsdr_set_tuner_gain(m_dev, settings.m_gain) != 0) {
-            qCritical("RTLSDRInput::applySettings: rtlsdr_set_tuner_gain() failed");
-        } else {
-            qDebug("RTLSDRInput::applySettings: rtlsdr_set_tuner_gain() to %d", settings.m_gain);
-        }
-    }
-
-    if ((m_dev != nullptr) && (settingsKeys.contains("biasTee") || force))
-    {
-        if (rtlsdr_set_bias_tee(m_dev, settings.m_biasTee ? 1 : 0) != 0) {
-            qCritical("RTLSDRInput::applySettings: rtlsdr_set_bias_tee() failed");
-        } else {
-            qDebug("RTLSDRInput::applySettings: rtlsdr_set_bias_tee() to %d", settings.m_biasTee ? 1 : 0);
-        }
     }
 
     if (settings.m_useReverseAPI)
@@ -570,6 +430,12 @@ bool RTLSDRInput::applySettings(const RTLSDRSettings& settings, const QList<QStr
             settingsKeys.contains("reverseAPIPort") ||
             settingsKeys.contains("reverseAPIDeviceIndex");
         webapiReverseSendSettings(settingsKeys, settings, fullUpdate || force);
+    }
+
+    if (m_rtlSDRThread)
+    {
+        MsgConfigureRTLSDR* message = MsgConfigureRTLSDR::create(settings, settingsKeys, force);
+        m_rtlSDRThread->getInputMessageQueue()->push(message);
     }
 
     if (force) {

--- a/plugins/samplesource/rtlsdr/rtlsdrthread.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrthread.cpp
@@ -52,7 +52,6 @@ RTLSDRThread::~RTLSDRThread()
 
 void RTLSDRThread::startWork()
 {
-    qDebug() << "RTLSDRThread::startWork";
     connect(&m_inputMessageQueue, &MessageQueue::messageEnqueued, this, &RTLSDRThread::handleInputMessages);
 	m_startWaitMutex.lock();
 	start();
@@ -63,7 +62,6 @@ void RTLSDRThread::startWork()
 
 void RTLSDRThread::stopWork()
 {
-    qDebug() << "RTLSDRThread::stopWork";
     if (m_running)
     {
         disconnect(&m_inputMessageQueue, &MessageQueue::messageEnqueued, this, &RTLSDRThread::handleInputMessages);

--- a/plugins/samplesource/rtlsdr/rtlsdrthread.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrthread.cpp
@@ -46,17 +46,18 @@ RTLSDRThread::~RTLSDRThread()
 {
     qDebug() << "RTLSDRThread::~RTLSDRThread";
     if (m_running) {
-	    stopWork();
+        stopWork();
     }
 }
 
 void RTLSDRThread::startWork()
 {
     connect(&m_inputMessageQueue, &MessageQueue::messageEnqueued, this, &RTLSDRThread::handleInputMessages);
-	m_startWaitMutex.lock();
-	start();
-	while(!m_running)
-		m_startWaiter.wait(&m_startWaitMutex, 100);
+    m_startWaitMutex.lock();
+    start();
+    while (!m_running) {
+        m_startWaiter.wait(&m_startWaitMutex, 100);
+    }
 	m_startWaitMutex.unlock();
 }
 
@@ -65,9 +66,9 @@ void RTLSDRThread::stopWork()
     if (m_running)
     {
         disconnect(&m_inputMessageQueue, &MessageQueue::messageEnqueued, this, &RTLSDRThread::handleInputMessages);
-	    m_running = false; // Cause run() to finish
+        m_running = false; // Cause run() to finish
 #ifndef __EMSCRIPTEN__
-    	wait();
+        wait();
 #endif
     }
 }
@@ -79,25 +80,25 @@ void RTLSDRThread::run()
 	m_running = true;
 	m_startWaiter.wakeAll();
 
-	while (m_running)
+    while (m_running)
     {
 #ifndef __EMSCRIPTEN__
-		if ((res = rtlsdr_read_async(m_dev, &RTLSDRThread::callbackHelper, this, 32, FCD_BLOCKSIZE)) < 0)
+        if ((res = rtlsdr_read_async(m_dev, &RTLSDRThread::callbackHelper, this, 32, FCD_BLOCKSIZE)) < 0)
         {
             if (m_running) {
-			    qCritical("RTLSDRThread: async read error: %s", strerror(errno));
+                qCritical("RTLSDRThread: async read error: %s", strerror(errno));
             }
-			break;
-		}
+            break;
+        }
 #else
         int len = 0;
         unsigned char buf[FCD_BLOCKSIZE];
 
-		if ((res = rtlsdr_read_sync(m_dev, buf, sizeof(buf), &len)) < 0)
+        if ((res = rtlsdr_read_sync(m_dev, buf, sizeof(buf), &len)) < 0)
         {
-			qCritical("RTLSDRThread: read error: %s", strerror(errno));
-			break;
-		}
+            qCritical("RTLSDRThread: read error: %s", strerror(errno));
+            break;
+        }
         else
         {
             if (m_settings.m_iqOrder) {
@@ -109,7 +110,7 @@ void RTLSDRThread::run()
 #endif
     }
 
-	m_running = false;
+    m_running = false;
 }
 
 //  Decimate according to specified log2 (ex: log2=4 => decim=16)

--- a/plugins/samplesource/rtlsdr/rtlsdrthread.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrthread.cpp
@@ -20,35 +20,40 @@
 
 #include <QDebug>
 
-#include <stdio.h>
 #include <errno.h>
-#include "rtlsdrthread.h"
 
+#include "rtlsdrthread.h"
+#include "rtlsdrinput.h"
+
+#include "dsp/devicesamplesource.h"
 #include "dsp/samplesinkfifo.h"
 
 #define FCD_BLOCKSIZE 16384
 
-RTLSDRThread::RTLSDRThread(rtlsdr_dev_t* dev, SampleSinkFifo* sampleFifo, ReplayBuffer<quint8> *replayBuffer, QObject* parent) :
+RTLSDRThread::RTLSDRThread(rtlsdr_dev_t* dev, SampleSinkFifo* sampleFifo, ReplayBuffer<quint8> *replayBuffer, const RTLSDRSettings& settings, QObject* parent) :
 	QThread(parent),
 	m_running(false),
 	m_dev(dev),
 	m_convertBuffer(FCD_BLOCKSIZE),
 	m_sampleFifo(sampleFifo),
-	m_replayBuffer(replayBuffer),
-	m_samplerate(288000),
-	m_log2Decim(4),
-	m_fcPos(0),
-    m_iqOrder(true)
+	m_replayBuffer(replayBuffer)
 {
+    applySettings(settings, QStringList(), true);
+    connect(&m_inputMessageQueue, &MessageQueue::messageEnqueued, this, &RTLSDRThread::handleInputMessages);
 }
 
 RTLSDRThread::~RTLSDRThread()
 {
-	stopWork();
+    qDebug() << "RTLSDRThread::~RTLSDRThread";
+    if (m_running) {
+	    stopWork();
+    }
 }
 
 void RTLSDRThread::startWork()
 {
+    qDebug() << "RTLSDRThread::startWork";
+    connect(&m_inputMessageQueue, &MessageQueue::messageEnqueued, this, &RTLSDRThread::handleInputMessages);
 	m_startWaitMutex.lock();
 	start();
 	while(!m_running)
@@ -58,23 +63,15 @@ void RTLSDRThread::startWork()
 
 void RTLSDRThread::stopWork()
 {
-	m_running = false;
-	wait();
-}
-
-void RTLSDRThread::setSamplerate(int samplerate)
-{
-	m_samplerate = samplerate;
-}
-
-void RTLSDRThread::setLog2Decimation(unsigned int log2_decim)
-{
-	m_log2Decim = log2_decim;
-}
-
-void RTLSDRThread::setFcPos(int fcPos)
-{
-	m_fcPos = fcPos;
+    qDebug() << "RTLSDRThread::stopWork";
+    if (m_running)
+    {
+        disconnect(&m_inputMessageQueue, &MessageQueue::messageEnqueued, this, &RTLSDRThread::handleInputMessages);
+	    m_running = false; // Cause run() to finish
+#ifndef __EMSCRIPTEN__
+    	wait();
+#endif
+    }
 }
 
 void RTLSDRThread::run()
@@ -84,12 +81,35 @@ void RTLSDRThread::run()
 	m_running = true;
 	m_startWaiter.wakeAll();
 
-	while(m_running) {
-		if((res = rtlsdr_read_async(m_dev, &RTLSDRThread::callbackHelper, this, 32, FCD_BLOCKSIZE)) < 0) {
-			qCritical("RTLSDRThread: async error: %s", strerror(errno));
+	while (m_running)
+    {
+#ifndef __EMSCRIPTEN__
+		if ((res = rtlsdr_read_async(m_dev, &RTLSDRThread::callbackHelper, this, 32, FCD_BLOCKSIZE)) < 0)
+        {
+            if (m_running) {
+			    qCritical("RTLSDRThread: async read error: %s", strerror(errno));
+            }
 			break;
 		}
-	}
+#else
+        int len = 0;
+        unsigned char buf[FCD_BLOCKSIZE];
+
+		if ((res = rtlsdr_read_sync(m_dev, buf, sizeof(buf), &len)) < 0)
+        {
+			qCritical("RTLSDRThread: read error: %s", strerror(errno));
+			break;
+		}
+        else
+        {
+            if (m_settings.m_iqOrder) {
+                callbackIQ(buf, len);
+            } else {
+                callbackQI(buf, len);
+            }
+        }
+#endif
+    }
 
 	m_running = false;
 }
@@ -120,15 +140,15 @@ void RTLSDRThread::callbackIQ(const quint8* inBuf, qint32 len)
         }
         remaining -= len;
 
-        if (m_log2Decim == 0)
+        if (m_settings.m_log2Decim == 0)
         {
             m_decimatorsIQ.decimate1(&it, buf, len);
         }
         else
         {
-            if (m_fcPos == 0) // Infradyne
+            if (m_settings.m_fcPos == 0) // Infradyne
             {
-                switch (m_log2Decim)
+                switch (m_settings.m_log2Decim)
                 {
                 case 1:
                     m_decimatorsIQ.decimate2_inf(&it, buf, len);
@@ -152,9 +172,9 @@ void RTLSDRThread::callbackIQ(const quint8* inBuf, qint32 len)
                     break;
                 }
             }
-            else if (m_fcPos == 1) // Supradyne
+            else if (m_settings.m_fcPos == 1) // Supradyne
             {
-                switch (m_log2Decim)
+                switch (m_settings.m_log2Decim)
                 {
                 case 1:
                     m_decimatorsIQ.decimate2_sup(&it, buf, len);
@@ -180,7 +200,7 @@ void RTLSDRThread::callbackIQ(const quint8* inBuf, qint32 len)
             }
             else // Centered
             {
-                switch (m_log2Decim)
+                switch (m_settings.m_log2Decim)
                 {
                 case 1:
                     m_decimatorsIQ.decimate2_cen(&it, buf, len);
@@ -211,8 +231,10 @@ void RTLSDRThread::callbackIQ(const quint8* inBuf, qint32 len)
 
     m_sampleFifo->write(m_convertBuffer.begin(), it);
 
-    if(!m_running)
+#ifndef __EMSCRIPTEN__
+    if (!m_running)
         rtlsdr_cancel_async(m_dev);
+#endif
 }
 
 void RTLSDRThread::callbackQI(const quint8* inBuf, qint32 len)
@@ -239,15 +261,15 @@ void RTLSDRThread::callbackQI(const quint8* inBuf, qint32 len)
         }
         remaining -= len;
 
-        if (m_log2Decim == 0)
+        if (m_settings.m_log2Decim == 0)
         {
             m_decimatorsQI.decimate1(&it, buf, len);
         }
         else
         {
-            if (m_fcPos == 0) // Infradyne
+            if (m_settings.m_fcPos == 0) // Infradyne
             {
-                switch (m_log2Decim)
+                switch (m_settings.m_log2Decim)
                 {
                 case 1:
                     m_decimatorsQI.decimate2_inf(&it, buf, len);
@@ -271,9 +293,9 @@ void RTLSDRThread::callbackQI(const quint8* inBuf, qint32 len)
                     break;
                 }
             }
-            else if (m_fcPos == 1) // Supradyne
+            else if (m_settings.m_fcPos == 1) // Supradyne
             {
-                switch (m_log2Decim)
+                switch (m_settings.m_log2Decim)
                 {
                 case 1:
                     m_decimatorsQI.decimate2_sup(&it, buf, len);
@@ -299,7 +321,7 @@ void RTLSDRThread::callbackQI(const quint8* inBuf, qint32 len)
             }
             else // Centered
             {
-                switch (m_log2Decim)
+                switch (m_settings.m_log2Decim)
                 {
                 case 1:
                     m_decimatorsQI.decimate2_cen(&it, buf, len);
@@ -330,17 +352,174 @@ void RTLSDRThread::callbackQI(const quint8* inBuf, qint32 len)
 
     m_sampleFifo->write(m_convertBuffer.begin(), it);
 
-    if(!m_running)
+#ifndef __EMSCRIPTEN__
+    if (!m_running)
         rtlsdr_cancel_async(m_dev);
+#endif
 }
 
+#ifndef __EMSCRIPTEN__
 void RTLSDRThread::callbackHelper(unsigned char* buf, uint32_t len, void* ctx)
 {
 	RTLSDRThread* thread = (RTLSDRThread*) ctx;
 
-    if (thread->m_iqOrder) {
+    if (thread->m_settings.m_iqOrder) {
     	thread->callbackIQ(buf, len);
     } else {
         thread->callbackQI(buf, len);
     }
+}
+#endif
+
+void RTLSDRThread::handleInputMessages()
+{
+    Message* message;
+
+    while ((message = m_inputMessageQueue.pop()) != 0)
+    {
+        if (handleMessage(*message)) {
+            delete message;
+        }
+    }
+}
+
+bool RTLSDRThread::handleMessage(const Message& cmd)
+{
+    if (RTLSDRInput::MsgConfigureRTLSDR::match(cmd))
+    {
+        RTLSDRInput::MsgConfigureRTLSDR& conf = (RTLSDRInput::MsgConfigureRTLSDR&) cmd;
+
+        applySettings(conf.getSettings(), conf.getSettingsKeys(), conf.getForce());
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+bool RTLSDRThread::applySettings(const RTLSDRSettings& settings, const QStringList& settingsKeys, bool force)
+{
+    qDebug() << "RTLSDRThread::applySettings: force: " << force << settings.getDebugString(settingsKeys, force);
+
+    if ((settingsKeys.contains("agc") && (settings.m_agc != m_settings.m_agc)) || force)
+    {
+        if (rtlsdr_set_agc_mode(m_dev, settings.m_agc ? 1 : 0) < 0) {
+            qCritical("RTLSDRThread::applySettings: could not set AGC mode %s", settings.m_agc ? "on" : "off");
+        } else {
+            qDebug("RTLSDRThread::applySettings: AGC mode %s", settings.m_agc ? "on" : "off");
+        }
+    }
+
+    if ((settingsKeys.contains("loPpmCorrection") && (settings.m_loPpmCorrection != m_settings.m_loPpmCorrection)) || force)
+    {
+        if (rtlsdr_set_freq_correction(m_dev, settings.m_loPpmCorrection) < 0) {
+            qCritical("RTLSDRThread::applySettings: could not set LO ppm correction: %d", settings.m_loPpmCorrection);
+        } else {
+            qDebug("RTLSDRThread::applySettings: LO ppm correction set to: %d", settings.m_loPpmCorrection);
+        }
+    }
+
+    if ((settingsKeys.contains("devSampleRate") && ((settings.m_devSampleRate) != m_settings.m_devSampleRate)) || force)
+    {
+        if (rtlsdr_set_sample_rate(m_dev, settings.m_devSampleRate) < 0) {
+            qCritical("RTLSDRThread::applySettings: could not set sample rate: %d", settings.m_devSampleRate);
+        } else {
+            qDebug("RTLSDRThread::applySettings: sample rate set to %d", settings.m_devSampleRate);
+        }
+    }
+
+    if ((settingsKeys.contains("log2Decim") && (settings.m_log2Decim != m_settings.m_log2Decim)) || force)
+    {
+        qDebug("RTLSDRThread::applySettings: log2decim set to %d", settings.m_log2Decim);
+    }
+
+    if (   (settingsKeys.contains("centerFrequency") && (settings.m_centerFrequency != m_settings.m_centerFrequency))
+        || (settingsKeys.contains("fcPos") && (settings.m_fcPos != m_settings.m_fcPos))
+        || (settingsKeys.contains("log2Decim") && (settings.m_log2Decim != m_settings.m_log2Decim))
+        || (settingsKeys.contains("devSampleRate") && (settings.m_devSampleRate != m_settings.m_devSampleRate))
+        || (settingsKeys.contains("transverterMode") && (settings.m_transverterMode != m_settings.m_transverterMode))
+        || (settingsKeys.contains("transverterDeltaFrequency") && (settings.m_transverterDeltaFrequency != m_settings.m_transverterDeltaFrequency))
+        || force)
+    {
+        qint64 deviceCenterFrequency = DeviceSampleSource::calculateDeviceCenterFrequency(
+                settings.m_centerFrequency,
+                settings.m_transverterDeltaFrequency,
+                settings.m_log2Decim,
+                (DeviceSampleSource::fcPos_t) settings.m_fcPos,
+                settings.m_devSampleRate,
+                DeviceSampleSource::FrequencyShiftScheme::FSHIFT_STD,
+                settings.m_transverterMode);
+
+        if (rtlsdr_set_center_freq(m_dev, deviceCenterFrequency) != 0) {
+            qWarning("RTLSDRThread::applySettings: rtlsdr_set_center_freq(%lld) failed", deviceCenterFrequency);
+        } else {
+            qDebug("RTLSDRThread::applySettings: rtlsdr_set_center_freq(%lld)", deviceCenterFrequency);
+        }
+    }
+
+    if ((settingsKeys.contains("noModMode") && (settings.m_noModMode != m_settings.m_noModMode)) || force)
+    {
+        qDebug() << "RTLSDRThread::applySettings: set noModMode to " << settings.m_noModMode;
+
+        // Direct Modes: 0: off, 1: I, 2: Q, 3: NoMod.
+        if (settings.m_noModMode) {
+            rtlsdr_set_direct_sampling(m_dev, 3);
+        } else {
+            rtlsdr_set_direct_sampling(m_dev, 0);
+        }
+    }
+
+    if ((settingsKeys.contains("rfBandwidth") && (settings.m_rfBandwidth != m_settings.m_rfBandwidth)) || force)
+    {
+        if (rtlsdr_set_tuner_bandwidth( m_dev, settings.m_rfBandwidth) != 0) {
+            qCritical("RTLSDRThread::applySettings: could not set RF bandwidth to %u", settings.m_rfBandwidth);
+        } else {
+            qDebug() << "RTLSDRThread::applySettings: set RF bandwidth to " << settings.m_rfBandwidth;
+        }
+    }
+
+    // Reapply offset_tuning setting if bandwidth is changed, otherwise frequency response of filter looks wrong on E4000
+    if (   (settingsKeys.contains("offsetTuning") && (settings.m_offsetTuning != m_settings.m_offsetTuning))
+        || (settingsKeys.contains("rfBandwidth") && (settings.m_rfBandwidth != m_settings.m_rfBandwidth))
+        || force)
+    {
+        if (rtlsdr_set_offset_tuning(m_dev, settings.m_offsetTuning ? 0 : 1) != 0) {
+            qCritical("RTLSDRThread::applySettings: could not set offset tuning to %s", settings.m_offsetTuning ? "on" : "off");
+        } else {
+            qDebug("RTLSDRThread::applySettings: offset tuning set to %s", settings.m_offsetTuning ? "on" : "off");
+        }
+    }
+
+    if ((settingsKeys.contains("gain") && (settings.m_gain != m_settings.m_gain)) || force)
+    {
+        // Nooelec E4000 SDRs appear to require tuner_gain_mode to be reset to manual before
+        // each call to set_tuner_gain, otherwise tuner AGC seems to be reenabled
+        if (rtlsdr_set_tuner_gain_mode(m_dev, 1) < 0) {
+            qCritical("RTLSDRThread::applySettings: error setting tuner gain mode to manual");
+        }
+        if (rtlsdr_set_tuner_gain(m_dev, settings.m_gain) != 0) {
+            qCritical("RTLSDRThread::applySettings: rtlsdr_set_tuner_gain() failed");
+        } else {
+            qDebug("RTLSDRThread::applySettings: rtlsdr_set_tuner_gain() to %d", settings.m_gain);
+        }
+    }
+
+    if ((settingsKeys.contains("biasTee") && (settings.m_biasTee != m_settings.m_biasTee)) || force)
+    {
+        if (rtlsdr_set_bias_tee(m_dev, settings.m_biasTee ? 1 : 0) != 0) {
+            qCritical("RTLSDRThread::applySettings: rtlsdr_set_bias_tee() failed");
+        } else {
+            qDebug("RTLSDRThread::applySettings: rtlsdr_set_bias_tee() to %d", settings.m_biasTee ? 1 : 0);
+        }
+    }
+
+    if (force) {
+        m_settings = settings;
+    } else {
+        m_settings.applySettings(settingsKeys, settings);
+    }
+
+    return true;
 }

--- a/plugins/samplesource/rtlsdr/rtlsdrthread.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrthread.cpp
@@ -374,7 +374,7 @@ void RTLSDRThread::handleInputMessages()
 {
     Message* message;
 
-    while ((message = m_inputMessageQueue.pop()) != 0)
+    while ((message = m_inputMessageQueue.pop()) != nullptr)
     {
         if (handleMessage(*message)) {
             delete message;
@@ -386,7 +386,7 @@ bool RTLSDRThread::handleMessage(const Message& cmd)
 {
     if (RTLSDRInput::MsgConfigureRTLSDR::match(cmd))
     {
-        RTLSDRInput::MsgConfigureRTLSDR& conf = (RTLSDRInput::MsgConfigureRTLSDR&) cmd;
+        auto& conf = (const RTLSDRInput::MsgConfigureRTLSDR&) cmd;
 
         applySettings(conf.getSettings(), conf.getSettingsKeys(), conf.getForce());
 

--- a/plugins/samplesource/rtlsdr/rtlsdrthread.h
+++ b/plugins/samplesource/rtlsdr/rtlsdrthread.h
@@ -26,6 +26,8 @@
 #include <QWaitCondition>
 #include <rtl-sdr.h>
 
+#include "rtlsdrsettings.h"
+
 #include "dsp/replaybuffer.h"
 #include "dsp/samplesinkfifo.h"
 #include "dsp/decimatorsu.h"
@@ -34,15 +36,12 @@ class RTLSDRThread : public QThread {
 	Q_OBJECT
 
 public:
-	RTLSDRThread(rtlsdr_dev_t* dev, SampleSinkFifo* sampleFifo, ReplayBuffer<quint8> *replayBuffer, QObject* parent = NULL);
+	RTLSDRThread(rtlsdr_dev_t* dev, SampleSinkFifo* sampleFifo, ReplayBuffer<quint8> *replayBuffer, const RTLSDRSettings& settings, QObject* parent = NULL);
 	~RTLSDRThread();
 
 	void startWork();
 	void stopWork();
-	void setSamplerate(int samplerate);
-	void setLog2Decimation(unsigned int log2_decim);
-	void setFcPos(int fcPos);
-    void setIQOrder(bool iqOrder) { m_iqOrder = iqOrder; }
+	MessageQueue *getInputMessageQueue() { return &m_inputMessageQueue; }
 
 private:
 	QMutex m_startWaitMutex;
@@ -54,10 +53,8 @@ private:
 	SampleSinkFifo* m_sampleFifo;
 	ReplayBuffer<quint8> *m_replayBuffer;
 
-	int m_samplerate;
-	unsigned int m_log2Decim;
-	int m_fcPos;
-    bool m_iqOrder;
+	RTLSDRSettings m_settings;
+	MessageQueue m_inputMessageQueue;  //!< Queue for asynchronous inbound communication
 
 	DecimatorsU<qint32, quint8, SDR_RX_SAMP_SZ, 8, 127, true> m_decimatorsIQ;
 	DecimatorsU<qint32, quint8, SDR_RX_SAMP_SZ, 8, 127, false> m_decimatorsQI;
@@ -66,7 +63,15 @@ private:
 	void callbackIQ(const quint8* buf, qint32 len);
 	void callbackQI(const quint8* buf, qint32 len);
 
+	bool handleMessage(const Message& cmd);
+	bool applySettings(const RTLSDRSettings& settings, const QStringList& settingsKeys, bool force);
+
+#ifndef __EMSCRIPTEN__
 	static void callbackHelper(unsigned char* buf, uint32_t len, void* ctx);
+#endif
+
+private slots:
+	void handleInputMessages();
 };
 
 #endif // INCLUDE_RTLSDRTHREAD_H

--- a/plugins/samplesource/rtlsdr/rtlsdrthread.h
+++ b/plugins/samplesource/rtlsdr/rtlsdrthread.h
@@ -36,7 +36,7 @@ class RTLSDRThread : public QThread {
 	Q_OBJECT
 
 public:
-	RTLSDRThread(rtlsdr_dev_t* dev, SampleSinkFifo* sampleFifo, ReplayBuffer<quint8> *replayBuffer, const RTLSDRSettings& settings, QObject* parent = NULL);
+	RTLSDRThread(rtlsdr_dev_t* dev, SampleSinkFifo* sampleFifo, ReplayBuffer<quint8> *replayBuffer, const RTLSDRSettings& settings, QObject* parent = nullptr);
 	~RTLSDRThread();
 
 	void startWork();


### PR DESCRIPTION
RTLSDR: Apply driver settings in RTLSDRThread, to avoid blocking main thread. Part of #2159 and #1522
Add sync read for WebAssembly (async read causes a crash - most likely due to libusb for WebAssembly issue).