### PR TITLE
Frequency scanner: Add multiplex mode

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemod.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemod.cpp
@@ -71,7 +71,7 @@ ADSBDemod::ADSBDemod(DeviceAPI *devieAPI) :
     m_worker = new ADSBDemodWorker();
     m_basebandSink->setMessageQueueToWorker(m_worker->getInputMessageQueue());
 
-    applySettings(m_settings, true);
+    applySettings(m_settings, QStringList(), true);
 
     m_deviceAPI->addChannelSink(this);
     m_deviceAPI->addChannelSinkAPI(this);
@@ -147,7 +147,7 @@ void ADSBDemod::start()
     m_basebandSink->startWork();
     m_thread->start();
 
-    ADSBDemodWorker::MsgConfigureADSBDemodWorker *msg = ADSBDemodWorker::MsgConfigureADSBDemodWorker::create(m_settings, true);
+    ADSBDemodWorker::MsgConfigureADSBDemodWorker *msg = ADSBDemodWorker::MsgConfigureADSBDemodWorker::create(m_settings, QStringList(), true);
     m_worker->getInputMessageQueue()->push(msg);
 }
 
@@ -169,7 +169,7 @@ bool ADSBDemod::handleMessage(const Message& cmd)
         MsgConfigureADSBDemod& cfg = (MsgConfigureADSBDemod&) cmd;
         qDebug() << "ADSBDemod::handleMessage: MsgConfigureADSBDemod";
 
-        applySettings(cfg.getSettings(), cfg.getForce());
+        applySettings(cfg.getSettings(), cfg.getSettingsKeys(), cfg.getForce());
 
         return true;
     }
@@ -200,111 +200,11 @@ bool ADSBDemod::handleMessage(const Message& cmd)
     }
 }
 
-void ADSBDemod::applySettings(const ADSBDemodSettings& settings, bool force)
+void ADSBDemod::applySettings(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force)
 {
     qDebug() << "ADSBDemod::applySettings:"
-            << " m_inputFrequencyOffset: " << settings.m_inputFrequencyOffset
-            << " m_rfBandwidth: " << settings.m_rfBandwidth
-            << " m_streamIndex: " << settings.m_streamIndex
-            << " m_useReverseAPI: " << settings.m_useReverseAPI
-            << " m_reverseAPIAddress: " << settings.m_reverseAPIAddress
-            << " m_reverseAPIPort: " << settings.m_reverseAPIPort
-            << " m_reverseAPIDeviceIndex: " << settings.m_reverseAPIDeviceIndex
-            << " m_reverseAPIChannelIndex: " << settings.m_reverseAPIChannelIndex
+            << settings.getDebugString(settingsKeys, force)
             << " force: " << force;
-
-    QList<QString> reverseAPIKeys;
-
-    if ((settings.m_inputFrequencyOffset != m_settings.m_inputFrequencyOffset) || force) {
-        reverseAPIKeys.append("inputFrequencyOffset");
-    }
-    if ((settings.m_rfBandwidth != m_settings.m_rfBandwidth) || force) {
-        reverseAPIKeys.append("rfBandwidth");
-    }
-    if ((settings.m_correlationThreshold != m_settings.m_correlationThreshold) || force) {
-        reverseAPIKeys.append("correlationThreshold");
-    }
-    if ((settings.m_samplesPerBit != m_settings.m_samplesPerBit) || force) {
-        reverseAPIKeys.append("samplesPerBit");
-    }
-    if ((settings.m_correlateFullPreamble != m_settings.m_correlateFullPreamble) || force) {
-        reverseAPIKeys.append("correlateFullPreamble");
-    }
-    if ((settings.m_demodModeS != m_settings.m_demodModeS) || force) {
-        reverseAPIKeys.append("demodModeS");
-    }
-    if ((settings.m_interpolatorPhaseSteps != m_settings.m_interpolatorPhaseSteps) || force) {
-        reverseAPIKeys.append("interpolatorPhaseSteps");
-    }
-    if ((settings.m_interpolatorTapsPerPhase != m_settings.m_interpolatorTapsPerPhase) || force) {
-        reverseAPIKeys.append("interpolatorTapsPerPhase");
-    }
-    if ((settings.m_removeTimeout != m_settings.m_removeTimeout) || force) {
-        reverseAPIKeys.append("removeTimeout");
-    }
-    if ((settings.m_feedEnabled != m_settings.m_feedEnabled) || force) {
-        reverseAPIKeys.append("feedEnabled");
-    }
-    if ((settings.m_exportClientEnabled != m_settings.m_exportClientEnabled) || force) {
-        reverseAPIKeys.append("exportClientEnabled");
-    }
-    if ((settings.m_exportClientHost != m_settings.m_exportClientHost) || force) {
-        reverseAPIKeys.append("exportClientHost");
-    }
-    if ((settings.m_exportClientPort != m_settings.m_exportClientPort) || force) {
-        reverseAPIKeys.append("exportClientPort");
-    }
-    if ((settings.m_exportClientFormat != m_settings.m_exportClientFormat) || force) {
-        reverseAPIKeys.append("exportClientFormat");
-    }
-     if ((settings.m_exportServerEnabled != m_settings.m_exportServerEnabled) || force) {
-        reverseAPIKeys.append("exportServerEnabled");
-    }
-    if ((settings.m_exportServerPort != m_settings.m_exportServerPort) || force) {
-        reverseAPIKeys.append("exportServerPort");
-    }
-   if ((settings.m_importEnabled != m_settings.m_importEnabled) || force) {
-        reverseAPIKeys.append("importEnabled");
-    }
-    if ((settings.m_importHost != m_settings.m_importHost) || force) {
-        reverseAPIKeys.append("importHost");
-    }
-    if ((settings.m_importUsername != m_settings.m_importUsername) || force) {
-        reverseAPIKeys.append("importUsername");
-    }
-    if ((settings.m_importPassword != m_settings.m_importPassword) || force) {
-        reverseAPIKeys.append("importPassword");
-    }
-    if ((settings.m_importParameters != m_settings.m_importParameters) || force) {
-        reverseAPIKeys.append("importParameters");
-    }
-    if ((settings.m_importPeriod != m_settings.m_importPeriod) || force) {
-        reverseAPIKeys.append("importPeriod");
-    }
-    if ((settings.m_importMinLatitude != m_settings.m_importMinLatitude) || force) {
-        reverseAPIKeys.append("importMinLatitude");
-    }
-    if ((settings.m_importMaxLatitude != m_settings.m_importMaxLatitude) || force) {
-        reverseAPIKeys.append("importMaxLatitude");
-    }
-    if ((settings.m_importMinLongitude != m_settings.m_importMinLongitude) || force) {
-        reverseAPIKeys.append("importMinLongitude");
-    }
-    if ((settings.m_importMaxLongitude != m_settings.m_importMaxLongitude) || force) {
-        reverseAPIKeys.append("importMaxLongitude");
-    }
-    if ((settings.m_logFilename != m_settings.m_logFilename) || force) {
-        reverseAPIKeys.append("logFilename");
-    }
-    if ((settings.m_logEnabled != m_settings.m_logEnabled) || force) {
-        reverseAPIKeys.append("logEnabled");
-    }
-    if ((settings.m_title != m_settings.m_title) || force) {
-        reverseAPIKeys.append("title");
-    }
-    if ((settings.m_rfBandwidth != m_settings.m_rfBandwidth) || force) {
-        reverseAPIKeys.append("rfBandwidth");
-    }
 
     if (m_settings.m_streamIndex != settings.m_streamIndex)
     {
@@ -317,38 +217,40 @@ void ADSBDemod::applySettings(const ADSBDemodSettings& settings, bool force)
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent
             emit streamIndexChanged(settings.m_streamIndex);
         }
-
-        reverseAPIKeys.append("streamIndex");
     }
 
-    ADSBDemodBaseband::MsgConfigureADSBDemodBaseband *msg = ADSBDemodBaseband::MsgConfigureADSBDemodBaseband::create(settings, force);
+    ADSBDemodBaseband::MsgConfigureADSBDemodBaseband *msg = ADSBDemodBaseband::MsgConfigureADSBDemodBaseband::create(settings, settingsKeys, force);
     m_basebandSink->getInputMessageQueue()->push(msg);
 
