### PR TITLE
SDRplayv3: Patch path to libsdrplay_api.so.3

### DIFF
--- a/plugins/samplesource/sdrplayv3/CMakeLists.txt
+++ b/plugins/samplesource/sdrplayv3/CMakeLists.txt
@@ -67,6 +67,9 @@ if (APPLE AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL arm64))
     add_custom_command(TARGET ${TARGET_NAME}
         POST_BUILD COMMAND
         ${CMAKE_INSTALL_NAME_TOOL} -change libsdrplay_api.so.3.15 /usr/local/lib/libsdrplay_api.so.3.15  $<TARGET_FILE:${TARGET_NAME}>)
+    add_custom_command(TARGET ${TARGET_NAME}
+        POST_BUILD COMMAND
+        ${CMAKE_INSTALL_NAME_TOOL} -change libsdrplay_api.so.3 /usr/local/lib/libsdrplay_api.so.3  $<TARGET_FILE:${TARGET_NAME}>)
 endif()
 
 install(TARGETS ${TARGET_NAME} DESTINATION ${INSTALL_FOLDER})


### PR DESCRIPTION
Mac build now seems to link to libsdrplay_api.so.3 rather than libsdrplay_api.so.3.15. So patch path to that as well. Should fix #2322. I don't know if there's a better way to do it.
