### PR TITLE
Use Qt 6 for Windows github build

### DIFF
--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -76,7 +76,7 @@ jobs:
           dir: ${{matrix.config.QT_INST_DIR}}
           arch: ${{matrix.config.QT_ARCH}}
           setup-python: false
-          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech'
+          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets'
       - name: build sdrangel on Windows
         if: startsWith(matrix.config.os, 'windows')
         run: |

--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -76,14 +76,14 @@ jobs:
           dir: ${{matrix.config.QT_INST_DIR}}
           arch: ${{matrix.config.QT_ARCH}}
           setup-python: false
-          modules: 'qtcharts qtscxml'
+          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech'
       - name: build sdrangel on Windows
         if: startsWith(matrix.config.os, 'windows')
         run: |
           cmd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           choco install patch
           mkdir build && cd build
-          cmake .. -G "${{ matrix.config.generators }}" -DCMAKE_BUILD_TYPE=Release -DARCH_OPT=SSE4_2 -DDEBUG_OUTPUT=ON -DENABLE_MIRISDR=OFF -DBUILD_SERVER=OFF -DCMAKE_PREFIX_PATH="C:\Qt\6.8.0\msvc2022_64;C:\Libraries\boost_1_73_0"
+          cmake .. -G "${{ matrix.config.generators }}" -DCMAKE_BUILD_TYPE=Release -DENABLE_QT6=ON -DARCH_OPT=SSE4_2 -DDEBUG_OUTPUT=ON -DENABLE_MIRISDR=OFF -DBUILD_SERVER=OFF -DCMAKE_PREFIX_PATH="C:\Qt\6.8.0\msvc2022_64;C:\Libraries\boost_1_73_0"
           cmake --build . --config Release --target package
       - name: Check disk space
         run: Get-PSDrive

--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -76,7 +76,7 @@ jobs:
           dir: ${{matrix.config.QT_INST_DIR}}
           arch: ${{matrix.config.QT_ARCH}}
           setup-python: false
-          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets qtwebengine'
+          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets qtwebengine qtshadertools'
       - name: build sdrangel on Windows
         if: startsWith(matrix.config.os, 'windows')
         run: |

--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -25,8 +25,8 @@ jobs:
             WIN_ARCH: "x64",
             os: windows-latest,
             QT_INST_DIR: "C:/",
-            QTDIR: "C:/Qt/6.8.0/msvc2022_64",
-            QT_ARCH: win64_msvc2022_64,
+            QTDIR: "C:/Qt/6.7.3/msvc2019_64",
+            QT_ARCH: win64_msvc2019_64,
             boost_dl: "${{ github.workspace }}\\downloads\\boost",
             lib_dir: "C:\\Libraries",
             generators: Ninja
@@ -72,18 +72,18 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.8.0'
+          version: '6.7.3'
           dir: ${{matrix.config.QT_INST_DIR}}
           arch: ${{matrix.config.QT_ARCH}}
           setup-python: false
-          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets qtwebview'
+          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets qtwebengine'
       - name: build sdrangel on Windows
         if: startsWith(matrix.config.os, 'windows')
         run: |
           cmd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           choco install patch
           mkdir build && cd build
-          cmake .. -G "${{ matrix.config.generators }}" -DCMAKE_BUILD_TYPE=Release -DENABLE_QT6=ON -DARCH_OPT=SSE4_2 -DDEBUG_OUTPUT=ON -DENABLE_MIRISDR=OFF -DBUILD_SERVER=OFF -DCMAKE_PREFIX_PATH="C:\Qt\6.8.0\msvc2022_64;C:\Libraries\boost_1_73_0"
+          cmake .. -G "${{ matrix.config.generators }}" -DCMAKE_BUILD_TYPE=Release -DENABLE_QT6=ON -DARCH_OPT=SSE4_2 -DDEBUG_OUTPUT=ON -DENABLE_MIRISDR=OFF -DBUILD_SERVER=OFF -DCMAKE_PREFIX_PATH="C:\Qt\6.7.3\msvc2019_64;C:\Libraries\boost_1_73_0"
           cmake --build . --config Release --target package
       - name: Check disk space
         run: Get-PSDrive

--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
       - mac_ci
-      - win_qt6
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - mac_ci
+      - win_qt6
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -76,7 +76,7 @@ jobs:
           dir: ${{matrix.config.QT_INST_DIR}}
           arch: ${{matrix.config.QT_ARCH}}
           setup-python: false
-          modules: 'qtcharts qtwebengine qtstatemachine'
+          modules: 'qtcharts qtscxml'
       - name: build sdrangel on Windows
         if: startsWith(matrix.config.os, 'windows')
         run: |

--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -24,8 +24,8 @@ jobs:
             WIN_ARCH: "x64",
             os: windows-latest,
             QT_INST_DIR: "C:/",
-            QTDIR: "C:/Qt/5.15.2/msvc2019_64",
-            QT_ARCH: win64_msvc2019_64,
+            QTDIR: "C:/Qt/6.8.0/msvc2022_64",
+            QT_ARCH: win64_msvc2022_64,
             boost_dl: "${{ github.workspace }}\\downloads\\boost",
             lib_dir: "C:\\Libraries",
             generators: Ninja
@@ -69,19 +69,20 @@ jobs:
           rm -rf boost_*/* download.tar.bz2 download.tar
         shell: bash
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
+          version: '6.8.0'
           dir: ${{matrix.config.QT_INST_DIR}}
           arch: ${{matrix.config.QT_ARCH}}
           setup-python: false
-          modules: 'qtcharts qtwebengine'
+          modules: 'qtcharts qtwebengine qtstatemachine'
       - name: build sdrangel on Windows
         if: startsWith(matrix.config.os, 'windows')
         run: |
-          cmd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cmd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           choco install patch
           mkdir build && cd build
-          cmake .. -G "${{ matrix.config.generators }}" -DCMAKE_BUILD_TYPE=Release -DARCH_OPT=SSE4_2 -DDEBUG_OUTPUT=ON -DENABLE_MIRISDR=OFF -DBUILD_SERVER=OFF -DCMAKE_PREFIX_PATH="C:\Qt\5.15.2\msvc2019_64;C:\Libraries\boost_1_73_0"
+          cmake .. -G "${{ matrix.config.generators }}" -DCMAKE_BUILD_TYPE=Release -DARCH_OPT=SSE4_2 -DDEBUG_OUTPUT=ON -DENABLE_MIRISDR=OFF -DBUILD_SERVER=OFF -DCMAKE_PREFIX_PATH="C:\Qt\6.8.0\msvc2022_64;C:\Libraries\boost_1_73_0"
           cmake --build . --config Release --target package
       - name: Check disk space
         run: Get-PSDrive

--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -76,7 +76,7 @@ jobs:
           dir: ${{matrix.config.QT_INST_DIR}}
           arch: ${{matrix.config.QT_ARCH}}
           setup-python: false
-          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets'
+          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets qtwebview'
       - name: build sdrangel on Windows
         if: startsWith(matrix.config.os, 'windows')
         run: |


### PR DESCRIPTION
This patch updates Windows build to use Qt 6.7.3. I've been using this for a while and find it has better UI scaling and multimonitor support than Qt 5. The Mac Arm build has been using it for a while. Fixes #2051.

Can't use Qt 6.8, as the github action qt installer (actually the python qt installer that it uses) doesn't yet support installing qtwebengine extension.
