### PR TITLE
Code Signing: Use relative path. Increase approval timeout to 30 minutes.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -102,7 +102,8 @@ jobs:
           signing-policy-slug: 'release-signing'
           github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
           wait-for-completion: true
-          output-artifact-directory: '${{ github.workspace }}\build\signed'
+          output-artifact-directory: 'build\signed'
+          wait-for-completion-timeout-in-seconds: 1800
       - name: Unzip signed artifact
         run: |
           dir ${{ github.workspace }}\build\signed


### PR DESCRIPTION
It appears for release build signing, we get an e-mail with a signing request, that we manually need to approve. Not ideal, and have asked if there's a way around this. For now, increase timeout that the github action will wait for to 30 minutes.
