### PR TITLE
Add github action to build and publish Snap

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get version
         id: get_version
         run: |
-            if [[ "${{github.ref_name}" == "snap" ]]; then
+            if [[ "${{github.ref_name}}" == "snap" ]]; then
                 echo "version=${{github.sha}}" >> $GITHUB_OUTPUT
             else
                 echo "version=$(echo ${{github.ref_name}} | cut -c2-)" >> $GITHUB_OUTPUT

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -18,6 +18,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - uses: snapcore/action-build@v1
+        id: snapcraft
       - name: Get version
         id: get_version
         run: echo "version=$(echo ${{github.ref_name}} | cut -c2-)" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -17,11 +17,16 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - uses: snapcore/action-build@v1
-        id: snapcraft
       - name: Get version
         id: get_version
-        run: echo "version=$(echo ${{github.ref_name}} | cut -c2-)" >> $env:GITHUB_OUTPUT
+        run: |
+            if [[ "${{github.ref_name}" == "snap" ]]; then
+                echo "version=${{github.sha}}" >> $GITHUB_OUTPUT
+            else
+                echo "version=$(echo ${{github.ref_name}} | cut -c2-)" >> $GITHUB_OUTPUT
+            fi
+      - uses: snapcore/action-build@v1
+        id: snapcraft
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,3 +1,4 @@
+# See: https://github.com/snapcore/action-build
 name: SDRangel snap release build
 
 on:
@@ -16,11 +17,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
-      - name: Build snap
-        run: |
-          snapcraft
+      - uses: snapcore/action-build@v1
       - name: Get version
         id: get_version
         run: echo "version=$(echo ${{github.ref_name}} | cut -c2-)" >> $env:GITHUB_OUTPUT
@@ -28,4 +25,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: sdrangel-${{ steps.get_version.outputs.version }}-amd64.snap
-          path: ${{ github.workspace }}/sdrangel_${{ steps.get_version.outputs.version }}_amd64.snap
+          path: ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,31 @@
+name: SDRangel snap release build
+
+on:
+  push:
+    branches:
+      - snap
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  build_snap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@v2
+      - name: Build snap
+        run: |
+          snapcraft
+      - name: Get version
+        id: get_version
+        run: echo "version=$(echo ${{github.ref_name}} | cut -c2-)" >> $env:GITHUB_OUTPUT
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdrangel-${{ steps.get_version.outputs.version }}-amd64.snap
+          path: ${{ github.workspace }}/sdrangel_${{ steps.get_version.outputs.version }}_amd64.snap

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -26,9 +26,20 @@ jobs:
                 echo "version=$(echo ${{github.ref_name}} | cut -c2-)" >> $GITHUB_OUTPUT
             fi
       - uses: snapcore/action-build@v1
-        id: snapcraft
+        id: build
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: sdrangel-${{ steps.get_version.outputs.version }}-amd64.snap
-          path: ${{ steps.snapcraft.outputs.snap }}
+          path: ${{ steps.build.outputs.snap }}
+      - name: Upload release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.build.outputs.snap }}
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable


### PR DESCRIPTION
This PR adds a github action to build and publish a SDRangel Snap to the Snap Store each time a release tag is created.