-    ADSBDemodWorker::MsgConfigureADSBDemodWorker *workerMsg = ADSBDemodWorker::MsgConfigureADSBDemodWorker::create(settings, force);
+    ADSBDemodWorker::MsgConfigureADSBDemodWorker *workerMsg = ADSBDemodWorker::MsgConfigureADSBDemodWorker::create(settings, settingsKeys, force);
     m_worker->getInputMessageQueue()->push(workerMsg);
 
     if (settings.m_useReverseAPI)
     {
-        bool fullUpdate = ((m_settings.m_useReverseAPI != settings.m_useReverseAPI) && settings.m_useReverseAPI) ||
-                (m_settings.m_reverseAPIAddress != settings.m_reverseAPIAddress) ||
-                (m_settings.m_reverseAPIPort != settings.m_reverseAPIPort) ||
-                (m_settings.m_reverseAPIDeviceIndex != settings.m_reverseAPIDeviceIndex) ||
-                (m_settings.m_reverseAPIChannelIndex != settings.m_reverseAPIChannelIndex);
-        webapiReverseSendSettings(reverseAPIKeys, settings, fullUpdate || force);
+        bool fullUpdate = (settingsKeys.contains("useReverseAPI") && settings.m_useReverseAPI) ||
+            settingsKeys.contains("reverseAPIAddress") ||
+            settingsKeys.contains("reverseAPIPort") ||
+            settingsKeys.contains("reverseAPIDeviceIndex") ||
+            settingsKeys.contains("reverseAPIChannelIndex");
+        webapiReverseSendSettings(settingsKeys, settings, fullUpdate || force);
     }
 
-    m_settings = settings;
+    if (force) {
+        m_settings = settings;
+    } else {
+        m_settings.applySettings(settingsKeys, settings);
+    }
 }
 
 void ADSBDemod::setCenterFrequency(qint64 frequency)
 {
     ADSBDemodSettings settings = m_settings;
     settings.m_inputFrequencyOffset = frequency;
-    applySettings(settings);
+    applySettings(settings, {"inputFrequencyOffset"}, false);
 
     if (m_guiMessageQueue) // forward to GUI if any
     {
-        MsgConfigureADSBDemod *msgToGUI = MsgConfigureADSBDemod::create(settings, false);
+        MsgConfigureADSBDemod *msgToGUI = MsgConfigureADSBDemod::create(settings, {"inputFrequencyOffset"}, false);
         m_guiMessageQueue->push(msgToGUI);
     }
 }
@@ -368,7 +270,7 @@ bool ADSBDemod::deserialize(const QByteArray& data)
         success = false;
     }
 
-    MsgConfigureADSBDemod *msg = MsgConfigureADSBDemod::create(m_settings, true);
+    MsgConfigureADSBDemod *msg = MsgConfigureADSBDemod::create(m_settings, QStringList(), true);
     m_inputMessageQueue.push(msg);
 
     return success;
@@ -404,12 +306,12 @@ int ADSBDemod::webapiSettingsPutPatch(
     ADSBDemodSettings settings = m_settings;
     webapiUpdateChannelSettings(settings, channelSettingsKeys, response);
 
-    MsgConfigureADSBDemod *msg = MsgConfigureADSBDemod::create(settings, force);
+    MsgConfigureADSBDemod *msg = MsgConfigureADSBDemod::create(settings, channelSettingsKeys, force);
     m_inputMessageQueue.push(msg);
 
     if (m_guiMessageQueue) // forward to GUI if any
     {
-        MsgConfigureADSBDemod *msgToGUI = MsgConfigureADSBDemod::create(settings, force);
+        MsgConfigureADSBDemod *msgToGUI = MsgConfigureADSBDemod::create(settings, channelSettingsKeys, force);
         m_guiMessageQueue->push(msgToGUI);
     }
 
@@ -661,7 +563,7 @@ void ADSBDemod::webapiFormatChannelReport(SWGSDRangel::SWGChannelReport& respons
     }
 }
 
-void ADSBDemod::webapiReverseSendSettings(QList<QString>& channelSettingsKeys, const ADSBDemodSettings& settings, bool force)
+void ADSBDemod::webapiReverseSendSettings(const QList<QString>& channelSettingsKeys, const ADSBDemodSettings& settings, bool force)
 {
     SWGSDRangel::SWGChannelSettings *swgChannelSettings = new SWGSDRangel::SWGChannelSettings();
     swgChannelSettings->setDirection(0); // single sink (Rx)

--- a/plugins/channelrx/demodadsb/adsbdemod.h
+++ b/plugins/channelrx/demodadsb/adsbdemod.h
@@ -20,8 +20,6 @@
 #ifndef INCLUDE_ADSBDEMOD_H
 #define INCLUDE_ADSBDEMOD_H
 
-#include <vector>
-
 #include <QNetworkRequest>
 
 #include "dsp/basebandsamplesink.h"
@@ -44,20 +42,23 @@ public:
 
     public:
         const ADSBDemodSettings& getSettings() const { return m_settings; }
+        const QStringList& getSettingsKeys() const { return m_settingsKeys; }
         bool getForce() const { return m_force; }
 
-        static MsgConfigureADSBDemod* create(const ADSBDemodSettings& settings, bool force)
+        static MsgConfigureADSBDemod* create(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force)
         {
-            return new MsgConfigureADSBDemod(settings, force);
+            return new MsgConfigureADSBDemod(settings, settingsKeys, force);
         }
 
     private:
         ADSBDemodSettings m_settings;
+        QStringList m_settingsKeys;
         bool m_force;
 
-        MsgConfigureADSBDemod(const ADSBDemodSettings& settings, bool force) :
+        MsgConfigureADSBDemod(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force) :
             Message(),
             m_settings(settings),
+            m_settingsKeys(settingsKeys),
             m_force(force)
         { }
     };
@@ -184,9 +185,9 @@ private:
     QNetworkRequest m_networkRequest;
 
 	virtual bool handleMessage(const Message& cmd); //!< Processing of a message. Returns true if message has actually been processed
-    void applySettings(const ADSBDemodSettings& settings, bool force = false);
+    void applySettings(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force = false);
     void webapiFormatChannelReport(SWGSDRangel::SWGChannelReport& response);
-    void webapiReverseSendSettings(QList<QString>& channelSettingsKeys, const ADSBDemodSettings& settings, bool force);
+    void webapiReverseSendSettings(const QList<QString>& channelSettingsKeys, const ADSBDemodSettings& settings, bool force);
 
 private slots:
     void networkManagerFinished(QNetworkReply *reply);

--- a/plugins/channelrx/demodadsb/adsbdemodbaseband.h
+++ b/plugins/channelrx/demodadsb/adsbdemodbaseband.h
@@ -39,20 +39,23 @@ public:
 
     public:
         const ADSBDemodSettings& getSettings() const { return m_settings; }
+        const QStringList& getSettingsKeys() const { return m_settingsKeys; }
         bool getForce() const { return m_force; }
 
-        static MsgConfigureADSBDemodBaseband* create(const ADSBDemodSettings& settings, bool force)
+        static MsgConfigureADSBDemodBaseband* create(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force)
         {
-            return new MsgConfigureADSBDemodBaseband(settings, force);
+            return new MsgConfigureADSBDemodBaseband(settings, settingsKeys, force);
         }
 
     private:
         ADSBDemodSettings m_settings;
+        QStringList m_settingsKeys;
         bool m_force;
 
-        MsgConfigureADSBDemodBaseband(const ADSBDemodSettings& settings, bool force) :
+        MsgConfigureADSBDemodBaseband(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force) :
             Message(),
             m_settings(settings),
+            m_settingsKeys(settingsKeys),
             m_force(force)
         { }
     };
@@ -80,7 +83,7 @@ private:
     QRecursiveMutex m_mutex;
 
     bool handleMessage(const Message& cmd);
-    void applySettings(const ADSBDemodSettings& settings, bool force = false);
+    void applySettings(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force = false);
 
 private slots:
     void handleInputMessages();

