### PR TITLE
Support more Qt configurations

### DIFF
--- a/devices/CMakeLists.txt
+++ b/devices/CMakeLists.txt
@@ -40,4 +40,6 @@ if(ENABLE_USRP AND UHD_FOUND)
     add_subdirectory(usrp)
 endif()
 
-add_subdirectory(metis)
+if(ENABLE_METIS)
+    add_subdirectory(metis)
+endif()

--- a/plugins/samplesource/remotetcpinput/remotetcpinputtcphandler.h
+++ b/plugins/samplesource/remotetcpinput/remotetcpinputtcphandler.h
@@ -187,7 +187,9 @@ public slots:
     void connected();
     void disconnected();
     void errorOccurred(QAbstractSocket::SocketError socketError);
+#ifndef QT_NO_OPENSSL
     void sslErrors(const QList<QSslError> &errors);
+#endif
 
 private:
 

--- a/qrtplib/rtpudptransmitter.cpp
+++ b/qrtplib/rtpudptransmitter.cpp
@@ -157,8 +157,10 @@ int RTPUDPTransmitter::Create(std::size_t maximumpacketsize, const RTPTransmissi
     }
 
     m_maxpacksize = maximumpacketsize;
-    m_multicastInterface = params->GetMulticastInterface();
-    m_receivemode = RTPTransmitter::AcceptAll;
+#ifndef QT_NO_NETWORKINTERFACE
+     m_multicastInterface = params->GetMulticastInterface();
+#endif
+     m_receivemode = RTPTransmitter::AcceptAll;
 
     m_waitingfordata = false;
     m_created = true;
@@ -306,7 +308,8 @@ void RTPUDPTransmitter::ClearDestinations()
 
 bool RTPUDPTransmitter::SupportsMulticasting()
 {
-    QNetworkInterface::InterfaceFlags flags = m_multicastInterface.flags();
+#ifndef QT_NO_NETWORKINTERFACE
+     QNetworkInterface::InterfaceFlags flags = m_multicastInterface.flags();
     QAbstractSocket::SocketState rtpSocketState = m_rtpsock->state();
     QAbstractSocket::SocketState rtcpSocketState = m_rtcpsock->state();
     return m_multicastInterface.isValid()
@@ -315,11 +318,16 @@ bool RTPUDPTransmitter::SupportsMulticasting()
             && (flags & QNetworkInterface::CanMulticast)
             && (flags & QNetworkInterface::IsRunning)
             && !(flags & QNetworkInterface::IsLoopBack);
+
+#else
+    return false;
+#endif
 }
 
 int RTPUDPTransmitter::JoinMulticastGroup(const RTPAddress &addr)
 {
-    if (!m_init) {
+#ifndef QT_NO_NETWORKINTERFACE
+     if (!m_init) {
         return ERR_RTP_UDPV4TRANS_NOTINIT;
     }
 
@@ -346,10 +354,14 @@ int RTPUDPTransmitter::JoinMulticastGroup(const RTPAddress &addr)
     }
 
     return 0;
+#else
+    return ERR_RTP_UDPV6TRANS_NOMULTICASTSUPPORT;
+#endif
 }
 
 int RTPUDPTransmitter::LeaveMulticastGroup(const RTPAddress &addr)
 {
+#ifndef QT_NO_NETWORKINTERFACE
     if (!m_init) {
         return ERR_RTP_UDPV4TRANS_NOTINIT;
     }
@@ -370,6 +382,9 @@ int RTPUDPTransmitter::LeaveMulticastGroup(const RTPAddress &addr)
     }
 
     return 0;
+#else
+    return ERR_RTP_UDPV6TRANS_NOMULTICASTSUPPORT;
+#endif
 }
 
 int RTPUDPTransmitter::SetReceiveMode(RTPTransmitter::ReceiveMode m)

--- a/qrtplib/rtpudptransmitter.h
+++ b/qrtplib/rtpudptransmitter.h
@@ -68,10 +68,12 @@ public:
         m_bindAddress = bindAddress;
     }
 
-    /** Sets the multicast interface IP address. */
+#ifndef QT_NO_NETWORKINTERFACE
+     /** Sets the multicast interface IP address. */
     void SetMulticastInterface(const QNetworkInterface& mcastInterface) {
         m_mcastInterface = mcastInterface;
     }
+#endif
 
     /** Sets the RTP portbase to \c pbase, which has to be an even number
      *  unless RTPUDPv4TransmissionParams::SetAllowOddPortbase was called;
@@ -87,11 +89,13 @@ public:
         return m_bindAddress;
     }
 
+#ifndef QT_NO_NETWORKINTERFACE
     /** Returns the multicast interface IP address. */
     QNetworkInterface GetMulticastInterface() const
     {
         return m_mcastInterface;
     }
+#endif
 
     /** Returns the RTP portbase which will be used (default is 5000). */
     uint16_t GetPortbase() const
@@ -210,7 +214,9 @@ public:
 
 private:
     QHostAddress m_bindAddress;
