### PR TITLE
RemoteTCPSink: Disable IQ compression for RTL0 protocol.

### DIFF
--- a/plugins/channelrx/remotetcpsink/remotetcpsink.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsink.cpp
@@ -149,6 +149,9 @@ void RemoteTCPSink::start()
         m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
     }
 
+    MsgConfigureRemoteTCPSink* msg = MsgConfigureRemoteTCPSink::create(m_settings, QStringList(), true, true);
+    m_basebandSink->getInputMessageQueue()->push(msg);
+
     updatePublicListing();
 }
 

--- a/plugins/channelrx/remotetcpsink/remotetcpsinkbaseband.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinkbaseband.cpp
@@ -43,6 +43,7 @@ RemoteTCPSinkBaseband::~RemoteTCPSinkBaseband()
 void RemoteTCPSinkBaseband::reset()
 {
     QMutexLocker mutexLocker(&m_mutex);
+    m_inputMessageQueue.clear();
     m_sampleFifo.reset();
     m_sink.init();
 }

--- a/plugins/channelrx/remotetcpsink/remotetcpsinksettingsdialog.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinksettingsdialog.cpp
@@ -32,7 +32,16 @@ RemoteTCPSinkSettingsDialog::RemoteTCPSinkSettingsDialog(RemoteTCPSinkSettings *
     ui->maxClients->setValue(m_settings->m_maxClients);
     ui->timeLimit->setValue(m_settings->m_timeLimit);
     ui->maxSampleRate->setValue(m_settings->m_maxSampleRate);
-    ui->iqOnly->setChecked(m_settings->m_iqOnly);
+    if (m_settings->m_protocol == RemoteTCPSinkSettings::RTL0)
+    {
+        ui->iqOnly->setChecked(true);
+        ui->iqOnlyLabel->setEnabled(false);
+        ui->iqOnly->setEnabled(false);
+    }
+    else
+    {
+        ui->iqOnly->setChecked(m_settings->m_iqOnly);
+    }
 
     ui->compressor->setCurrentIndex((int) m_settings->m_compression);
     ui->compressionLevel->setValue(m_settings->m_compressionLevel);
@@ -40,6 +49,9 @@ RemoteTCPSinkSettingsDialog::RemoteTCPSinkSettingsDialog(RemoteTCPSinkSettings *
 
     ui->certificate->setText(m_settings->m_certificate);
     ui->key->setText(m_settings->m_key);
+    if (m_settings->m_protocol != RemoteTCPSinkSettings::SDRA_WSS) {
+        ui->sslSettingsGroup->setEnabled(false);
+    }
 
     ui->publicListing->setChecked(m_settings->m_public);
     ui->publicAddress->setText(m_settings->m_publicAddress);
@@ -94,10 +106,13 @@ void RemoteTCPSinkSettingsDialog::accept()
         m_settings->m_maxSampleRate = ui->maxSampleRate->value();
         m_settingsKeys.append("maxSampleRate");
     }
-    if (ui->iqOnly->isChecked() != m_settings->m_iqOnly)
+    if (m_settings->m_protocol != RemoteTCPSinkSettings::RTL0)
     {
-        m_settings->m_iqOnly = ui->iqOnly->isChecked();
-        m_settingsKeys.append("iqOnly");
+        if (ui->iqOnly->isChecked() != m_settings->m_iqOnly)
+        {
+            m_settings->m_iqOnly = ui->iqOnly->isChecked();
+            m_settingsKeys.append("iqOnly");
+        }
     }
     RemoteTCPSinkSettings::Compressor compressor = (RemoteTCPSinkSettings::Compressor) ui->compressor->currentIndex();
     if (compressor != m_settings->m_compression)

--- a/plugins/channelrx/remotetcpsink/remotetcpsinksink.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsinksink.cpp
@@ -269,7 +269,7 @@ void RemoteTCPSinkSink::processOneSample(Complex &ci)
         }
     }
 
-    if (!m_settings.m_iqOnly && (m_settings.m_compression == RemoteTCPSinkSettings::FLAC))
+    if (!m_settings.m_iqOnly && (m_settings.m_compression == RemoteTCPSinkSettings::FLAC) && (m_settings.m_protocol != RemoteTCPSinkSettings::RTL0))
     {
         // Compress using FLAC
         FLAC__int32 iqBuf[2];
@@ -360,7 +360,7 @@ void RemoteTCPSinkSink::processOneSample(Complex &ci)
         int bytes = 2 * m_settings.m_sampleBits / 8;
         m_bytesUncompressed += bytes;
 
-        if (!m_settings.m_iqOnly && (m_settings.m_compression == RemoteTCPSinkSettings::ZLIB))
+        if (!m_settings.m_iqOnly && (m_settings.m_compression == RemoteTCPSinkSettings::ZLIB) && (m_settings.m_protocol != RemoteTCPSinkSettings::RTL0))
         {
             if (m_zStreamInitialised)
             {
@@ -1027,12 +1027,12 @@ void RemoteTCPSinkSink::acceptConnection(Socket *client)
         client->flush();
 
         // Inform client if they are in a queue
-        if (!m_settings.m_iqOnly && (m_clients.size() > m_settings.m_maxClients)) {
+        if (!m_settings.m_iqOnly && (m_clients.size() > m_settings.m_maxClients) && (m_settings.m_protocol != RemoteTCPSinkSettings::RTL0)) {
             sendQueuePosition(client, m_clients.size() - m_settings.m_maxClients);
         }
 
         // Send existing FLAC header to new client
-        if (!m_settings.m_iqOnly && (m_settings.m_compression == RemoteTCPSinkSettings::FLAC) && (m_flacHeader.size() == m_flacHeaderSize))
+        if (!m_settings.m_iqOnly && (m_settings.m_compression == RemoteTCPSinkSettings::FLAC) && (m_flacHeader.size() == m_flacHeaderSize) && (m_settings.m_protocol != RemoteTCPSinkSettings::RTL0))
         {
             char header[1+4];
 


### PR DESCRIPTION
Disable IQ compression when protocol is RTL0, as clients can't support it.
