### PR TITLE
Windows code signing update

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -103,7 +103,7 @@ jobs:
           github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
           wait-for-completion: true
           output-artifact-directory: 'build\signed'
-          wait-for-completion-timeout-in-seconds: 1800
+          wait-for-completion-timeout-in-seconds: 3600
       - name: Upload signed artifact
         id: upload-signed-artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -104,11 +104,6 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: 'build\signed'
           wait-for-completion-timeout-in-seconds: 1800
-      - name: Unzip signed artifact
-        run: |
-          dir ${{ github.workspace }}\build\signed
-          cd ${{ github.workspace }}\build\signed
-          7z x sdrangel-${{ steps.get_version.outputs.version }}-win64.exe.zip
       - name: Upload signed artifact
         id: upload-signed-artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Remove unzip step, as it looks like it's not needed. And increase timeout to 1hour.

Hopefully that should now work and we can close #1877