### PR TITLE
Split button added, swagger changed manually, but should be the same …

### DIFF
--- a/plugins/samplesink/limesdroutput/limesdroutput.cpp
+++ b/plugins/samplesink/limesdroutput/limesdroutput.cpp
@@ -807,7 +807,9 @@ bool LimeSDROutput::applySettings(const LimeSDROutputSettings& settings, const Q
     if (settingsKeys.contains("devSampleRate")
        || settingsKeys.contains("log2HardInterp") || force)
     {
-        forwardChangeAllDSP = true; //m_settings.m_devSampleRate != settings.m_devSampleRate;
+        //forwardChangeAllDSP = true; //m_settings.m_devSampleRate != settings.m_devSampleRate;
+        forwardChangeTxDSP  = m_settings.m_log2HardInterp != settings.m_log2HardInterp;
+        forwardChangeAllDSP = m_settings.m_devSampleRate != settings.m_devSampleRate;
 
         if (m_deviceShared.m_deviceParams->getDevice())
         {

--- a/plugins/samplesource/limesdrinput/limesdrinput.cpp
+++ b/plugins/samplesource/limesdrinput/limesdrinput.cpp
@@ -969,8 +969,14 @@ bool LimeSDRInput::applySettings(const LimeSDRInputSettings& settings, const QLi
     if (settingsKeys.contains("devSampleRate")
        || settingsKeys.contains("log2HardDecim") || force)
     {
-        forwardChangeAllDSP = true; //m_settings.m_devSampleRate != settings.m_devSampleRate;
-
+        
+        if(!settings.m_splitFreq) {
+            forwardChangeAllDSP = true; //m_settings.m_devSampleRate != settings.m_devSampleRate;
+            qDebug() << "LimeSDRInput::applySettings: Split is false, val:" << settings.m_splitFreq;
+        }else{
+            forwardChangeRxDSP  = m_settings.m_log2HardDecim != settings.m_log2HardDecim;
+            forwardChangeAllDSP = m_settings.m_devSampleRate != settings.m_devSampleRate;
+        }
         if (m_deviceShared.m_deviceParams->getDevice() && m_channelAcquired)
         {
             if (LMS_SetSampleRateDir(m_deviceShared.m_deviceParams->getDevice(),
@@ -1439,6 +1445,9 @@ void LimeSDRInput::webapiUpdateDeviceSettings(
     if (deviceSettingsKeys.contains("dcBlock")) {
         settings.m_dcBlock = response.getLimeSdrInputSettings()->getDcBlock() != 0;
     }
+    if (deviceSettingsKeys.contains("splitFreq")) {
+        settings.m_splitFreq = response.getLimeSdrInputSettings()->getSplitFreq() != 0;
+    }
     if (deviceSettingsKeys.contains("devSampleRate")) {
         settings.m_devSampleRate = response.getLimeSdrInputSettings()->getDevSampleRate();
     }
@@ -1521,6 +1530,7 @@ void LimeSDRInput::webapiFormatDeviceSettings(SWGSDRangel::SWGDeviceSettings& re
     response.getLimeSdrInputSettings()->setAntennaPath((int) settings.m_antennaPath);
     response.getLimeSdrInputSettings()->setCenterFrequency(settings.m_centerFrequency);
     response.getLimeSdrInputSettings()->setDcBlock(settings.m_dcBlock ? 1 : 0);
+    response.getLimeSdrInputSettings()->setSplitFreq(settings.m_splitFreq ? 1 : 0);
     response.getLimeSdrInputSettings()->setDevSampleRate(settings.m_devSampleRate);
     response.getLimeSdrInputSettings()->setExtClock(settings.m_extClock ? 1 : 0);
     response.getLimeSdrInputSettings()->setExtClockFreq(settings.m_extClockFreq);
@@ -1652,6 +1662,9 @@ void LimeSDRInput::webapiReverseSendSettings(const QList<QString>& deviceSetting
     }
     if (deviceSettingsKeys.contains("dcBlock") || force) {
         swgLimeSdrInputSettings->setDcBlock(settings.m_dcBlock ? 1 : 0);
+    }
+    if (deviceSettingsKeys.contains("splitFreq") || force) {
+        swgLimeSdrInputSettings->setSplitFreq(settings.m_splitFreq ? 1 : 0);
     }
     if (deviceSettingsKeys.contains("devSampleRate") || force) {
         swgLimeSdrInputSettings->setDevSampleRate(settings.m_devSampleRate);

--- a/plugins/samplesource/limesdrinput/limesdrinputgui.cpp
+++ b/plugins/samplesource/limesdrinput/limesdrinputgui.cpp
@@ -428,6 +428,7 @@ void LimeSDRInputGUI::displaySettings()
     displaySampleRate();
 
     ui->dcOffset->setChecked(m_settings.m_dcBlock);
+    ui->splitFreq->setChecked(m_settings.m_splitFreq);
     ui->iqImbalance->setChecked(m_settings.m_iqCorrection);
 
     ui->hwDecim->setCurrentIndex(m_settings.m_log2HardDecim);
@@ -632,6 +633,13 @@ void LimeSDRInputGUI::on_dcOffset_toggled(bool checked)
 {
     m_settings.m_dcBlock = checked;
     m_settingsKeys.append("dcBlock");
+    sendSettings();
+}
+
+void LimeSDRInputGUI::on_splitFreq_toggled(bool checked)
+{
+    m_settings.m_splitFreq = checked;
+    m_settingsKeys.append("splitFreq");
     sendSettings();
 }
 
@@ -939,6 +947,7 @@ void LimeSDRInputGUI::makeUIConnections()
     QObject::connect(ui->ncoFrequency, &ValueDialZ::changed, this, &LimeSDRInputGUI::on_ncoFrequency_changed);
     QObject::connect(ui->ncoEnable, &ButtonSwitch::toggled, this, &LimeSDRInputGUI::on_ncoEnable_toggled);
     QObject::connect(ui->dcOffset, &ButtonSwitch::toggled, this, &LimeSDRInputGUI::on_dcOffset_toggled);
+    QObject::connect(ui->splitFreq, &ButtonSwitch::toggled, this, &LimeSDRInputGUI::on_splitFreq_toggled);
     QObject::connect(ui->iqImbalance, &ButtonSwitch::toggled, this, &LimeSDRInputGUI::on_iqImbalance_toggled);
     QObject::connect(ui->sampleRate, &ValueDial::changed, this, &LimeSDRInputGUI::on_sampleRate_changed);
     QObject::connect(ui->hwDecim, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LimeSDRInputGUI::on_hwDecim_currentIndexChanged);

--- a/plugins/samplesource/limesdrinput/limesdrinputgui.h
+++ b/plugins/samplesource/limesdrinput/limesdrinputgui.h
@@ -89,6 +89,7 @@ private slots:
     void on_ncoFrequency_changed(qint64 value);
     void on_ncoEnable_toggled(bool checked);
     void on_dcOffset_toggled(bool checked);
+    void on_splitFreq_toggled(bool checked);
     void on_iqImbalance_toggled(bool checked);
     void on_sampleRate_changed(quint64 value);
     void on_hwDecim_currentIndexChanged(int index);

--- a/plugins/samplesource/limesdrinput/limesdrinputgui.ui
+++ b/plugins/samplesource/limesdrinput/limesdrinputgui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>360</width>
+    <width>386</width>
     <height>255</height>
    </rect>
   </property>
@@ -309,6 +309,16 @@
        <property name="icon">
         <iconset resource="../../../sdrgui/resources/res.qrc">
          <normaloff>:/clocksource.png</normaloff>:/clocksource.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ButtonSwitch" name="splitFreq">
+       <property name="toolTip">
+        <string>Disable RX/TX frequency being locked</string>
+       </property>
+       <property name="text">
+        <string>Split</string>
        </property>
       </widget>
      </item>

--- a/plugins/samplesource/limesdrinput/limesdrinputsettings.cpp
+++ b/plugins/samplesource/limesdrinput/limesdrinputsettings.cpp
@@ -31,6 +31,7 @@ void LimeSDRInputSettings::resetToDefaults()
     m_devSampleRate = 5000000;
     m_log2HardDecim = 3;
     m_dcBlock = false;
+    m_splitFreq = false;
     m_iqCorrection = false;
     m_log2SoftDecim = 0;
     m_lpfBW = 4.5e6f;
@@ -96,6 +97,7 @@ QByteArray LimeSDRInputSettings::serialize() const
     s.writeFloat(30, m_replayLength);
     s.writeFloat(31, m_replayStep);
     s.writeBool(32, m_replayLoop);
+    s.writeBool(33, m_splitFreq);
 
     return s.final();
 }
@@ -158,6 +160,7 @@ bool LimeSDRInputSettings::deserialize(const QByteArray& data)
         d.readFloat(30, &m_replayLength, 20.0f);
         d.readFloat(31, &m_replayStep, 5.0f);
         d.readBool(32, &m_replayLoop, false);
+        d.readBool(33, &m_splitFreq, false);
 
         return true;
     }
@@ -182,6 +185,9 @@ void LimeSDRInputSettings::applySettings(const QStringList& settingsKeys, const 
     }
     if (settingsKeys.contains("dcBlock")) {
         m_dcBlock = settings.m_dcBlock;
+    }
+    if (settingsKeys.contains("splitFreq")) {
+        m_splitFreq = settings.m_splitFreq;
     }
     if (settingsKeys.contains("iqCorrection")) {
         m_iqCorrection = settings.m_iqCorrection;
@@ -284,6 +290,9 @@ QString LimeSDRInputSettings::getDebugString(const QStringList& settingsKeys, bo
     }
     if (settingsKeys.contains("dcBlock") || force) {
         ostr << " m_dcBlock: " << m_dcBlock;
+    }
+    if (settingsKeys.contains("splitFreq") || force) {
+        ostr << " m_splitFreq: " << m_splitFreq;
     }
     if (settingsKeys.contains("iqCorrection") || force) {
         ostr << " m_iqCorrection: " << m_iqCorrection;

--- a/plugins/samplesource/limesdrinput/limesdrinputsettings.h
+++ b/plugins/samplesource/limesdrinput/limesdrinputsettings.h
@@ -51,6 +51,7 @@ struct LimeSDRInputSettings
     uint32_t m_log2HardDecim;
     // channel settings
     bool     m_dcBlock;
+    bool     m_splitFreq;
     bool     m_iqCorrection;
     uint32_t m_log2SoftDecim;
     float    m_lpfBW;        //!< LMS amalog lowpass filter bandwidth (Hz)

--- a/swagger/sdrangel/api/swagger/include/LimeSdr.yaml
+++ b/swagger/sdrangel/api/swagger/include/LimeSdr.yaml
@@ -10,6 +10,8 @@ LimeSdrInputSettings:
       type: integer
     dcBlock:
       type: integer
+    splitFreq:
+      type: integer
     iqCorrection:
       type: integer
     log2SoftDecim:

--- a/swagger/sdrangel/code/qt5/client/SWGLimeSdrInputSettings.cpp
+++ b/swagger/sdrangel/code/qt5/client/SWGLimeSdrInputSettings.cpp
@@ -35,7 +35,9 @@ SWGLimeSdrInputSettings::SWGLimeSdrInputSettings() {
     log2_hard_decim = 0;
     m_log2_hard_decim_isSet = false;
     dc_block = 0;
+    splitFreq = 0;
     m_dc_block_isSet = false;
+    m_splitFreq_isSet = false;
     iq_correction = 0;
     m_iq_correction_isSet = false;
     log2_soft_decim = 0;
@@ -100,6 +102,8 @@ SWGLimeSdrInputSettings::init() {
     m_log2_hard_decim_isSet = false;
     dc_block = 0;
     m_dc_block_isSet = false;
+    splitFreq = 0;
+    m_splitFreq_isSet = false;
     iq_correction = 0;
     m_iq_correction_isSet = false;
     log2_soft_decim = 0;
@@ -202,6 +206,8 @@ SWGLimeSdrInputSettings::fromJsonObject(QJsonObject &pJson) {
     ::SWGSDRangel::setValue(&log2_hard_decim, pJson["log2HardDecim"], "qint32", "");
     
     ::SWGSDRangel::setValue(&dc_block, pJson["dcBlock"], "qint32", "");
+
+    ::SWGSDRangel::setValue(&splitFreq, pJson["splitFreq"], "qint32", "");
     
     ::SWGSDRangel::setValue(&iq_correction, pJson["iqCorrection"], "qint32", "");
     
@@ -278,6 +284,9 @@ SWGLimeSdrInputSettings::asJsonObject() {
     }
     if(m_dc_block_isSet){
         obj->insert("dcBlock", QJsonValue(dc_block));
+    }
+    if(m_splitFreq_isSet){
+        obj->insert("splitFreq", QJsonValue(splitFreq));
     }
     if(m_iq_correction_isSet){
         obj->insert("iqCorrection", QJsonValue(iq_correction));
@@ -393,6 +402,16 @@ void
 SWGLimeSdrInputSettings::setDcBlock(qint32 dc_block) {
     this->dc_block = dc_block;
     this->m_dc_block_isSet = true;
+}
+
+qint32
+SWGLimeSdrInputSettings::getSplitFreq() {
+    return splitFreq;
+}
+void
+SWGLimeSdrInputSettings::setSplitFreq(qint32 splitFreq) {
+    this->splitFreq = splitFreq;
+    this->m_splitFreq_isSet = true;
 }
 
 qint32
@@ -650,6 +669,9 @@ SWGLimeSdrInputSettings::isSet(){
             isObjectUpdated = true; break;
         }
         if(m_dc_block_isSet){
+            isObjectUpdated = true; break;
+        }
+        if(m_splitFreq_isSet){
             isObjectUpdated = true; break;
         }
         if(m_iq_correction_isSet){

--- a/swagger/sdrangel/code/qt5/client/SWGLimeSdrInputSettings.h
+++ b/swagger/sdrangel/code/qt5/client/SWGLimeSdrInputSettings.h
@@ -52,7 +52,10 @@ public:
     void setLog2HardDecim(qint32 log2_hard_decim);
 
     qint32 getDcBlock();
-    void setDcBlock(qint32 dc_block);
+    void setDcBlock(qint32 splitFreq);
+
+    qint32 getSplitFreq();
+    void setSplitFreq(qint32 splitFreq);
 
     qint32 getIqCorrection();
     void setIqCorrection(qint32 iq_correction);
@@ -141,6 +144,9 @@ private:
 
     qint32 dc_block;
     bool m_dc_block_isSet;
+
+    qint32 splitFreq;
+    bool m_splitFreq_isSet;
 
     qint32 iq_correction;
     bool m_iq_correction_isSet;


### PR DESCRIPTION
Split button added to Lime RX allowing for the RX/TX freq lock to be disabled.

Swager generated code was updated manually, but it shuold be the same when regenerated as yaml was also updated.

This is to fix issue https://github.com/f4exb/sdrangel/issues/2424
![image](https://github.com/user-attachments/assets/a8d20625-faef-4cea-ad05-5edda8d9838f)