--- a/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.cpp
@@ -82,35 +82,124 @@ ADSBDemodDisplayDialog::~ADSBDemodDisplayDialog()
 
 void ADSBDemodDisplayDialog::accept()
 {
-    m_settings->m_removeTimeout = ui->timeout->value();
-    m_settings->m_aircraftMinZoom = ui->aircraftMinZoom->value();
-    m_settings->m_airportRange = ui->airportRange->value();
-    m_settings->m_airportMinimumSize = (ADSBDemodSettings::AirportType)ui->airportSize->currentIndex();
-    m_settings->m_displayHeliports = ui->heliports->isChecked();
-    m_settings->m_siUnits = ui->units->currentIndex() == 0 ? false : true;
-    m_settings->m_displayDemodStats = ui->displayStats->isChecked();
-    m_settings->m_autoResizeTableColumns = ui->autoResizeTableColumns->isChecked();
-    m_settings->m_aviationstackAPIKey = ui->aviationstackAPIKey->text();
-    m_settings->m_checkWXAPIKey = ui->checkWXAPIKey->text();
-    m_settings->m_airspaces = QStringList();
+    if (m_settings->m_removeTimeout != ui->timeout->value())
+    {
+        m_settings->m_removeTimeout = ui->timeout->value();
+        m_settingsKeys.append("removeTimeout");
+    }
+    if (m_settings->m_aircraftMinZoom != ui->aircraftMinZoom->value())
+    {
+        m_settings->m_aircraftMinZoom = ui->aircraftMinZoom->value();
+        m_settingsKeys.append("aircraftMinZoom");
+    }
+    if (m_settings->m_airportRange != ui->airportRange->value())
+    {
+        m_settings->m_airportRange = ui->airportRange->value();
+        m_settingsKeys.append("airportRange");
+    }
+    if (m_settings->m_airportMinimumSize != (ADSBDemodSettings::AirportType)ui->airportSize->currentIndex())
+    {
+        m_settings->m_airportMinimumSize = (ADSBDemodSettings::AirportType)ui->airportSize->currentIndex();
+        m_settingsKeys.append("airportMinimumSize");
+    }
+    if (m_settings->m_displayHeliports != ui->heliports->isChecked())
+    {
+        m_settings->m_displayHeliports = ui->heliports->isChecked();
+        m_settingsKeys.append("displayHeliports");
+    }
+    if (m_settings->m_siUnits != ui->units->currentIndex() == 0 ? false : true)
+    {
+        m_settings->m_siUnits = ui->units->currentIndex() == 0 ? false : true;
+        m_settingsKeys.append("siUnits");
+    }
+    if (m_settings->m_displayDemodStats != ui->displayStats->isChecked())
+    {
+        m_settings->m_displayDemodStats = ui->displayStats->isChecked();
+        m_settingsKeys.append("displayDemodStats");
+    }
+    if (m_settings->m_autoResizeTableColumns != ui->autoResizeTableColumns->isChecked())
+    {
+        m_settings->m_autoResizeTableColumns = ui->autoResizeTableColumns->isChecked();
+        m_settingsKeys.append("autoResizeTableColumns");
+    }
+    if (m_settings->m_aviationstackAPIKey != ui->aviationstackAPIKey->text())
+    {
+        m_settings->m_aviationstackAPIKey = ui->aviationstackAPIKey->text();
+        m_settingsKeys.append("aviationstackAPIKey");
+    }
+    if (m_settings->m_checkWXAPIKey != ui->checkWXAPIKey->text())
+    {
+        m_settings->m_checkWXAPIKey = ui->checkWXAPIKey->text();
+        m_settingsKeys.append("checkWXAPIKey");
+    }
+    QStringList airspaces;
     for (int i = 0; i < ui->airspaces->count(); i++)
     {
         QListWidgetItem *item = ui->airspaces->item(i);
         if (item->checkState() == Qt::Checked) {
-            m_settings->m_airspaces.append(item->text());
+            airspaces.append(item->text());
         }
     }
-    m_settings->m_airspaceRange = ui->airspaceRange->value();
-    m_settings->m_mapProvider = ui->mapProvider->currentText();
-    m_settings->m_mapType = (ADSBDemodSettings::MapType)ui->mapType->currentIndex();
-    m_settings->m_displayNavAids = ui->navAids->isChecked();
-    m_settings->m_atcCallsigns = ui->atcCallsigns->isChecked();
-    m_settings->m_displayPhotos = ui->photos->isChecked();
-    m_settings->m_verboseModelMatching = ui->verboseModelMatching->isChecked();
-    m_settings->m_airfieldElevation = ui->airfieldElevation->value();
-    m_settings->m_transitionAlt = ui->transitionAltitude->value();
-    m_settings->m_tableFontName = m_fontName;
-    m_settings->m_tableFontSize = m_fontSize;
+    if (m_settings->m_airspaces != airspaces)
+    {
+        m_settings->m_airspaces = airspaces;
+        m_settingsKeys.append("airspaces");
+    }
+    if (m_settings->m_airspaceRange != ui->airspaceRange->value())
+    {
+        m_settings->m_airspaceRange = ui->airspaceRange->value();
+        m_settingsKeys.append("airspaceRange");
+    }
+    if (m_settings->m_mapProvider != ui->mapProvider->currentText())
+    {
+        m_settings->m_mapProvider = ui->mapProvider->currentText();
+        m_settingsKeys.append("mapProvider");
+    }
+    if (m_settings->m_mapType != (ADSBDemodSettings::MapType)ui->mapType->currentIndex())
+    {
+        m_settings->m_mapType = (ADSBDemodSettings::MapType)ui->mapType->currentIndex();
+        m_settingsKeys.append("mapType");
+    }
+    if (m_settings->m_displayNavAids != ui->navAids->isChecked())
+    {
+        m_settings->m_displayNavAids = ui->navAids->isChecked();
+        m_settingsKeys.append("displayNavAids");
+    }
+    if (m_settings->m_atcCallsigns != ui->atcCallsigns->isChecked())
+    {
+        m_settings->m_atcCallsigns = ui->atcCallsigns->isChecked();
+        m_settingsKeys.append("atcCallsigns");
+    }
+    if (m_settings->m_displayPhotos != ui->photos->isChecked())
+    {
+        m_settings->m_displayPhotos = ui->photos->isChecked();
+        m_settingsKeys.append("displayPhotos");
+    }
+    if (m_settings->m_verboseModelMatching != ui->verboseModelMatching->isChecked())
+    {
+        m_settings->m_verboseModelMatching = ui->verboseModelMatching->isChecked();
+        m_settingsKeys.append("verboseModelMatching");
+    }
+    if (m_settings->m_airfieldElevation != ui->airfieldElevation->value())
+    {
+        m_settings->m_airfieldElevation = ui->airfieldElevation->value();
+        m_settingsKeys.append("airfieldElevation");
+    }
+    if (m_settings->m_transitionAlt != ui->transitionAltitude->value())
+    {
+        m_settings->m_transitionAlt = ui->transitionAltitude->value();
+        m_settingsKeys.append("transitionAlt");
+    }
+    if (m_settings->m_tableFontName != m_fontName)
+    {
+        m_settings->m_tableFontName = m_fontName;
+        m_settingsKeys.append("tableFontName");
+    }
+    if (m_settings->m_tableFontSize != m_fontSize)
+    {
+        m_settings->m_tableFontSize = m_fontSize;
+        m_settingsKeys.append("tableFontSize");
+    }
     QDialog::accept();
 }
 

--- a/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.h
+++ b/plugins/channelrx/demodadsb/adsbdemoddisplaydialog.h
@@ -28,6 +28,8 @@ public:
     explicit ADSBDemodDisplayDialog(ADSBDemodSettings *settings, QWidget* parent = 0);
     ~ADSBDemodDisplayDialog();
 
+    const QStringList& getSettingsKeys() const { return m_settingsKeys; };
+
 private slots:
     void accept();
     void on_font_clicked();
@@ -35,6 +37,7 @@ private slots:
 private:
     Ui::ADSBDemodDisplayDialog* ui;
     ADSBDemodSettings *m_settings;
+    QStringList m_settingsKeys;
     QString m_fontName;
     int m_fontSize;
 };

--- a/plugins/channelrx/demodadsb/adsbdemodgui.h
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.h
@@ -811,7 +811,7 @@ public:
     {
         m_aircraftRegExp.optimize();
     }
