### PR TITLE
Upload signed releases rather than unsigned releases to Github

### DIFF
--- a/.github/workflows/sdrangel.yml
+++ b/.github/workflows/sdrangel.yml
@@ -94,11 +94,6 @@ jobs:
         with:
           name: sdrangel-${{ steps.get_version.outputs.version }}-win64.exe
           path: ${{ github.workspace }}/build/sdrangel-${{ steps.get_version.outputs.version }}-win64.exe
-      - name: Upload release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v0.1.13
-        with:
-          files: ${{ github.workspace }}/build/sdrangel-${{ steps.get_version.outputs.version }}-win64.exe
 
   build_mac:
     runs-on: macos-14

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,7 +6,6 @@ on:
       - master
     tags:
       - 'v*'
-  pull_request:
 
 jobs:
   build:
@@ -110,3 +109,8 @@ jobs:
         with:
           name: sdrangel-${{ steps.get_version.outputs.version }}-win64-signed.exe
           path: ${{ github.workspace }}/build/signed/sdrangel-${{ steps.get_version.outputs.version }}-win64.exe
+      - name: Upload release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ github.workspace }}/build/signed/sdrangel-${{ steps.get_version.outputs.version }}-win64.exe


### PR DESCRIPTION
Upload signed releases rather than unsigned releases to Github releases page.

Only sign releases, not all pull requests.