### PR TITLE
Add github action to test code signing on Windows using SignPath.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,111 @@
+name: SDRangel Windows release build and signing
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Windows-x64",
+            WIN_ARCH: "x64",
+            os: windows-latest,
+            QT_INST_DIR: "C:/",
+            QTDIR: "C:/Qt/6.7.3/msvc2019_64",
+            QT_ARCH: win64_msvc2019_64,
+            boost_dl: "${{ github.workspace }}\\downloads\\boost",
+            lib_dir: "C:\\Libraries",
+            generators: Ninja
+          }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Print env
+        run: |
+          echo github.event.action: ${{ github.event.action }}
+          echo github.event_name: ${{ github.event_name }}
+          echo github.ref: ${{ github.ref }}
+          echo github.workspace: ${{ github.workspace }}
+      - name: Install basic dependencies on Windows
+        if: startsWith(matrix.config.os, 'windows')
+        run: |
+          choco install ninja cmake
+          ninja --version
+          cmake --version
+      - name: Install MSVC on Windows
+        if: startsWith(matrix.config.os, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+      - name: Install Boost
+        env:
+          BOOST_ROOT: ${{ matrix.config.boost_dl }}
+          BOOST_DEST: ${{ matrix.config.lib_dir }}
+          BOOST_URL: https://archives.boost.io/release/1.73.0/source/boost_1_73_0.tar.bz2
+        run: |
+          mkdir -p $BOOST_ROOT
+          mkdir -p $BOOST_DEST
+          curl --progress-bar --location --output $BOOST_ROOT/download.tar.bz2 $BOOST_URL
+          7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar.bz2 -y -bd
+          7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar -y -bd
+          cd $BOOST_ROOT && cp -r boost_* $BOOST_DEST
+          ls -l $BOOST_DEST
+          ls -l "C:\\"
+          rm -rf boost_*/* download.tar.bz2 download.tar
+        shell: bash
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.7.3'
+          dir: ${{matrix.config.QT_INST_DIR}}
+          arch: ${{matrix.config.QT_ARCH}}
+          setup-python: false
+          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets qtwebengine qtshadertools'
+      - name: build sdrangel on Windows
+        if: startsWith(matrix.config.os, 'windows')
+        run: |
+          cmd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          choco install patch
+          mkdir build && cd build
+          cmake .. -G "${{ matrix.config.generators }}" -DCMAKE_BUILD_TYPE=Release -DENABLE_QT6=ON -DARCH_OPT=SSE4_2 -DDEBUG_OUTPUT=ON -DENABLE_MIRISDR=OFF -DBUILD_SERVER=OFF -DCMAKE_PREFIX_PATH="C:\Qt\6.7.3\msvc2019_64;C:\Libraries\boost_1_73_0"
+          cmake --build . --config Release --target package
+      - name: Check disk space
+        run: Get-PSDrive
+      - name: Get version
+        id: get_version
+        run: echo "version=$(grep sdrangel_VERSION build/CMakeCache.txt | cut -d "=" -f2)" >> $env:GITHUB_OUTPUT
+      - name: Upload unsigned artifact
+        id: upload-unsigned-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdrangel-${{ steps.get_version.outputs.version }}-win64.exe
+          path: ${{ github.workspace }}/build/sdrangel-${{ steps.get_version.outputs.version }}-win64.exe
+      - name: Sign Code
+        id: sign_code
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '553b8f53-adf0-4fe5-be3d-283504a21a51'
+          project-slug: 'sdrangel'
+          signing-policy-slug: 'release-signing'
+          github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: '${{ github.workspace }}/build/sdrangel-${{ steps.get_version.outputs.version }}-win64-signed.exe'
+      - name: Upload signed artifact
+        id: upload-signed-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdrangel-${{ steps.get_version.outputs.version }}-win64-signed.exe
+          path: ${{ github.workspace }}/build/sdrangel-${{ steps.get_version.outputs.version }}-win64-signed.exe


### PR DESCRIPTION
Add a github action for testing code signing on Windows using SignPath. For #1877

I can't test this from my github account, as the build needs to come from https://github.com/f4exb/sdrangel - so will probably take a few tries to get it working... 