-    
+
     virtual ~ModelMatch() = default;
 
     virtual bool match(const QString &aircraft, const QString &manufacturer, QString &model)
@@ -911,6 +911,7 @@ private:
     ChannelMarker m_channelMarker;
     RollupState m_rollupState;
     ADSBDemodSettings m_settings;
+    QStringList m_settingsKeys;
     qint64 m_deviceCenterFrequency;
     int m_basebandSampleRate;
     bool m_basicSettingsShown;
@@ -981,8 +982,10 @@ private:
     virtual ~ADSBDemodGUI();
 
     void blockApplySettings(bool block);
-    void applySettings(bool force = false);
-    void displaySettings();
+    void applySetting(const QString& settingsKey);
+    void applySettings(const QStringList& settingsKeys, bool force = false);
+    void applyAllSettings();
+    void displaySettings(const QStringList& settingsKeys, bool force);
     bool handleMessage(const Message& message);
     void makeUIConnections();
     void updateAbsoluteCenterFrequency();

--- a/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
@@ -401,3 +401,375 @@ void ADSBDemodSettings::NotificationSettings::updateRegularExpression()
         qDebug() << "ADSBDemod: Regular expression is not valid: " << m_regExp;
     }
 }
+
+void ADSBDemodSettings::applySettings(const QStringList& settingsKeys, const ADSBDemodSettings& settings)
+{
+    if (settingsKeys.contains("inputFrequencyOffset")) {
+        m_inputFrequencyOffset = settings.m_inputFrequencyOffset;
+    }
+    if (settingsKeys.contains("rfBandwidth")) {
+        m_rfBandwidth = settings.m_rfBandwidth;
+    }
+    if (settingsKeys.contains("correlationThreshold")) {
+        m_correlationThreshold = settings.m_correlationThreshold;
+    }
+    if (settingsKeys.contains("samplesPerBit")) {
+        m_samplesPerBit = settings.m_samplesPerBit;
+    }
+    if (settingsKeys.contains("removeTimeout")) {
+        m_removeTimeout = settings.m_removeTimeout;
+    }
+    if (settingsKeys.contains("feedEnabled")) {
+        m_feedEnabled = settings.m_feedEnabled;
+    }
+    if (settingsKeys.contains("exportClientEnabled")) {
+        m_exportClientEnabled = settings.m_exportClientEnabled;
+    }
+    if (settingsKeys.contains("exportClientHost")) {
+        m_exportClientHost = settings.m_exportClientHost;
+    }
+    if (settingsKeys.contains("exportClientPort")) {
+        m_exportClientPort = settings.m_exportClientPort;
+    }
+    if (settingsKeys.contains("exportClientFormat")) {
+        m_exportClientFormat = settings.m_exportClientFormat;
+    }
+    if (settingsKeys.contains("exportServerEnabled")) {
+        m_exportServerEnabled = settings.m_exportServerEnabled;
+    }
+    if (settingsKeys.contains("exportServerPort")) {
+        m_exportServerPort = settings.m_exportServerPort;
+    }
+    if (settingsKeys.contains("importEnabled")) {
+        m_importEnabled = settings.m_importEnabled;
+    }
+    if (settingsKeys.contains("importHost")) {
+        m_importHost = settings.m_importHost;
+    }
+    if (settingsKeys.contains("importUsername")) {
+        m_importUsername = settings.m_importUsername;
+    }
+    if (settingsKeys.contains("importPassword")) {
+        m_importPassword = settings.m_importPassword;
+    }
+    if (settingsKeys.contains("importParameters")) {
+        m_importParameters = settings.m_importParameters;
+    }
+    if (settingsKeys.contains("importPeriod")) {
+        m_importPeriod = settings.m_importPeriod;
+    }
+    if (settingsKeys.contains("importMinLatitude")) {
+        m_importMinLatitude = settings.m_importMinLatitude;
+    }
+    if (settingsKeys.contains("importMaxLatitude")) {
+        m_importMaxLatitude = settings.m_importMaxLatitude;
+    }
+    if (settingsKeys.contains("importMinLongitude")) {
+        m_importMinLongitude = settings.m_importMinLongitude;
+    }
+    if (settingsKeys.contains("importMaxLongitude")) {
+        m_importMaxLongitude = settings.m_importMaxLongitude;
+    }
+    if (settingsKeys.contains("rgbColor")) {
+        m_rgbColor = settings.m_rgbColor;
+    }
+    if (settingsKeys.contains("title")) {
+        m_title = settings.m_title;
+    }
+    if (settingsKeys.contains("useReverseAPI")) {
+        m_useReverseAPI = settings.m_useReverseAPI;
+    }
+    if (settingsKeys.contains("reverseAPIAddress")) {
+        m_reverseAPIAddress = settings.m_reverseAPIAddress;
+    }
+    if (settingsKeys.contains("reverseAPIPort")) {
+        m_reverseAPIPort = settings.m_reverseAPIPort;
+    }
+    if (settingsKeys.contains("reverseAPIDeviceIndex")) {
+        m_reverseAPIDeviceIndex = settings.m_reverseAPIDeviceIndex;
+    }
+    if (settingsKeys.contains("columnIndexes")) {
+        std::copy(std::begin(settings.m_columnIndexes), std::end(settings.m_columnIndexes), std::begin(m_columnIndexes));
+    }
+    if (settingsKeys.contains("columnSizes")) {
+        std::copy(std::begin(settings.m_columnSizes), std::end(settings.m_columnIndexes), std::begin(m_columnSizes));
+    }
+    if (settingsKeys.contains("airportRange")) {
+        m_airportRange = settings.m_airportRange;
+    }
+    if (settingsKeys.contains("airportMinimumSize")) {
+        m_airportMinimumSize = settings.m_airportMinimumSize;
+    }
+    if (settingsKeys.contains("displayHeliports")) {
+        m_displayHeliports = settings.m_displayHeliports;
+    }
+    if (settingsKeys.contains("flightPaths")) {
+        m_flightPaths = settings.m_flightPaths;
+    }
+    if (settingsKeys.contains("allFlightPaths")) {
+        m_allFlightPaths = settings.m_allFlightPaths;
+    }
+    if (settingsKeys.contains("siUnits")) {
+        m_siUnits = settings.m_siUnits;
+    }
+    if (settingsKeys.contains("tableFontName")) {
+        m_tableFontName = settings.m_tableFontName;
+    }
+    if (settingsKeys.contains("tableFontSize")) {
+        m_tableFontSize = settings.m_tableFontSize;
+    }
+    if (settingsKeys.contains("displayDemodStats")) {
+        m_displayDemodStats = settings.m_displayDemodStats;
+    }
+    if (settingsKeys.contains("correlateFullPreamble")) {
+        m_correlateFullPreamble = settings.m_correlateFullPreamble;
+    }
+    if (settingsKeys.contains("demodModeS")) {
+        m_demodModeS = settings.m_demodModeS;
+    }
+    if (settingsKeys.contains("amDemod")) {
+        m_amDemod = settings.m_amDemod;
+    }
+    if (settingsKeys.contains("autoResizeTableColumns")) {
+        m_autoResizeTableColumns = settings.m_autoResizeTableColumns;
+    }
+    if (settingsKeys.contains("interpolatorPhaseSteps")) {
+        m_interpolatorPhaseSteps = settings.m_interpolatorPhaseSteps;
+    }
+    if (settingsKeys.contains("interpolatorTapsPerPhase")) {
+        m_interpolatorTapsPerPhase = settings.m_interpolatorTapsPerPhase;
+    }
+    if (settingsKeys.contains("notificationSettings")) {
+        m_notificationSettings = settings.m_notificationSettings;
+    }
+    if (settingsKeys.contains("aviationstackAPIKey")) {
+        m_aviationstackAPIKey = settings.m_aviationstackAPIKey;
+    }
+    if (settingsKeys.contains("checkWXAPIKey")) {
+        m_checkWXAPIKey = settings.m_checkWXAPIKey;
+    }
+    if (settingsKeys.contains("logFilename")) {
+        m_logFilename = settings.m_logFilename;
+    }
+    if (settingsKeys.contains("logEnabled")) {
+        m_logEnabled = settings.m_logEnabled;
+    }
+    if (settingsKeys.contains("airspaces")) {
+        m_airspaces = settings.m_airspaces;
+    }
+    if (settingsKeys.contains("airspaceRange")) {
+        m_airspaceRange = settings.m_airspaceRange;
+    }
+    if (settingsKeys.contains("mapProvider")) {
+        m_mapProvider = settings.m_mapProvider;
+    }
+    if (settingsKeys.contains("mapType")) {
+        m_mapType = settings.m_mapType;
+    }
+    if (settingsKeys.contains("displayNavAids")) {
+        m_displayNavAids = settings.m_displayNavAids;
+    }
+    if (settingsKeys.contains("displayPhotos")) {
+        m_displayPhotos = settings.m_displayPhotos;
+    }
+    if (settingsKeys.contains("verboseModelMatching")) {
+        m_verboseModelMatching = settings.m_verboseModelMatching;
+    }
+    if (settingsKeys.contains("airfieldElevation")) {
+        m_airfieldElevation = settings.m_airfieldElevation;
+    }
+    if (settingsKeys.contains("aircraftMinZoom")) {
+        m_aircraftMinZoom = settings.m_aircraftMinZoom;
+    }
+    if (settingsKeys.contains("atcLabels")) {
+        m_atcLabels = settings.m_atcLabels;
+    }
+    if (settingsKeys.contains("atcCallsigns")) {
+        m_atcCallsigns = settings.m_atcCallsigns;
+    }
+    if (settingsKeys.contains("transitionAlt")) {
+        m_transitionAlt = settings.m_transitionAlt;
+    }
+}
+
+QString ADSBDemodSettings::getDebugString(const QStringList& settingsKeys, bool force) const
+{
+    std::ostringstream ostr;
+
+    if (settingsKeys.contains("inputFrequencyOffset") || force) {
+        ostr << " m_inputFrequencyOffset: " << m_inputFrequencyOffset;
+    }
+    if (settingsKeys.contains("rfBandwidth") || force) {
+        ostr << " m_rfBandwidth: " << m_rfBandwidth;
+    }
+    if (settingsKeys.contains("correlationThreshold") || force) {
+        ostr << " m_correlationThreshold: " << m_correlationThreshold;
+    }
+    if (settingsKeys.contains("samplesPerBit") || force) {
+        ostr << " m_samplesPerBit: " << m_samplesPerBit;
+    }
+    if (settingsKeys.contains("removeTimeout") || force) {
+        ostr << " m_removeTimeout: " << m_removeTimeout;
+    }
+    if (settingsKeys.contains("feedEnabled") || force) {
+        ostr << " m_feedEnabled: " << m_feedEnabled;
+    }
+    if (settingsKeys.contains("exportClientEnabled") || force) {
+        ostr << " m_exportClientEnabled: " << m_exportClientEnabled;
+    }
+    if (settingsKeys.contains("exportClientHost") || force) {
+        ostr << " m_exportClientHost: " << m_exportClientHost.toStdString();
+    }
+    if (settingsKeys.contains("exportClientPort") || force) {
+        ostr << " m_exportClientPort: " << m_exportClientPort;
+    }
+    if (settingsKeys.contains("exportClientFormat") || force) {
+        ostr << " m_exportClientFormat: " << m_exportClientFormat;
+    }
+    if (settingsKeys.contains("exportServerEnabled") || force) {
+        ostr << " m_exportServerEnabled: " << m_exportServerEnabled;
+    }
+    if (settingsKeys.contains("exportServerPort") || force) {
+        ostr << " m_exportServerPort: " << m_exportServerPort;
+    }
+    if (settingsKeys.contains("importEnabled") || force) {
+        ostr << " m_importEnabled: " << m_importEnabled;
+    }
+    if (settingsKeys.contains("importHost") || force) {
+        ostr << " m_importHost: " << m_importHost.toStdString();
+    }
+    if (settingsKeys.contains("importUsername") || force) {
+        ostr << " m_importUsername: " << m_importUsername.toStdString();
+    }
+    if (settingsKeys.contains("importPassword") || force) {
+        ostr << " m_importPassword: " << m_importPassword.toStdString();
+    }
+    if (settingsKeys.contains("importParameters") || force) {
+        ostr << " m_importParameters: " << m_importParameters.toStdString();
+    }
+    if (settingsKeys.contains("importPeriod") || force) {
+        ostr << " m_importPeriod: " << m_importPeriod;
+    }
+    if (settingsKeys.contains("importMinLatitude") || force) {
+        ostr << " m_importMinLatitude: " << m_importMinLatitude.toStdString();
+    }
+    if (settingsKeys.contains("importMaxLatitude") || force) {
+        ostr << " m_importMaxLatitude: " << m_importMaxLatitude.toStdString();
+    }
+    if (settingsKeys.contains("importMinLongitude") || force) {
+        ostr << " m_importMinLongitude: " << m_importMinLongitude.toStdString();
+    }
+    if (settingsKeys.contains("importMaxLongitude") || force) {
+        ostr << " m_importMaxLongitude: " << m_importMaxLongitude.toStdString();
+    }
+    if (settingsKeys.contains("title") || force) {
+        ostr << " m_title: " << m_title.toStdString();
+    }
+    if (settingsKeys.contains("useReverseAPI") || force) {
+        ostr << " m_useReverseAPI: " << m_useReverseAPI;
+    }
+    if (settingsKeys.contains("reverseAPIAddress") || force) {
+        ostr << " m_reverseAPIAddress: " << m_reverseAPIAddress.toStdString();
+    }
+    if (settingsKeys.contains("reverseAPIPort") || force) {
+        ostr << " m_reverseAPIPort: " << m_reverseAPIPort;
+    }
+    if (settingsKeys.contains("reverseAPIDeviceIndex") || force) {
+        ostr << " m_reverseAPIDeviceIndex: " << m_reverseAPIDeviceIndex;
+    }
+    if (settingsKeys.contains("airportRange") || force) {
+        ostr << " m_airportRange: " << m_airportRange;
+    }
+    if (settingsKeys.contains("airportMinimumSize") || force) {
+        ostr << " m_airportMinimumSize: " << m_airportMinimumSize;
+    }
+    if (settingsKeys.contains("displayHeliports") || force) {
+        ostr << " m_displayHeliports: " << m_displayHeliports;
+    }
+    if (settingsKeys.contains("flightPaths") || force) {
+        ostr << " m_flightPaths: " << m_flightPaths;
+    }
+    if (settingsKeys.contains("allFlightPaths") || force) {
+        ostr << " m_allFlightPaths: " << m_allFlightPaths;
+    }
+    if (settingsKeys.contains("siUnits") || force) {
+        ostr << " m_siUnits: " << m_siUnits;
+    }
+    if (settingsKeys.contains("tableFontName") || force) {
+        ostr << " m_tableFontName: " << m_tableFontName.toStdString();
+    }
+    if (settingsKeys.contains("tableFontSize") || force) {
+        ostr << " m_tableFontSize: " << m_tableFontSize;
+    }
+    if (settingsKeys.contains("displayDemodStats") || force) {
+        ostr << " m_displayDemodStats: " << m_displayDemodStats;
+    }
+    if (settingsKeys.contains("correlateFullPreamble") || force) {
+        ostr << " m_correlateFullPreamble: " << m_correlateFullPreamble;
+    }
+    if (settingsKeys.contains("demodModeS") || force) {
+        ostr << " m_demodModeS: " << m_demodModeS;
+    }
+    if (settingsKeys.contains("amDemod") || force) {
+        ostr << " m_amDemod: " << m_amDemod.toStdString();
+    }
+    if (settingsKeys.contains("autoResizeTableColumns") || force) {
+        ostr << " m_autoResizeTableColumns: " << m_autoResizeTableColumns;
+    }
+    if (settingsKeys.contains("interpolatorPhaseSteps") || force) {
+        ostr << " m_interpolatorPhaseSteps: " << m_interpolatorPhaseSteps;
+    }
+    if (settingsKeys.contains("notificationSettings") || force) {
+        //ostr << " m_notificationSettings: " << m_notificationSettings.join(",").toStdString();
+    }
+    if (settingsKeys.contains("aviationstackAPIKey") || force) {
+        ostr << " m_aviationstackAPIKey: " << m_aviationstackAPIKey.toStdString();
+    }
+    if (settingsKeys.contains("checkWXAPIKey") || force) {
+        ostr << " m_checkWXAPIKey: " << m_checkWXAPIKey.toStdString();
+    }
+    if (settingsKeys.contains("logFilename") || force) {
+        ostr << " m_logFilename: " << m_logFilename.toStdString();
+    }
+    if (settingsKeys.contains("logEnabled") || force) {
+        ostr << " m_logEnabled: " << m_logEnabled;
+    }
+    if (settingsKeys.contains("airspaces") || force) {
+        ostr << " m_airspaces: " << m_airspaces.join(",").toStdString();
+    }
+    if (settingsKeys.contains("airspaceRange") || force) {
+        ostr << " m_airspaceRange: " << m_airspaceRange;
+    }
+    if (settingsKeys.contains("mapProvider") || force) {
+        ostr << " m_mapProvider: " << m_mapProvider.toStdString();
+    }
+    if (settingsKeys.contains("mapType") || force) {
+        ostr << " m_mapType: " << m_mapType;
+    }
+    if (settingsKeys.contains("displayNavAids") || force) {
+        ostr << " m_displayNavAids: " << m_displayNavAids;
+    }
+    if (settingsKeys.contains("displayPhotos") || force) {
+        ostr << " m_displayPhotos: " << m_displayPhotos;
+    }
+    if (settingsKeys.contains("verboseModelMatching") || force) {
+        ostr << " m_verboseModelMatching: " << m_verboseModelMatching;
+    }
+    if (settingsKeys.contains("airfieldElevation") || force) {
+        ostr << " m_airfieldElevation: " << m_airfieldElevation;
+    }
+    if (settingsKeys.contains("aircraftMinZoom") || force) {
+        ostr << " m_aircraftMinZoom: " << m_aircraftMinZoom;
+    }
+    if (settingsKeys.contains("atcLabels") || force) {
+        ostr << " m_atcLabels: " << m_atcLabels;
+    }
+    if (settingsKeys.contains("atcCallsigns") || force) {
+        ostr << " m_atcCallsigns: " << m_atcCallsigns;
+    }
+    if (settingsKeys.contains("transitionAlt") || force) {
+        ostr << " m_transitionAlt: " << m_transitionAlt;
+    }
+
+    return QString(ostr.str().c_str());
+}