+#ifndef QT_NO_NETWORKINTERFACE
     QNetworkInterface m_mcastInterface;
+#endif
     uint16_t m_portbase;
     int m_rtpsendbufsz, m_rtprecvbufsz;
     int m_rtcpsendbufsz, m_rtcprecvbufsz;
@@ -349,8 +355,10 @@ private:
     QUdpSocket *m_rtpsock, *m_rtcpsock;
     bool m_deletesocketswhendone;
     QHostAddress m_localIP; //!< from parameters bind IP
-    QNetworkInterface m_multicastInterface; //!< from parameters multicast interface
-    uint16_t m_rtpPort, m_rtcpPort;
+#ifndef QT_NO_NETWORKINTERFACE
+     QNetworkInterface m_multicastInterface; //!< from parameters multicast interface
+#endif
+     uint16_t m_rtpPort, m_rtcpPort;
     RTPTransmitter::ReceiveMode m_receivemode;
 
     std::size_t m_maxpacksize;

--- a/sdrbase/commands/command.cpp
+++ b/sdrbase/commands/command.cpp
@@ -28,6 +28,7 @@
 #include "util/timeutil.h"
 
 Command::Command() :
+#if QT_CONFIG(process)
     m_currentProcess(nullptr),
     m_currentProcessState(QProcess::NotRunning),
     m_isInError(false),
@@ -35,6 +36,7 @@ Command::Command() :
     m_hasExited(false),
     m_currentProcessExitCode(0),
     m_currentProcessExitStatus(QProcess::NormalExit),
+#endif
     m_currentProcessPid(0)
 {
     m_currentProcessStartTimeStampms = 0;
@@ -53,6 +55,7 @@ Command::Command(const Command& command) :
         m_keyModifiers(command.m_keyModifiers),
         m_associateKey(command.m_associateKey),
         m_release(command.m_release),
+#if QT_CONFIG(process)
         m_currentProcess(nullptr),
         m_currentProcessState(QProcess::NotRunning),
         m_isInError(false),
@@ -60,6 +63,7 @@ Command::Command(const Command& command) :
         m_hasExited(false),
         m_currentProcessExitCode(0),
         m_currentProcessExitStatus(QProcess::NormalExit),
+#endif
         m_currentProcessPid(0)
 {
     m_currentProcessStartTimeStampms = 0;
@@ -68,6 +72,7 @@ Command::Command(const Command& command) :
 
 Command::~Command()
 {
+#if QT_CONFIG(process)
     if (m_currentProcess)
     {
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
@@ -79,6 +84,7 @@ Command::~Command()
         disconnect(m_currentProcess, SIGNAL(stateChanged(QProcess::ProcessState)), this, SLOT(processStateChanged(QProcess::ProcessState)));
         m_currentProcess->deleteLater();
     }
+#endif
 }
 
 void Command::resetToDefaults()
@@ -164,6 +170,7 @@ QString Command::getKeyLabel() const
 
 void Command::run(const QString& apiAddress, int apiPort, int deviceSetIndex)
 {
+#if QT_CONFIG(process)
     if (m_currentProcess)
     {
         qWarning("Command::run: process already running");
@@ -212,17 +219,22 @@ void Command::run(const QString& apiAddress, int apiPort, int deviceSetIndex)
     QStringList allArgs = args.split(" ", QString::SkipEmptyParts);
 #endif
     m_currentProcess->start(m_command, allArgs);
+
+#endif
 }
 
 void Command::kill()
 {
+#if QT_CONFIG(process)
     if (m_currentProcess)
     {
         qDebug("Command::kill: %lld", m_currentProcessPid);
         m_currentProcess->kill();
     }
+#endif
 }
 
+#if QT_CONFIG(process)
 QProcess::ProcessState Command::getLastProcessState() const
 {
     return m_currentProcessState;
@@ -307,3 +319,4 @@ void Command::processFinished(int exitCode, QProcess::ExitStatus exitStatus)
     m_currentProcess->deleteLater(); // make sure other threads can still access it until all events have been processed
     m_currentProcess = nullptr; // for this thread it can assume it was deleted
 }
+#endif /* QT_CONFIG(process) */

--- a/sdrbase/commands/command.h
+++ b/sdrbase/commands/command.h
@@ -62,10 +62,12 @@ public:
 
     void run(const QString& apiAddress, int apiPort, int deviceSetIndex = 0);
     void kill();
+#if QT_CONFIG(process)
     QProcess::ProcessState getLastProcessState() const;
     bool getLastProcessError(QProcess::ProcessError& error) const;
     bool getLastProcessExit(int& exitCode, QProcess::ExitStatus& exitStatus) const;
     const QString& getLastProcessLog() const;
+#endif
     uint64_t  getLastProcessStartTimestampms() const { return m_currentProcessStartTimeStampms; }
     uint64_t  getLastProcessFinishTimestampms() const { return m_currentProcessFinishTimeStampms; }
     const QString& getLastProcessCommandLine() const { return m_currentProcessCommandLine; }
@@ -102,6 +104,7 @@ private:
     Qt::KeyboardModifiers m_keyModifiers;
     bool m_associateKey;
     bool m_release;
+#if QT_CONFIG(process)
     QProcess *m_currentProcess;
     QProcess::ProcessState m_currentProcessState;
     bool m_isInError;
@@ -109,6 +112,7 @@ private:
     bool m_hasExited;
     int m_currentProcessExitCode;
     QProcess::ExitStatus m_currentProcessExitStatus;
+#endif
     QString m_log;
     uint64_t  m_currentProcessStartTimeStampms;
     uint64_t  m_currentProcessFinishTimeStampms;
@@ -116,9 +120,11 @@ private:
     qint64 m_currentProcessPid;
 
 private slots:
+#if QT_CONFIG(process)
     void processStateChanged(QProcess::ProcessState newState);
     void processError(QProcess::ProcessError error);
     void processFinished(int exitCode, QProcess::ExitStatus exitStatus);
+#endif
 };
 
 Q_DECLARE_METATYPE(const Command*);

--- a/sdrgui/gui/commandoutputdialog.cpp
+++ b/sdrgui/gui/commandoutputdialog.cpp
@@ -22,6 +22,8 @@
 
 #include <QDateTime>
 
+#if QT_CONFIG(process)
+
 CommandOutputDialog::CommandOutputDialog(Command& command, QWidget* parent) :
     QDialog(parent),
     ui(new Ui::CommandOutputDialog),
@@ -167,3 +169,4 @@ void CommandOutputDialog::on_processKill_toggled(bool checked)
     }
 }
 
