### PR TITLE
Fix a few memory leaks and race conditions

### DIFF
--- a/plugins/channelrx/demodfreedv/freedvdemod.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemod.cpp
@@ -79,6 +79,7 @@ FreeDVDemod::FreeDVDemod(DeviceAPI *deviceAPI) :
 
 FreeDVDemod::~FreeDVDemod()
 {
+    stop();
     QObject::disconnect(
         m_networkManager,
         &QNetworkAccessManager::finished,

--- a/plugins/channelrx/demodfreedv/freedvdemodsink.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemodsink.cpp
@@ -176,6 +176,8 @@ FreeDVDemodSink::~FreeDVDemodSink()
 {
     delete SSBFilter;
     delete[] m_SSBFilterBuffer;
+    delete[] m_speechOut;
+    delete[] m_modIn;
 }
 
 void FreeDVDemodSink::feed(const SampleVector::const_iterator& begin, const SampleVector::const_iterator& end)
@@ -449,7 +451,7 @@ void FreeDVDemodSink::applyFreeDVMode(FreeDVDemodSettings::FreeDVMode mode)
         freedv_set_ext_vco(m_freeDV, 0);
         freedv_set_sync(m_freeDV, FREEDV_SYNC_MANUAL);
 
-        int nSpeechSamples = freedv_get_n_speech_samples(m_freeDV);
+        int nSpeechSamples = freedv_get_n_max_speech_samples(m_freeDV);
         int nMaxModemSamples = freedv_get_n_max_modem_samples(m_freeDV);
         int Fs = freedv_get_modem_sample_rate(m_freeDV);
         int Rs = freedv_get_modem_symbol_rate(m_freeDV);

--- a/sdrbase/dsp/dspengine.cpp
+++ b/sdrbase/dsp/dspengine.cpp
@@ -187,39 +187,41 @@ void DSPEngine::removeLastDeviceMIMOEngine()
     }
 }
 
-QThread * DSPEngine::removeDeviceEngineAt(int deviceIndex)
+QThread *DSPEngine::getDeviceEngineThread(int deviceIndex)
 {
     if (deviceIndex >= m_deviceEngineReferences.size()) {
         return nullptr;
+    } else {
+        return m_deviceEngineReferences[deviceIndex].m_thread;
     }
+}
 
-    QThread *deviceThread = nullptr;
+void DSPEngine::removeDeviceEngineAt(int deviceIndex)
+{
+    if (deviceIndex >= m_deviceEngineReferences.size()) {
+        return;
+    }
 
     if (m_deviceEngineReferences[deviceIndex].m_deviceEngineType == 0) // source
     {
         DSPDeviceSourceEngine *deviceEngine = m_deviceEngineReferences[deviceIndex].m_deviceSourceEngine;
-        deviceThread = m_deviceEngineReferences[deviceIndex].m_thread;
-        deviceThread->exit();
+        m_deviceEngineReferences[deviceIndex].m_thread->exit();
         m_deviceSourceEngines.removeAll(deviceEngine);
     }
     else if (m_deviceEngineReferences[deviceIndex].m_deviceEngineType == 1) // sink
     {
         DSPDeviceSinkEngine *deviceEngine = m_deviceEngineReferences[deviceIndex].m_deviceSinkEngine;
-        deviceThread = m_deviceEngineReferences[deviceIndex].m_thread;
-        deviceThread->exit();
+        m_deviceEngineReferences[deviceIndex].m_thread->exit();
         m_deviceSinkEngines.removeAll(deviceEngine);
     }
     else if (m_deviceEngineReferences[deviceIndex].m_deviceEngineType == 2) // MIMO
     {
         DSPDeviceMIMOEngine *deviceEngine = m_deviceEngineReferences[deviceIndex].m_deviceMIMOEngine;
-        deviceThread = m_deviceEngineReferences[deviceIndex].m_thread;
-        deviceThread->exit();
+        m_deviceEngineReferences[deviceIndex].m_thread->exit();
         m_deviceMIMOEngines.removeAll(deviceEngine);
     }
 
     m_deviceEngineReferences.removeAt(deviceIndex);
-
-    return deviceThread;
 }
 
 void DSPEngine::createFFTFactory(const QString& fftWisdomFileName)

--- a/sdrbase/dsp/dspengine.h
+++ b/sdrbase/dsp/dspengine.h
@@ -53,7 +53,8 @@ public:
 	DSPDeviceMIMOEngine *addDeviceMIMOEngine();
 	void removeLastDeviceMIMOEngine();
 
-    QThread *removeDeviceEngineAt(int deviceIndex);
+    QThread *getDeviceEngineThread(int deviceIndex);
+    void removeDeviceEngineAt(int deviceIndex);
 
 	AudioDeviceManager *getAudioDeviceManager() { return &m_audioDeviceManager; }
 


### PR DESCRIPTION
This PR fixes a few memory leaks and race conditions noticed while investigating #2315.

In FreeDV:

- Fix buffer overflow by using freedv_get_n_max_speech_samples instead of freedv_get_n_speech_samples
- Fix memory leak for m_speechOut and m_modIn
- Call stop() before delete, to avoid "QThread: Destroyed while thread is still running"

In mainwindow.cpp/dspengine.cpp:

- Fix memory leak by deleting m_deviceSourceEngine after it is last used.
- Fix race condition by connecting to thread before exit is called.

We still have a problem causing the crash in #2315 though - will add a further comment there.