--- a/plugins/channelrx/demodadsb/adsbdemodsettings.h
+++ b/plugins/channelrx/demodadsb/adsbdemodsettings.h
@@ -201,6 +201,8 @@ struct ADSBDemodSettings
     bool deserialize(const QByteArray& data);
     QByteArray serializeNotificationSettings(QList<NotificationSettings *> notificationSettings) const;
     void deserializeNotificationSettings(const QByteArray& data, QList<NotificationSettings *>& notificationSettings);
+    void applySettings(const QStringList& settingsKeys, const ADSBDemodSettings& settings);
+    QString getDebugString(const QStringList& settingsKeys, bool force = false) const;
 };
 
 #endif /* PLUGINS_CHANNELRX_DEMODADSB_ADSBDEMODSETTINGS_H_ */

--- a/plugins/channelrx/demodadsb/adsbdemodsink.h
+++ b/plugins/channelrx/demodadsb/adsbdemodsink.h
@@ -55,7 +55,7 @@ public:
     }
 
     void applyChannelSettings(int channelSampleRate, int channelFrequencyOffset, bool force = false);
-    void applySettings(const ADSBDemodSettings& settings, bool force = false);
+    void applySettings(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force = false);
     void setMessageQueueToGUI(MessageQueue *messageQueue) { m_messageQueueToGUI = messageQueue; }
     void setMessageQueueToWorker(MessageQueue *messageQueue) { m_messageQueueToWorker = messageQueue; }
     void startWorker();

