### PR TITLE
Fix crash and audio mod

### DIFF
--- a/plugins/channelrx/chanalyzer/chanalyzer.cpp
+++ b/plugins/channelrx/chanalyzer/chanalyzer.cpp
@@ -88,7 +88,7 @@ ChannelAnalyzer::~ChannelAnalyzer()
     delete m_networkManager;
 
 	m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -103,7 +103,7 @@ void ChannelAnalyzer::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/channelpower/channelpower.cpp
+++ b/plugins/channelrx/channelpower/channelpower.cpp
@@ -84,7 +84,7 @@ ChannelPower::~ChannelPower()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -98,7 +98,7 @@ void ChannelPower::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodadsb/adsbdemod.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemod.cpp
@@ -104,7 +104,7 @@ ADSBDemod::~ADSBDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     delete m_basebandSink; // This results in a call to ADSBDemod::stop(), so need to delete before worker and thread
     delete m_worker;
     delete m_thread;
@@ -115,7 +115,7 @@ void ADSBDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodais/aisdemod.cpp
+++ b/plugins/channelrx/demodais/aisdemod.cpp
@@ -85,7 +85,7 @@ AISDemod::~AISDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -99,7 +99,7 @@ void AISDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodam/amdemod.cpp
+++ b/plugins/channelrx/demodam/amdemod.cpp
@@ -91,7 +91,7 @@ AMDemod::~AMDemod()
     );
     delete m_networkManager;
 	m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     stop();
 }
 
@@ -100,7 +100,7 @@ void AMDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodapt/aptdemod.cpp
+++ b/plugins/channelrx/demodapt/aptdemod.cpp
@@ -95,7 +95,7 @@ APTDemod::~APTDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_imageWorker->isRunning()) {
         stopImageWorker();
@@ -115,7 +115,7 @@ void APTDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodatv/atvdemod.cpp
+++ b/plugins/channelrx/demodatv/atvdemod.cpp
@@ -67,7 +67,7 @@ ATVDemod::~ATVDemod()
 {
     qDebug("ATVDemod::~ATVDemod");
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -81,7 +81,7 @@ void ATVDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodbfm/bfmdemod.cpp
+++ b/plugins/channelrx/demodbfm/bfmdemod.cpp
@@ -89,7 +89,7 @@ BFMDemod::~BFMDemod()
     delete m_networkManager;
 
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     stop();
 }
 
@@ -98,7 +98,7 @@ void BFMDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodchirpchat/chirpchatdemod.cpp
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemod.cpp
@@ -97,7 +97,7 @@ ChirpChatDemod::~ChirpChatDemod()
 {
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     stop();
 }
 
@@ -106,7 +106,7 @@ void ChirpChatDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demoddab/dabdemod.cpp
+++ b/plugins/channelrx/demoddab/dabdemod.cpp
@@ -100,7 +100,7 @@ DABDemod::~DABDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -114,7 +114,7 @@ void DABDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demoddatv/datvdemod.cpp
+++ b/plugins/channelrx/demoddatv/datvdemod.cpp
@@ -84,7 +84,7 @@ DATVDemod::~DATVDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -98,7 +98,7 @@ void DATVDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demoddsc/dscdemod.cpp
+++ b/plugins/channelrx/demoddsc/dscdemod.cpp
@@ -89,7 +89,7 @@ DSCDemod::~DSCDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -103,7 +103,7 @@ void DSCDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demoddsd/dsddemod.cpp
+++ b/plugins/channelrx/demoddsd/dsddemod.cpp
@@ -113,7 +113,7 @@ DSDDemod::~DSDDemod()
     );
     delete m_networkManager;
 	m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     stop();
 }
@@ -123,7 +123,7 @@ void DSDDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodendoftrain/endoftraindemod.cpp
+++ b/plugins/channelrx/demodendoftrain/endoftraindemod.cpp
@@ -84,7 +84,7 @@ EndOfTrainDemod::~EndOfTrainDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -98,7 +98,7 @@ void EndOfTrainDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodfreedv/freedvdemod.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemod.cpp
@@ -88,7 +88,7 @@ FreeDVDemod::~FreeDVDemod()
     );
     delete m_networkManager;
 	m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     delete m_basebandSink;
     delete m_thread;
 }
