### PR TITLE
Fix missing 3D map and Sky Map from latest Windows release.

### DIFF
--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -75,7 +75,7 @@ jobs:
           dir: ${{matrix.config.QT_INST_DIR}}
           arch: ${{matrix.config.QT_ARCH}}
           setup-python: false
-          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets qtwebengine qtshadertools'
+          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets qtwebengine qtshadertools qtwebchannel'
       - name: build sdrangel on Windows
         if: startsWith(matrix.config.os, 'windows')
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,7 +72,7 @@ jobs:
           dir: ${{matrix.config.QT_INST_DIR}}
           arch: ${{matrix.config.QT_ARCH}}
           setup-python: false
-          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets qtwebengine qtshadertools'
+          modules: 'qtcharts qtscxml qt5compat qtlocation qtmultimedia qtpositioning qtserialport qtspeech qtwebsockets qtwebengine qtshadertools qtwebchannel'
       - name: build sdrangel on Windows
         if: startsWith(matrix.config.os, 'windows')
         run: |


### PR DESCRIPTION
3D map and Sky Map are missing from 7.22.3 Windows release, as Qt WebEngine is reported as not found. This PR adds qtwebchannel  package apparently needed by qtwebengine to the github build.

I've also hopefully fixed the latest error reported by SignPath (Needed to add filename in the XML file).