--- a/plugins/channelrx/demodadsb/adsbdemodsinkworker.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodsinkworker.cpp
@@ -357,22 +357,30 @@ void ADSBDemodSinkWorker::handleInputMessages()
             MsgConfigureADSBDemodSinkWorker* cfg = (MsgConfigureADSBDemodSinkWorker*)message;
 
             ADSBDemodSettings settings = cfg->getSettings();
+            QStringList settingsKeys = cfg->getSettingsKeys();
             bool force = cfg->getForce();
 
-            if (settings.m_correlateFullPreamble) {
-                m_correlationScale = 3.0;
-            } else {
-                m_correlationScale = 2.0;
+            if (settingsKeys.contains("correlateFullPreamble") || force)
+            {
+                if (settings.m_correlateFullPreamble) {
+                    m_correlationScale = 3.0;
+                } else {
+                    m_correlationScale = 2.0;
+                }
             }
 
-            if ((m_settings.m_correlationThreshold != settings.m_correlationThreshold) || force)
+            if ((settingsKeys.contains("correlationThreshold") && (m_settings.m_correlationThreshold != settings.m_correlationThreshold)) || force)
             {
                 m_correlationThresholdLinear = CalcDb::powerFromdB(settings.m_correlationThreshold);
                 m_correlationThresholdLinear /= m_correlationScale;
                 qDebug() << "m_correlationThresholdLinear: " << m_correlationThresholdLinear;
             }
 
-            m_settings = settings;
+            if (force) {
+                m_settings = settings;
+            } else {
+                m_settings.applySettings(settingsKeys, settings);
+            }
             delete message;
         }
     }

--- a/plugins/channelrx/demodadsb/adsbdemodsinkworker.h
+++ b/plugins/channelrx/demodadsb/adsbdemodsinkworker.h
@@ -40,20 +40,23 @@ public:
 
     public:
         const ADSBDemodSettings& getSettings() const { return m_settings; }
+        const QStringList& getSettingsKeys() const { return m_settingsKeys; }
         bool getForce() const { return m_force; }
 
-        static MsgConfigureADSBDemodSinkWorker* create(const ADSBDemodSettings& settings, bool force)
+        static MsgConfigureADSBDemodSinkWorker* create(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force)
         {
-            return new MsgConfigureADSBDemodSinkWorker(settings, force);
+            return new MsgConfigureADSBDemodSinkWorker(settings, settingsKeys, force);
         }
 
     private:
         ADSBDemodSettings m_settings;
+        QStringList m_settingsKeys;
         bool m_force;
 
-        MsgConfigureADSBDemodSinkWorker(const ADSBDemodSettings& settings, bool force) :
+        MsgConfigureADSBDemodSinkWorker(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force) :
             Message(),
             m_settings(settings),
+            m_settingsKeys(settingsKeys),
             m_force(force)
         { }
     };

--- a/plugins/channelrx/demodadsb/adsbdemodworker.h
+++ b/plugins/channelrx/demodadsb/adsbdemodworker.h
@@ -61,20 +61,23 @@ public:
 
     public:
         const ADSBDemodSettings& getSettings() const { return m_settings; }
+        const QStringList& getSettingsKeys() const { return m_settingsKeys; }
         bool getForce() const { return m_force; }
 
-        static MsgConfigureADSBDemodWorker* create(const ADSBDemodSettings& settings, bool force)
+        static MsgConfigureADSBDemodWorker* create(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force)
         {
-            return new MsgConfigureADSBDemodWorker(settings, force);
+            return new MsgConfigureADSBDemodWorker(settings, settingsKeys, force);
         }
 
     private:
         ADSBDemodSettings m_settings;
+        QStringList m_settingsKeys;
         bool m_force;
 
-        MsgConfigureADSBDemodWorker(const ADSBDemodSettings& settings, bool force) :
+        MsgConfigureADSBDemodWorker(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force) :
             Message(),
             m_settings(settings),
+            m_settingsKeys(settingsKeys),
             m_force(force)
         { }
     };
@@ -101,7 +104,7 @@ private:
     ADSBBeastServer m_beastServer;
 
     bool handleMessage(const Message& cmd);
-    void applySettings(const ADSBDemodSettings& settings, bool force = false);
+    void applySettings(const ADSBDemodSettings& settings, const QStringList& settingsKeys, bool force = false);
     void send(const char *data, int length);
     char *escape(char *p, char c);
     void handleADSB(QByteArray data, const QDateTime dateTime, float correlation);