@@ -98,7 +98,7 @@ void FreeDVDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodft8/ft8demod.cpp
+++ b/plugins/channelrx/demodft8/ft8demod.cpp
@@ -94,7 +94,7 @@ FT8Demod::~FT8Demod()
     );
     delete m_networkManager;
 	m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     stop();
 }
@@ -104,7 +104,7 @@ void FT8Demod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodils/ilsdemod.cpp
+++ b/plugins/channelrx/demodils/ilsdemod.cpp
@@ -97,7 +97,7 @@ ILSDemod::~ILSDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -111,7 +111,7 @@ void ILSDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodm17/m17demod.cpp
+++ b/plugins/channelrx/demodm17/m17demod.cpp
@@ -94,7 +94,7 @@ M17Demod::~M17Demod()
     );
     delete m_networkManager;
 	m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     stop();
 }
 
@@ -103,7 +103,7 @@ void M17Demod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodnavtex/navtexdemod.cpp
+++ b/plugins/channelrx/demodnavtex/navtexdemod.cpp
@@ -89,7 +89,7 @@ NavtexDemod::~NavtexDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -103,7 +103,7 @@ void NavtexDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodnfm/nfmdemod.cpp
+++ b/plugins/channelrx/demodnfm/nfmdemod.cpp
@@ -90,7 +90,7 @@ NFMDemod::~NFMDemod()
     );
     delete m_networkManager;
 	m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     stop();
 }
@@ -100,7 +100,7 @@ void NFMDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodpacket/packetdemod.cpp
+++ b/plugins/channelrx/demodpacket/packetdemod.cpp
@@ -88,7 +88,7 @@ PacketDemod::~PacketDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -102,7 +102,7 @@ void PacketDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodpager/pagerdemod.cpp
+++ b/plugins/channelrx/demodpager/pagerdemod.cpp
@@ -83,7 +83,7 @@ PagerDemod::~PagerDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -97,7 +97,7 @@ void PagerDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodradiosonde/radiosondedemod.cpp
+++ b/plugins/channelrx/demodradiosonde/radiosondedemod.cpp
@@ -84,7 +84,7 @@ RadiosondeDemod::~RadiosondeDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -98,7 +98,7 @@ void RadiosondeDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodrtty/rttydemod.cpp
+++ b/plugins/channelrx/demodrtty/rttydemod.cpp
@@ -89,7 +89,7 @@ RttyDemod::~RttyDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -103,7 +103,7 @@ void RttyDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodssb/ssbdemod.cpp
+++ b/plugins/channelrx/demodssb/ssbdemod.cpp
@@ -92,7 +92,7 @@ SSBDemod::~SSBDemod()
     );
     delete m_networkManager;
 	m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     stop();
 }
@@ -102,7 +102,7 @@ void SSBDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodvor/vordemod.cpp
+++ b/plugins/channelrx/demodvor/vordemod.cpp
@@ -91,7 +91,7 @@ VORDemod::~VORDemod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     stop();
 }
 
@@ -100,7 +100,7 @@ void VORDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodvormc/vordemodmc.cpp
+++ b/plugins/channelrx/demodvormc/vordemodmc.cpp
@@ -85,7 +85,7 @@ VORDemodMC::~VORDemodMC()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -99,7 +99,7 @@ void VORDemodMC::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/demodwfm/wfmdemod.cpp
+++ b/plugins/channelrx/demodwfm/wfmdemod.cpp
@@ -92,7 +92,7 @@ WFMDemod::~WFMDemod()
     delete m_networkManager;
 
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     stop();
 }
 
@@ -101,7 +101,7 @@ void WFMDemod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/filesink/filesink.cpp
+++ b/plugins/channelrx/filesink/filesink.cpp
@@ -95,7 +95,7 @@ FileSink::~FileSink()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     stop();
 }
@@ -105,7 +105,7 @@ void FileSink::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/freqscanner/freqscanner.cpp
+++ b/plugins/channelrx/freqscanner/freqscanner.cpp
@@ -112,7 +112,7 @@ FreqScanner::~FreqScanner()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     stop();
 }
@@ -122,7 +122,7 @@ void FreqScanner::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/freqtracker/freqtracker.cpp
+++ b/plugins/channelrx/freqtracker/freqtracker.cpp
@@ -91,7 +91,7 @@ FreqTracker::~FreqTracker()
     delete m_networkManager;
 
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     stop();
 }
 