+#endif // QT_CONFIG(process)

--- a/sdrgui/gui/commandoutputdialog.h
+++ b/sdrgui/gui/commandoutputdialog.h
@@ -24,6 +24,8 @@
 #include <QDialog>
 #include <QProcess>
 
+#if QT_CONFIG(process)
+
 #include "export.h"
 
 namespace Ui {
@@ -54,5 +56,6 @@ private slots:
     void on_processKill_toggled(bool checked);
 };
 
+#endif
 
 #endif /* SDRGUI_GUI_COMMANDOUTPUTDIALOG_H_ */

--- a/sdrgui/gui/commandsdialog.cpp
+++ b/sdrgui/gui/commandsdialog.cpp
@@ -29,6 +29,8 @@
 #include "commandsdialog.h"
 #include "ui_commandsdialog.h"
 
+#if QT_CONFIG(process)
+
 CommandsDialog::CommandsDialog(QWidget* parent) :
     QDialog(parent),
     ui(new Ui::CommandsDialog),
@@ -309,3 +311,5 @@ QTreeWidgetItem* CommandsDialog::addCommandToTree(const Command* command)
     //updatePresetControls();
     return item;
 }
+
+#endif // QT_CONFIG(process)

--- a/sdrgui/gui/commandsdialog.h
+++ b/sdrgui/gui/commandsdialog.h
@@ -25,6 +25,8 @@
 
 #include "export.h"
 
+#if QT_CONFIG(process)
+
 class CommandKeyReceiver;
 
 namespace Ui {
@@ -65,5 +67,7 @@ private slots:
     void on_commandDelete_clicked();
     void on_commandKeyboardConnect_toggled(bool checked);
 };
+
+#endif // QT_CONFIG(process)
 
 #endif // SDRGUI_GUI_COMMANDSDIALOG_H_

--- a/sdrgui/gui/fftwisdomdialog.cpp
+++ b/sdrgui/gui/fftwisdomdialog.cpp
@@ -24,6 +24,8 @@
 #include "fftwisdomdialog.h"
 #include "ui_fftwisdomdialog.h"
 
+#if QT_CONFIG(process)
+
 FFTWisdomDialog::FFTWisdomDialog(QProcess *process, QWidget* parent) :
     QDialog(parent),
     ui(new Ui::FFTWisdomDialog),
@@ -132,3 +134,5 @@ void FFTWisdomDialog::updateArguments(int fftMaxLog2, bool includeReverse)
     qDebug("FFTWisdomDialog::updateArguments: %s %s", qPrintable(m_fftwExecPath), qPrintable(argStr));
     ui->fftwCommand->setText(m_fftwExecPath + " " + argStr);
 }
+
+#endif // QT_CONFIG(process)

--- a/sdrgui/gui/fftwisdomdialog.h
+++ b/sdrgui/gui/fftwisdomdialog.h
@@ -25,6 +25,8 @@
 
 #include "export.h"
 
+#if QT_CONFIG(process)
+
 namespace Ui {
     class FFTWisdomDialog;
 }
@@ -54,6 +56,8 @@ private:
     QStringList m_fftwArguments;
     QProcess *m_process;
 };
+
+#endif
 
 
 #endif // SDRGUI_GUI_FFTWISDOMDIALOG_H_


### PR DESCRIPTION
This patch adds support for a few more Qt configurations (QT_NO_OPENSSL, QT_NO_NETWORKINTERFACE, !QT_CONFIG(process)) required for the WebAssembly build.