--- a/plugins/channelrx/demodais/aisdemodgui.ui
+++ b/plugins/channelrx/demodais/aisdemodgui.ui
@@ -29,7 +29,7 @@
    </font>
   </property>
   <property name="focusPolicy">
-   <enum>Qt::StrongFocus</enum>
+   <enum>Qt::FocusPolicy::StrongFocus</enum>
   </property>
   <property name="windowTitle">
    <string>AIS Demodulator</string>
@@ -110,7 +110,7 @@
          <cursorShape>PointingHandCursor</cursorShape>
         </property>
         <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
         </property>
         <property name="toolTip">
          <string>Demod shift frequency from center in Hz</string>
@@ -127,14 +127,14 @@
       <item>
        <widget class="Line" name="line">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
        </widget>
       </item>
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -152,7 +152,7 @@
            <string>Channel power</string>
           </property>
           <property name="layoutDirection">
-           <enum>Qt::RightToLeft</enum>
+           <enum>Qt::LayoutDirection::RightToLeft</enum>
           </property>
           <property name="text">
            <string>0.0</string>
@@ -209,7 +209,7 @@
     <item>
      <widget class="Line" name="line_5">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
      </widget>
     </item>
@@ -252,7 +252,7 @@
          <number>100</number>
         </property>
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
        </widget>
       </item>
@@ -268,14 +268,14 @@
          <string>10.0k</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
         </property>
        </widget>
       </item>
       <item>
        <widget class="Line" name="line_2">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
        </widget>
       </item>
@@ -316,7 +316,7 @@
          <number>24</number>
         </property>
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
        </widget>
       </item>
@@ -332,14 +332,14 @@
          <string>±2.4k</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
         </property>
        </widget>
       </item>
       <item>
        <widget class="Line" name="line_7">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
        </widget>
       </item>
@@ -390,7 +390,7 @@
     <item>
      <widget class="Line" name="line_6">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
      </widget>
     </item>
@@ -409,7 +409,7 @@
          <string>Send packets via UDP</string>
         </property>
         <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
+         <enum>Qt::LayoutDirection::RightToLeft</enum>
         </property>
         <property name="text">
          <string/>
@@ -425,7 +425,7 @@
          </size>
         </property>
         <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
+         <enum>Qt::FocusPolicy::ClickFocus</enum>
         </property>
         <property name="toolTip">
          <string>Destination UDP address</string>
@@ -444,7 +444,7 @@
          <string>:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <set>Qt::AlignmentFlag::AlignCenter</set>
         </property>
        </widget>
       </item>
@@ -463,7 +463,7 @@
          </size>
         </property>
         <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
+         <enum>Qt::FocusPolicy::ClickFocus</enum>
         </property>
         <property name="toolTip">
          <string>Destination UDP port</string>
@@ -509,7 +509,7 @@
       <item>
        <spacer name="horizontalSpacer_4">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -524,7 +524,7 @@
     <item>
      <widget class="Line" name="line_3">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
      </widget>
     </item>
@@ -547,7 +547,7 @@
       <item>
        <spacer name="horizontalSpacer_3">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -695,10 +695,22 @@
     <string>Received Messages</string>
    </property>
    <layout class="QHBoxLayout" name="horizontalLayout">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
     <item>
      <widget class="QSplitter" name="splitter">
       <property name="orientation">
-       <enum>Qt::Vertical</enum>
+       <enum>Qt::Orientation::Vertical</enum>
       </property>
       <widget class="QWidget" name="slotMapWidget" native="true">
        <property name="sizePolicy">
@@ -738,10 +750,10 @@
            <string>Slot map</string>
           </property>
           <property name="frameShape">
-           <enum>QFrame::Panel</enum>
+           <enum>QFrame::Shape::Panel</enum>
           </property>
           <property name="frameShadow">
-           <enum>QFrame::Sunken</enum>
+           <enum>QFrame::Shadow::Sunken</enum>
           </property>
           <property name="text">
            <string/>
@@ -750,7 +762,7 @@
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
@@ -776,7 +788,7 @@
           <item>
            <widget class="Line" name="line_4">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
            </widget>
           </item>
@@ -800,7 +812,7 @@
           <item>
            <widget class="Line" name="line_8">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
            </widget>
           </item>
@@ -830,7 +842,7 @@
         <string>Received packets</string>
        </property>
        <property name="editTriggers">
-        <set>QAbstractItemView::NoEditTriggers</set>
+        <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
        </property>
        <column>
         <property name="text">
@@ -1012,7 +1024,7 @@
  </customwidgets>
  <resources>
   <include location="../../../sdrgui/resources/res.qrc"/>
-  <include location="../demodadsb/icons.qrc"/>
+  <include location="../demodadsb/adsbdemodicons.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/plugins/channelrx/freqscanner/freqscanner.h
+++ b/plugins/channelrx/freqscanner/freqscanner.h
@@ -399,7 +399,8 @@ private:
         START_SCAN,
         SCAN_FOR_MAX_POWER,
         WAIT_FOR_END_TX,
-        WAIT_FOR_RETRANSMISSION
+        WAIT_FOR_RETRANSMISSION,
+        WAIT_FOR_RX_TIME
     } m_state;
 
     QTimer m_timeoutTimer;

--- a/plugins/channelrx/freqscanner/freqscannergui.cpp
+++ b/plugins/channelrx/freqscanner/freqscannergui.cpp
@@ -364,6 +364,22 @@ void FreqScannerGUI::on_mode_currentIndexChanged(int index)
 {
     m_settings.m_mode = (FreqScannerSettings::Mode)index;
     applySetting("mode");
+    bool multiplex = m_settings.m_mode == FreqScannerSettings::MULTIPLEX;
+    ui->threshLabel->setEnabled(!multiplex);
+    ui->thresh->setEnabled(!multiplex);
+    ui->threshText->setEnabled(!multiplex);
+    ui->priorityLabel->setEnabled(!multiplex);
+    ui->priority->setEnabled(!multiplex);
+    if (multiplex)
+    {
+        ui->retransmitTimeLabel->setText("t<sub>TX</sub>");
+        ui->retransmitTime->setToolTip("Time in seconds to listen on each frequency");
+    }
+    else
+    {
+        ui->retransmitTimeLabel->setText("t<sub>RTX</sub>");
+        ui->retransmitTime->setToolTip("Time in seconds to wait for frequency to become active again, before restarting scan");
+    }
 }
 
 void FreqScannerGUI::onWidgetRolled(QWidget* widget, bool rollDown)

--- a/plugins/channelrx/freqscanner/freqscannergui.ui
+++ b/plugins/channelrx/freqscanner/freqscannergui.ui
@@ -29,7 +29,7 @@
    </font>
   </property>
   <property name="focusPolicy">
-   <enum>Qt::StrongFocus</enum>
+   <enum>Qt::FocusPolicy::StrongFocus</enum>
   </property>
   <property name="windowTitle">
    <string>Frequency Scanner</string>
@@ -102,7 +102,7 @@
       <item>
        <widget class="Line" name="line_6">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
        </widget>
       </item>
@@ -143,7 +143,7 @@
          <cursorShape>PointingHandCursor</cursorShape>
         </property>
         <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
         </property>
         <property name="toolTip">
          <string>Minimum demod shift frequency from center in Hz</string>
@@ -160,14 +160,14 @@
       <item>
        <widget class="Line" name="line">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
        </widget>
       </item>
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -191,13 +191,13 @@
            <string>Active frequency power </string>
           </property>
           <property name="layoutDirection">
-           <enum>Qt::RightToLeft</enum>
+           <enum>Qt::LayoutDirection::RightToLeft</enum>
           </property>
           <property name="text">
            <string>-120.0</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
           </property>
          </widget>
         </item>
@@ -215,7 +215,7 @@
     <item>
      <widget class="Line" name="line_7">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
      </widget>
     </item>
@@ -266,7 +266,7 @@
       <item>
        <spacer name="horizontalSpacer_3">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -279,7 +279,7 @@
       <item>
        <widget class="Line" name="line_4">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
        </widget>
       </item>
@@ -328,7 +328,7 @@
       <item>
        <widget class="Line" name="line_3">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
        </widget>
       </item>
@@ -377,7 +377,7 @@
       <item>
        <widget class="Line" name="line_2">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
        </widget>
       </item>