@@ -100,7 +100,7 @@ void FreqTracker::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/heatmap/heatmap.cpp
+++ b/plugins/channelrx/heatmap/heatmap.cpp
@@ -82,7 +82,7 @@ HeatMap::~HeatMap()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -96,7 +96,7 @@ void HeatMap::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/localsink/localsink.cpp
+++ b/plugins/channelrx/localsink/localsink.cpp
@@ -104,7 +104,7 @@ LocalSink::~LocalSink()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     stopProcessing();
 }
 
@@ -113,7 +113,7 @@ void LocalSink::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this ,false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/noisefigure/noisefigure.cpp
+++ b/plugins/channelrx/noisefigure/noisefigure.cpp
@@ -98,7 +98,7 @@ NoiseFigure::~NoiseFigure()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -112,7 +112,7 @@ void NoiseFigure::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/radioastronomy/radioastronomy.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomy.cpp
@@ -153,7 +153,7 @@ RadioAstronomy::~RadioAstronomy()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if ((m_basebandSink->isRunning()) || (m_worker->isRunning())) {
         stop();
@@ -168,7 +168,7 @@ void RadioAstronomy::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/radioclock/radioclock.cpp
+++ b/plugins/channelrx/radioclock/radioclock.cpp
@@ -87,7 +87,7 @@ RadioClock::~RadioClock()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     if (m_basebandSink->isRunning()) {
         stop();
@@ -101,7 +101,7 @@ void RadioClock::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/remotesink/remotesink.cpp
+++ b/plugins/channelrx/remotesink/remotesink.cpp
@@ -91,7 +91,7 @@ RemoteSink::~RemoteSink()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     stop();
 }
 
@@ -100,7 +100,7 @@ void RemoteSink::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/remotetcpsink/remotetcpsink.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsink.cpp
@@ -108,7 +108,7 @@ RemoteTCPSink::~RemoteTCPSink()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     m_basebandSink->deleteLater();
 }
@@ -118,7 +118,7 @@ void RemoteTCPSink::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/sigmffilesink/sigmffilesink.cpp
+++ b/plugins/channelrx/sigmffilesink/sigmffilesink.cpp
@@ -94,7 +94,7 @@ SigMFFileSink::~SigMFFileSink()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     stop();
 }
@@ -104,7 +104,7 @@ void SigMFFileSink::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/udpsink/udpsink.cpp
+++ b/plugins/channelrx/udpsink/udpsink.cpp
@@ -81,6 +81,7 @@ UDPSink::UDPSink(DeviceAPI *deviceAPI) :
 
 UDPSink::~UDPSink()
 {
+    stop();
     QObject::disconnect(
         m_networkManager,
         &QNetworkAccessManager::finished,
@@ -89,7 +90,7 @@ UDPSink::~UDPSink()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
     delete m_basebandSink;
     delete m_thread;
 }
@@ -99,7 +100,7 @@ void UDPSink::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channelrx/wdsprx/wdsprx.cpp
+++ b/plugins/channelrx/wdsprx/wdsprx.cpp
@@ -93,7 +93,7 @@ WDSPRx::~WDSPRx()
     );
     delete m_networkManager;
 	m_deviceAPI->removeChannelSinkAPI(this);
-    m_deviceAPI->removeChannelSink(this);
+    m_deviceAPI->removeChannelSink(this, true);
 
     WDSPRx::stop();
     qDebug("WDSPRx::~WDSPRx: emd");