@@ -428,7 +428,7 @@
     <item>
      <widget class="Line" name="line_5">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
      </widget>
     </item>
@@ -465,7 +465,7 @@
          <cursorShape>PointingHandCursor</cursorShape>
         </property>
         <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
         </property>
         <property name="toolTip">
          <string>Channel bandwidth</string>
@@ -482,7 +482,7 @@
       <item>
        <spacer name="horizontalSpacer_4">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -551,7 +551,7 @@
     <item>
      <widget class="Line" name="filterLine">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
      </widget>
     </item>
@@ -569,7 +569,7 @@
          <string>Run mode</string>
         </property>
         <property name="currentIndex">
-         <number>1</number>
+         <number>0</number>
         </property>
         <item>
          <property name="text">
@@ -586,6 +586,11 @@
           <string>Scan-only</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>Multiplex</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item>
@@ -597,7 +602,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../../../sdrgui/resources/res.qrc">
+         <iconset resource="../../../../srcejon_sdrangel/sdrgui/resources/res.qrc">
           <normaloff>:/play.png</normaloff>
           <normalon>:/stop.png</normalon>:/play.png</iconset>
         </property>
@@ -621,7 +626,7 @@
     <item>
      <widget class="Line" name="line_8">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
      </widget>
     </item>
@@ -767,7 +772,7 @@ Leave blank for no adjustment</string>
            <string>Up</string>
           </property>
           <property name="icon">
-           <iconset resource="../../../sdrgui/resources/res.qrc">
+           <iconset resource="../../../../srcejon_sdrangel/sdrgui/resources/res.qrc">
             <normaloff>:/arrow_up.png</normaloff>:/arrow_up.png</iconset>
           </property>
          </widget>
@@ -781,7 +786,7 @@ Leave blank for no adjustment</string>
            <string/>
           </property>
           <property name="icon">
-           <iconset resource="../../../sdrgui/resources/res.qrc">
+           <iconset resource="../../../../srcejon_sdrangel/sdrgui/resources/res.qrc">
             <normaloff>:/arrow_down.png</normaloff>:/arrow_down.png</iconset>
           </property>
          </widget>
@@ -789,7 +794,7 @@ Leave blank for no adjustment</string>
         <item>
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -808,7 +813,7 @@ Leave blank for no adjustment</string>
            <string/>
           </property>
           <property name="icon">
-           <iconset resource="../../../sdrgui/resources/res.qrc">
+           <iconset resource="../../../../srcejon_sdrangel/sdrgui/resources/res.qrc">
             <normaloff>:/bin.png</normaloff>:/bin.png</iconset>
           </property>
          </widget>
@@ -843,7 +848,7 @@ Leave blank for no adjustment</string>
   <tabstop>deltaFrequency</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../sdrgui/resources/res.qrc"/>
+  <include location="../../../../srcejon_sdrangel/sdrgui/resources/res.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/plugins/channelrx/freqscanner/freqscannergui.ui
+++ b/plugins/channelrx/freqscanner/freqscannergui.ui
@@ -602,7 +602,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../../../../srcejon_sdrangel/sdrgui/resources/res.qrc">
+         <iconset resource="../../../sdrgui/resources/res.qrc">
           <normaloff>:/play.png</normaloff>
           <normalon>:/stop.png</normalon>:/play.png</iconset>
         </property>
@@ -772,7 +772,7 @@ Leave blank for no adjustment</string>
            <string>Up</string>
           </property>
           <property name="icon">
-           <iconset resource="../../../../srcejon_sdrangel/sdrgui/resources/res.qrc">
+           <iconset resource="../../../sdrgui/resources/res.qrc">
             <normaloff>:/arrow_up.png</normaloff>:/arrow_up.png</iconset>
           </property>
          </widget>
@@ -786,7 +786,7 @@ Leave blank for no adjustment</string>
            <string/>
           </property>
           <property name="icon">
-           <iconset resource="../../../../srcejon_sdrangel/sdrgui/resources/res.qrc">
+           <iconset resource="../../../sdrgui/resources/res.qrc">
             <normaloff>:/arrow_down.png</normaloff>:/arrow_down.png</iconset>
           </property>
          </widget>
@@ -813,7 +813,7 @@ Leave blank for no adjustment</string>
            <string/>
           </property>
           <property name="icon">
-           <iconset resource="../../../../srcejon_sdrangel/sdrgui/resources/res.qrc">
+           <iconset resource="../../../sdrgui/resources/res.qrc">
             <normaloff>:/bin.png</normaloff>:/bin.png</iconset>
           </property>
          </widget>
@@ -848,7 +848,7 @@ Leave blank for no adjustment</string>
   <tabstop>deltaFrequency</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../../srcejon_sdrangel/sdrgui/resources/res.qrc"/>
+  <include location="../../../sdrgui/resources/res.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/plugins/channelrx/freqscanner/freqscannersettings.h
+++ b/plugins/channelrx/freqscanner/freqscannersettings.h
@@ -64,7 +64,8 @@ struct FreqScannerSettings
     enum Mode {
         SINGLE,
         CONTINUOUS,
-        SCAN_ONLY
+        SCAN_ONLY,
+        MULTIPLEX
     } m_mode;                       //!< Whether to run a single or many scans
 
     QList<int> m_columnIndexes;//!< How the columns are ordered in the table

--- a/plugins/channelrx/freqscanner/readme.md
+++ b/plugins/channelrx/freqscanner/readme.md
@@ -6,6 +6,14 @@ This plugin can be used to scan a range of frequencies looking for a transmissio
 
 [Tutorial Video](https://www.youtube.com/watch?v=IpKP3t4Bmmg)
 
+With the Run Mode (11) set to Multiplex, it can also repeatedly cycle through frequencies listening for a fixed period of time. This can be used, for example, to
+receive both AIS and ADS-B data via a single SDR.
+
+Note that when scanning, the device centre frequency will often not be set exactly to the frequencies you enter. 
+The Frequency Scanner will typically try to set the device centre frequency in order to
+scan as many frequencies simultanously as possible, and also avoid having a DC offset within the bandwidth of a scanned frequency. 
+The demodulator channel's frequency offset option will be used so that it receives at the specified frequency.
+
 <h2>Interface</h2>
 
 The top and bottom bars of the channel window are described [here](../../../sdrgui/channel/readme.md)
@@ -40,10 +48,12 @@ that corresponds to the set frequency is being received.
 
 Specifies the time in seconds that the Frequency Scanner will average its power measurement over.
 
-<h3>7: t_rtx - Retransmission Time</h3>
+<h3>7: t_rtx - Retransmission Time / t_rx Receive Time</h3>
 
-Specifies the time in seconds that the Frequency Scanner will wait after the power on the active frequency falls below the threshold, before restarting
+t_rtx: When Run Mode (11) is not Multiplex, specifies the time in seconds that the Frequency Scanner will wait after the power on the active frequency falls below the threshold, before restarting
 scanning. This enables the channel to remain tuned to a single frequency while there is a temporary break in transmission.
+
+t_rx: When Run Mode (11) is Multiplex, specifies the time in seconds the channel will be tuned to each frequency.
 
 <h3>8: Ch BW - Channel Bandwidth</h3>
 
@@ -75,6 +85,7 @@ Specifies the run mode:
 - Single: All frequencies are scanned once. Channel (1) is tuned to the active frequency at the end of the scan. The scan does not repeat.
 - Continuous: All frequencies scanned, with channel (1) being tuned to active frequency at the end of the scan. Scan repeats once the power on the active frequency falls below the threshold (4) for longer than the retransmission time (7).
 - Scan only: All frequencies are scanned repeatedly. The channel will not be tuned. This mode is just for counting how often frequencies are active, which can be seen in the Active Count column in the frequency table (14).
+- Multiplex: Frequencies will be stepped through sequentially and repeatedly, with the channel (1) being tuned for the time specified by t_rx (7).
 
 <h3>12: Start/Stop Scanning</h3>
 


### PR DESCRIPTION
Frequency Scanner: Add multiplex mode, to switch between frequencies at fixed intervals, regardless of power level. This allows, for example, AIS and ADS-B data to be received via a single SDR.

ADS-B updated to use settings keys, which helps to avoid updating the entire GUI (which can be slow) when unrelated settings are set.