@@ -104,7 +104,7 @@ void WDSPRx::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSinkAPI(this);
-        m_deviceAPI->removeChannelSink(this);
+        m_deviceAPI->removeChannelSink(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSink(this);
         m_deviceAPI->addChannelSinkAPI(this);

--- a/plugins/channeltx/filesource/filesource.cpp
+++ b/plugins/channeltx/filesource/filesource.cpp
@@ -86,7 +86,8 @@ FileSource::~FileSource()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -96,7 +97,7 @@ void FileSource::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -262,7 +263,7 @@ void FileSource::applySettings(const FileSourceSettings& settings, bool force)
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/localsource/localsource.cpp
+++ b/plugins/channeltx/localsource/localsource.cpp
@@ -80,7 +80,8 @@ LocalSource::~LocalSource()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -90,7 +91,7 @@ void LocalSource::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -307,7 +308,7 @@ void LocalSource::applySettings(const LocalSourceSettings& settings, bool force)
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/mod802.15.4/ieee_802_15_4_mod.cpp
+++ b/plugins/channeltx/mod802.15.4/ieee_802_15_4_mod.cpp
@@ -89,7 +89,8 @@ IEEE_802_15_4_Mod::~IEEE_802_15_4_Mod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -99,7 +100,7 @@ void IEEE_802_15_4_Mod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -371,7 +372,7 @@ void IEEE_802_15_4_Mod::applySettings(const IEEE_802_15_4_ModSettings& settings,
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/modais/aismod.cpp
+++ b/plugins/channeltx/modais/aismod.cpp
@@ -92,7 +92,8 @@ AISMod::~AISMod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -102,7 +103,7 @@ void AISMod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -458,7 +459,7 @@ void AISMod::applySettings(const AISModSettings& settings, bool force)
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/modam/ammod.h
+++ b/plugins/channeltx/modam/ammod.h
@@ -254,6 +254,8 @@ private:
     bool m_running = false;
     AMModBaseband* m_basebandSource;
     AMModSettings m_settings;
+    int m_basebandSampleRate;
+    qint64 m_centerFrequency;
 
     SampleVector m_sampleBuffer;
     QRecursiveMutex m_settingsMutex;

--- a/plugins/channeltx/modam/ammodsource.cpp
+++ b/plugins/channeltx/modam/ammodsource.cpp
@@ -29,6 +29,7 @@ const int AMModSource::m_levelNbSamples = 480; // every 10ms
 
 AMModSource::AMModSource() :
     m_audioFifo(12000),
+    m_feedbackAudioSampleRate(48000),
     m_feedbackAudioFifo(48000)
 {
     m_audioFifo.setLabel("AMModSource.m_audioFifo");

--- a/plugins/channeltx/modatv/atvmod.cpp
+++ b/plugins/channeltx/modatv/atvmod.cpp
@@ -89,7 +89,8 @@ ATVMod::~ATVMod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -99,7 +100,7 @@ void ATVMod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -342,7 +343,7 @@ void ATVMod::applySettings(const ATVModSettings& settings, bool force)
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/modchirpchat/chirpchatmod.cpp
+++ b/plugins/channeltx/modchirpchat/chirpchatmod.cpp
@@ -88,7 +88,8 @@ ChirpChatMod::~ChirpChatMod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -98,7 +99,7 @@ void ChirpChatMod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -338,7 +339,7 @@ void ChirpChatMod::applySettings(const ChirpChatModSettings& settings, bool forc
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/moddatv/datvmod.cpp
+++ b/plugins/channeltx/moddatv/datvmod.cpp
@@ -90,7 +90,8 @@ DATVMod::~DATVMod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -100,7 +101,7 @@ void DATVMod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -306,7 +307,7 @@ void DATVMod::applySettings(const DATVModSettings& settings, bool force)
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/modfreedv/freedvmod.cpp
+++ b/plugins/channeltx/modfreedv/freedvmod.cpp
@@ -92,7 +92,8 @@ FreeDVMod::~FreeDVMod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -102,7 +103,7 @@ void FreeDVMod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -313,7 +314,7 @@ void FreeDVMod::applySettings(const FreeDVModSettings& settings, bool force)
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/modm17/m17mod.cpp
+++ b/plugins/channeltx/modm17/m17mod.cpp
@@ -97,7 +97,8 @@ M17Mod::~M17Mod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -107,7 +108,7 @@ void M17Mod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -329,7 +330,7 @@ void M17Mod::applySettings(const M17ModSettings& settings, const QList<QString>&
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/modnfm/nfmmod.h
+++ b/plugins/channeltx/modnfm/nfmmod.h
@@ -254,6 +254,8 @@ private:
     bool m_running = false;
     NFMModBaseband* m_basebandSource;
     NFMModSettings m_settings;
+    int m_basebandSampleRate;
+    qint64 m_centerFrequency;
 
     SampleVector m_sampleBuffer;
     QRecursiveMutex m_settingsMutex;

--- a/plugins/channeltx/modpacket/packetmod.cpp
+++ b/plugins/channeltx/modpacket/packetmod.cpp
@@ -94,7 +94,8 @@ PacketMod::~PacketMod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -104,7 +105,7 @@ void PacketMod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -406,7 +407,7 @@ void PacketMod::applySettings(const PacketModSettings& settings, bool force)
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/modpsk31/psk31mod.cpp
+++ b/plugins/channeltx/modpsk31/psk31mod.cpp
@@ -90,7 +90,8 @@ PSK31::~PSK31()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -100,7 +101,7 @@ void PSK31::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -297,7 +298,7 @@ void PSK31::applySettings(const PSK31Settings& settings, bool force)
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/modrtty/rttymod.cpp
+++ b/plugins/channeltx/modrtty/rttymod.cpp
@@ -90,7 +90,8 @@ RttyMod::~RttyMod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -100,7 +101,7 @@ void RttyMod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -322,7 +323,7 @@ void RttyMod::applySettings(const RttyModSettings& settings, bool force)
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/modssb/ssbmod.h
+++ b/plugins/channeltx/modssb/ssbmod.h
@@ -256,6 +256,8 @@ private:
     bool m_running = false;
     SSBModBaseband* m_basebandSource;
     SSBModSettings m_settings;
+    int m_basebandSampleRate;
+    qint64 m_centerFrequency;
     SpectrumVis m_spectrumVis;
 
 	SampleVector m_sampleBuffer;

--- a/plugins/channeltx/modwfm/wfmmod.cpp
+++ b/plugins/channeltx/modwfm/wfmmod.cpp
@@ -90,7 +90,8 @@ WFMMod::~WFMMod()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -100,7 +101,7 @@ void WFMMod::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -313,7 +314,7 @@ void WFMMod::applySettings(const WFMModSettings& settings, bool force)
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/remotesource/remotesource.cpp
+++ b/plugins/channeltx/remotesource/remotesource.cpp
@@ -84,7 +84,8 @@ RemoteSource::~RemoteSource()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -94,7 +95,7 @@ void RemoteSource::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -242,7 +243,7 @@ void RemoteSource::applySettings(const RemoteSourceSettings& settings, bool forc
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/plugins/channeltx/udpsource/udpsource.cpp
+++ b/plugins/channeltx/udpsource/udpsource.cpp
@@ -78,7 +78,8 @@ UDPSource::~UDPSource()
     );
     delete m_networkManager;
     m_deviceAPI->removeChannelSourceAPI(this);
-    m_deviceAPI->removeChannelSource(this);
+    m_deviceAPI->removeChannelSource(this, true);
+    stop();
     delete m_basebandSource;
     delete m_thread;
 }
@@ -88,7 +89,7 @@ void UDPSource::setDeviceAPI(DeviceAPI *deviceAPI)
     if (deviceAPI != m_deviceAPI)
     {
         m_deviceAPI->removeChannelSourceAPI(this);
-        m_deviceAPI->removeChannelSource(this);
+        m_deviceAPI->removeChannelSource(this, false);
         m_deviceAPI = deviceAPI;
         m_deviceAPI->addChannelSource(this);
         m_deviceAPI->addChannelSinkAPI(this);
@@ -277,7 +278,7 @@ void UDPSource::applySettings(const UDPSourceSettings& settings, bool force)
         if (m_deviceAPI->getSampleMIMO()) // change of stream is possible for MIMO devices only
         {
             m_deviceAPI->removeChannelSourceAPI(this);
-            m_deviceAPI->removeChannelSource(this, m_settings.m_streamIndex);
+            m_deviceAPI->removeChannelSource(this, false, m_settings.m_streamIndex);
             m_deviceAPI->addChannelSource(this, settings.m_streamIndex);
             m_deviceAPI->addChannelSourceAPI(this);
             m_settings.m_streamIndex = settings.m_streamIndex; // make sure ChannelAPI::getStreamIndex() is consistent

--- a/sdrbase/device/deviceapi.cpp
+++ b/sdrbase/device/deviceapi.cpp
@@ -83,10 +83,10 @@ void DeviceAPI::addChannelSink(BasebandSampleSink* sink, int streamIndex)
     }
 }
 
-void DeviceAPI::removeChannelSink(BasebandSampleSink* sink, int streamIndex)
+void DeviceAPI::removeChannelSink(BasebandSampleSink* sink, bool deleting, int streamIndex)
 {
     if (m_deviceSourceEngine) {
-        m_deviceSourceEngine->removeSink(sink);
+        m_deviceSourceEngine->removeSink(sink, deleting);
     } else if (m_deviceMIMOEngine) {
         m_deviceMIMOEngine->removeChannelSink(sink, streamIndex);
     }
@@ -101,12 +101,12 @@ void DeviceAPI::addChannelSource(BasebandSampleSource* source, int streamIndex)
     }
 }
 
-void DeviceAPI::removeChannelSource(BasebandSampleSource* source, int streamIndex)
+void DeviceAPI::removeChannelSource(BasebandSampleSource* source, bool deleting, int streamIndex)
 {
     if (m_deviceSinkEngine) {
-        m_deviceSinkEngine->removeChannelSource(source);
+        m_deviceSinkEngine->removeChannelSource(source, deleting);
     } else if (m_deviceMIMOEngine) {
-        m_deviceMIMOEngine->removeChannelSource(source, streamIndex);
+        m_deviceMIMOEngine->removeChannelSource(source, deleting, streamIndex);
     }
 }
 

--- a/sdrbase/device/deviceapi.h
+++ b/sdrbase/device/deviceapi.h
@@ -70,9 +70,9 @@ public:
     void setSpectrumSinkInput(bool sourceElseSink = true, unsigned int index = 0); //!< Used in the MIMO case to select which stream is used as input to main spectrum
 
     void addChannelSink(BasebandSampleSink* sink, int streamIndex = 0);                //!< Add a channel sink (Rx)
-    void removeChannelSink(BasebandSampleSink* sink, int streamIndex = 0);             //!< Remove a channel sink (Rx)
+    void removeChannelSink(BasebandSampleSink* sink, bool deleting, int streamIndex = 0);             //!< Remove a channel sink (Rx)
     void addChannelSource(BasebandSampleSource* sink, int streamIndex = 0);            //!< Add a channel source (Tx)
-    void removeChannelSource(BasebandSampleSource* sink, int streamIndex = 0);         //!< Remove a channel source (Tx)
+    void removeChannelSource(BasebandSampleSource* sink, bool deleting, int streamIndex = 0);         //!< Remove a channel source (Tx)
     void addMIMOChannel(MIMOChannel* channel);   //!< Add a MIMO channel (n Rx and m Tx combination)
     void removeMIMOChannel(MIMOChannel* channel); //!< Remove a MIMO channel (n Rx and m Tx combination)
 

--- a/sdrbase/dsp/dspcommands.h
+++ b/sdrbase/dsp/dspcommands.h
@@ -152,12 +152,14 @@ class SDRBASE_API DSPRemoveBasebandSampleSink : public Message {
 	MESSAGE_CLASS_DECLARATION
 
 public:
-	DSPRemoveBasebandSampleSink(BasebandSampleSink* sampleSink) : Message(), m_sampleSink(sampleSink) { }
+	DSPRemoveBasebandSampleSink(BasebandSampleSink* sampleSink, bool deleting) : Message(), m_sampleSink(sampleSink), m_deleting(deleting) { }
 
 	BasebandSampleSink* getSampleSink() const { return m_sampleSink; }
+	bool getDeleting() const { return m_deleting; }
 
 private:
 	BasebandSampleSink* m_sampleSink;
+	bool m_deleting;
 };
 
 class SDRBASE_API DSPRemoveSpectrumSink : public Message {
@@ -176,12 +178,14 @@ class SDRBASE_API DSPRemoveBasebandSampleSource : public Message {
 	MESSAGE_CLASS_DECLARATION
 
 public:
-	DSPRemoveBasebandSampleSource(BasebandSampleSource* sampleSource) : Message(), m_sampleSource(sampleSource) { }
+	DSPRemoveBasebandSampleSource(BasebandSampleSource* sampleSource, bool deleting) : Message(), m_sampleSource(sampleSource), m_deleting(deleting) { }
 
 	BasebandSampleSource* getSampleSource() const { return m_sampleSource; }
+	bool getDeleting() const { return m_deleting; }
 
 private:
 	BasebandSampleSource* m_sampleSource;
+	bool m_deleting;
 };
 
 class SDRBASE_API DSPAddAudioSink : public Message {

--- a/sdrbase/dsp/dspdevicemimoengine.cpp
+++ b/sdrbase/dsp/dspdevicemimoengine.cpp
@@ -155,13 +155,13 @@ void DSPDeviceMIMOEngine::addChannelSource(BasebandSampleSource* source, int ind
 	getInputMessageQueue()->push(cmd);
 }
 
-void DSPDeviceMIMOEngine::removeChannelSource(BasebandSampleSource* source, int index)
+void DSPDeviceMIMOEngine::removeChannelSource(BasebandSampleSource* source, bool deleting, int index)
 {
 	qDebug() << "DSPDeviceMIMOEngine::removeChannelSource: "
         << source->getSourceName().toStdString().c_str()
         << " at: "
         << index;
-	auto *cmd = new RemoveBasebandSampleSource(source, index);
+	auto *cmd = new RemoveBasebandSampleSource(source, index, deleting);
 	getInputMessageQueue()->push(cmd);
 }
 
@@ -1129,10 +1129,13 @@ bool DSPDeviceMIMOEngine::handleMessage(const Message& message)
         const auto& msg = (const RemoveBasebandSampleSource&) message;
 		BasebandSampleSource* sampleSource = msg.getSampleSource();
         unsigned int isink = msg.getIndex();
+        bool deleting = msg.getDeleting();
 
         if (isink < m_basebandSampleSources.size())
         {
-            sampleSource->stop();
+            if (!deleting) {
+                sampleSource->stop();
+            }
             m_basebandSampleSources[isink].remove(sampleSource);
         }
 

--- a/sdrbase/dsp/dspdevicemimoengine.h
+++ b/sdrbase/dsp/dspdevicemimoengine.h
@@ -65,16 +65,19 @@ public:
 	    MESSAGE_CLASS_DECLARATION
 
     public:
-        RemoveBasebandSampleSource(BasebandSampleSource* sampleSource, unsigned int index) :
+        RemoveBasebandSampleSource(BasebandSampleSource* sampleSource, unsigned int index, bool deleting) :
             Message(),
             m_sampleSource(sampleSource),
-            m_index(index)
+            m_index(index),
+            m_deleting(deleting)
         { }
         BasebandSampleSource* getSampleSource() const { return m_sampleSource; }
         unsigned int getIndex() const { return m_index; }
+        bool getDeleting() const { return m_deleting; }
     private:
         BasebandSampleSource* m_sampleSource;
         unsigned int m_index;
+        bool m_deleting;
     };
 
     class AddMIMOChannel : public Message {
@@ -227,7 +230,7 @@ public:
     uint getUID() const { return m_uid; }
 
 	void addChannelSource(BasebandSampleSource* source, int index = 0);            //!< Add a channel source
-	void removeChannelSource(BasebandSampleSource* source, int index = 0);         //!< Remove a channel source
+	void removeChannelSource(BasebandSampleSource* source, bool deleting, int index = 0); //!< Remove a channel source
 	void addChannelSink(BasebandSampleSink* sink, int index = 0);                  //!< Add a channel sink
 	void removeChannelSink(BasebandSampleSink* sink, int index = 0);               //!< Remove a channel sink
     void addMIMOChannel(MIMOChannel *channel);                                     //!< Add a MIMO channel

--- a/sdrbase/dsp/dspdevicesinkengine.cpp
+++ b/sdrbase/dsp/dspdevicesinkengine.cpp
@@ -101,10 +101,10 @@ void DSPDeviceSinkEngine::addChannelSource(BasebandSampleSource* source)
     getInputMessageQueue()->push(cmd);
 }
 
-void DSPDeviceSinkEngine::removeChannelSource(BasebandSampleSource* source)
+void DSPDeviceSinkEngine::removeChannelSource(BasebandSampleSource* source, bool deleting)
 {
 	qDebug() << "DSPDeviceSinkEngine::removeChannelSource: " << source->getSourceName().toStdString().c_str();
-	auto *cmd = new DSPRemoveBasebandSampleSource(source);
+	auto *cmd = new DSPRemoveBasebandSampleSource(source, deleting);
     getInputMessageQueue()->push(cmd);
 }
 
@@ -499,8 +499,9 @@ bool DSPDeviceSinkEngine::handleMessage(const Message& message)
 	{
         auto& cmd = (const DSPRemoveBasebandSampleSource&) message;
 		BasebandSampleSource* source = cmd.getSampleSource();
+		bool deleting = cmd.getDeleting();
 
-		if(m_state == State::StRunning) {
+		if (!deleting && (m_state == State::StRunning)) {
 			source->stop();
 		}
 

--- a/sdrbase/dsp/dspdevicesinkengine.h
+++ b/sdrbase/dsp/dspdevicesinkengine.h
@@ -68,7 +68,7 @@ public:
 	void setSinkSequence(int sequence); //!< Set the sample sink sequence in type
 
 	void addChannelSource(BasebandSampleSource* source);       //!< Add a baseband sample source
-	void removeChannelSource(BasebandSampleSource* source);    //!< Remove a baseband sample source
+	void removeChannelSource(BasebandSampleSource* source, bool deleting);    //!< Remove a baseband sample source
 
 	void addSpectrumSink(BasebandSampleSink* spectrumSink);    //!< Add a spectrum vis baseband sample sink
 	void removeSpectrumSink(BasebandSampleSink* spectrumSink); //!< Add a spectrum vis baseband sample sink

--- a/sdrbase/dsp/dspdevicesourceengine.cpp
+++ b/sdrbase/dsp/dspdevicesourceengine.cpp
@@ -109,10 +109,10 @@ void DSPDeviceSourceEngine::addSink(BasebandSampleSink* sink)
     getInputMessageQueue()->push(cmd);
 }
 
-void DSPDeviceSourceEngine::removeSink(BasebandSampleSink* sink)
+void DSPDeviceSourceEngine::removeSink(BasebandSampleSink* sink, bool deleting)
 {
 	qDebug() << "DSPDeviceSourceEngine::removeSink: " << sink->getSinkName().toStdString().c_str();
-	auto *cmd = new DSPRemoveBasebandSampleSink(sink);
+	auto *cmd = new DSPRemoveBasebandSampleSink(sink, deleting);
     getInputMessageQueue()->push(cmd);
 }
 
@@ -629,8 +629,10 @@ bool DSPDeviceSourceEngine::handleMessage(const Message& message)
 	{
         auto cmd = (const DSPRemoveBasebandSampleSink&) message;
 		BasebandSampleSink* sink = cmd.getSampleSink();
+		bool deleting = cmd.getDeleting();
 
-		if(m_state == State::StRunning) {
+		// Don't dereference sink if deleting, as it may have already been deleted
+		if (!deleting && (m_state == State::StRunning)) {
 			sink->stop();
 		}
 

--- a/sdrbase/dsp/dspdevicesourceengine.h
+++ b/sdrbase/dsp/dspdevicesourceengine.h
@@ -62,7 +62,7 @@ public:
 	DeviceSampleSource *getSource() { return m_deviceSampleSource; }
 
 	void addSink(BasebandSampleSink* sink); //!< Add a sample sink
-	void removeSink(BasebandSampleSink* sink); //!< Remove a sample sink
+	void removeSink(BasebandSampleSink* sink, bool deleting); //!< Remove a sample sink
 
 	void configureCorrections(bool dcOffsetCorrection, bool iqImbalanceCorrection); //!< Configure DSP corrections
 

--- a/sdrgui/mainwindow.cpp
+++ b/sdrgui/mainwindow.cpp
@@ -740,7 +740,7 @@ void RemoveDeviceSetFSM::removeSink()
 {
     qDebug() << "RemoveDeviceSetFSM::removeSink";
     if (m_deviceSourceEngine) {
-        m_deviceSourceEngine->removeSink(m_deviceUISet->m_spectrumVis);
+        m_deviceSourceEngine->removeSink(m_deviceUISet->m_spectrumVis, false);
     } else if (m_deviceSinkEngine) {
         m_deviceSinkEngine->removeSpectrumSink(m_deviceUISet->m_spectrumVis);
     } else {


### PR DESCRIPTION
Don't stop source if being deleted, to avoid potentially accessing deleted object. Make sure thread stopped before deleting it. For #2315

Send DSPSignalNotification to audio mod (AM/NFM/SSB) baseband when start is called, to ensure baseband sample rate is set. For #2336.
