### PR TITLE
Set csv as default filename extension for save file dialogs. 

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -7896,6 +7896,7 @@ void ADSBDemodGUI::on_logFilename_clicked()
 {
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select file to log received frames to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/demodais/aisdemodgui.cpp
+++ b/plugins/channelrx/demodais/aisdemodgui.cpp
@@ -986,6 +986,7 @@ void AISDemodGUI::on_logFilename_clicked()
 {
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select file to log received frames to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/demoddsc/dscdemodgui.cpp
+++ b/plugins/channelrx/demoddsc/dscdemodgui.cpp
@@ -1092,6 +1092,7 @@ void DSCDemodGUI::on_logFilename_clicked()
 {
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select file to log received messages to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/demodendoftrain/endoftraindemodgui.cpp
+++ b/plugins/channelrx/demodendoftrain/endoftraindemodgui.cpp
@@ -661,6 +661,7 @@ void EndOfTrainDemodGUI::on_logFilename_clicked()
 {
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select file to log received frames to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/demodils/ilsdemodgui.cpp
+++ b/plugins/channelrx/demodils/ilsdemodgui.cpp
@@ -1336,6 +1336,7 @@ void ILSDemodGUI::on_logFilename_clicked()
 {
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select CSV file to log data to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/demodnavtex/navtexdemodgui.cpp
+++ b/plugins/channelrx/demodnavtex/navtexdemodgui.cpp
@@ -761,6 +761,7 @@ void NavtexDemodGUI::on_logFilename_clicked()
 {
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select file to log received messages to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/demodpacket/packetdemodgui.cpp
+++ b/plugins/channelrx/demodpacket/packetdemodgui.cpp
@@ -608,6 +608,7 @@ void PacketDemodGUI::on_logFilename_clicked()
 {
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select file to log received frames to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/demodpager/pagerdemodgui.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodgui.cpp
@@ -781,6 +781,7 @@ void PagerDemodGUI::on_logFilename_clicked()
 {
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select file to log received messages to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/demodradiosonde/radiosondedemodgui.cpp
+++ b/plugins/channelrx/demodradiosonde/radiosondedemodgui.cpp
@@ -830,6 +830,7 @@ void RadiosondeDemodGUI::on_logFilename_clicked()
 {
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select file to log received frames to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/heatmap/heatmapgui.cpp
+++ b/plugins/channelrx/heatmap/heatmapgui.cpp
@@ -305,6 +305,7 @@ void HeatMapGUI::on_writeCSV_clicked()
 {
     m_csvFileDialog.setAcceptMode(QFileDialog::AcceptSave);
     m_csvFileDialog.setNameFilter("*.csv");
+    m_csvFileDialog.setDefaultSuffix("csv");
     if (m_csvFileDialog.exec())
     {
         QStringList fileNames = m_csvFileDialog.selectedFiles();

--- a/plugins/channelrx/noisefigure/noisefiguregui.cpp
+++ b/plugins/channelrx/noisefigure/noisefiguregui.cpp
@@ -425,6 +425,7 @@ void NoiseFigureGUI::on_saveResults_clicked()
 {
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select file to save results to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -1510,6 +1510,7 @@ void RadioAstronomyGUI::on_savePowerData_clicked(bool checked)
 
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select file to save data to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {
@@ -1528,6 +1529,7 @@ void RadioAstronomyGUI::on_savePowerData_rightClicked(const QPoint& point)
     {
         // Get filename to save to
         QFileDialog fileDialog(nullptr, "Select file to auto save data to", "", "*.csv");
+        fileDialog.setDefaultSuffix("csv");
         fileDialog.setAcceptMode(QFileDialog::AcceptSave);
         if (fileDialog.exec())
         {
@@ -1801,6 +1803,7 @@ void RadioAstronomyGUI::on_saveSpectrumData_clicked(bool checked)
 
     // Get filename to save to
     QFileDialog fileDialog(nullptr, "Select file to save data to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {
@@ -1819,6 +1822,7 @@ void RadioAstronomyGUI::on_saveSpectrumData_rightClicked(const QPoint &point)
     {
         // Get filename to save to
         QFileDialog fileDialog(nullptr, "Select file to auto save data to", "", "*.csv");
+        fileDialog.setDefaultSuffix("csv");
         fileDialog.setAcceptMode(QFileDialog::AcceptSave);
         if (fileDialog.exec())
         {
@@ -1846,6 +1850,7 @@ void RadioAstronomyGUI::on_loadSpectrumData_clicked()
 {
     // Get filename to load from
     QFileDialog fileDialog(nullptr, "Select file to load data from", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
     if (fileDialog.exec())
     {

--- a/plugins/feature/sid/sidgui.cpp
+++ b/plugins/feature/sid/sidgui.cpp
@@ -2237,6 +2237,7 @@ void SIDGUI::autosave()
 
 void SIDGUI::on_saveData_clicked()
 {
+    m_fileDialog.setDefaultSuffix("csv");
     m_fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (m_fileDialog.exec())
     {

--- a/plugins/feature/sid/sidsettingsdialog.cpp
+++ b/plugins/feature/sid/sidsettingsdialog.cpp
@@ -155,6 +155,7 @@ void SIDSettingsDialog::accept()
 
 void SIDSettingsDialog::on_browse_clicked()
 {
+    m_fileDialog.setDefaultSuffix("csv");
     m_fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (m_fileDialog.exec())
     {

--- a/sdrgui/gui/glspectrumgui.cpp
+++ b/sdrgui/gui/glspectrumgui.cpp
@@ -549,6 +549,7 @@ void GLSpectrumGUI::on_save_clicked(bool checked)
 
     // Get filename to write
     QFileDialog fileDialog(nullptr, "Select file to save data to", "", "*.csv");
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     if (fileDialog.exec())
     {

--- a/sdrgui/gui/spectrumcalibrationpointsdialog.cpp
+++ b/sdrgui/gui/spectrumcalibrationpointsdialog.cpp
@@ -281,6 +281,7 @@ void SpectrumCalibrationPointsDialog::on_calibPointsExport_clicked()
         QStandardPaths::writableLocation(QStandardPaths::AppDataLocation),
         "*.csv"
     );
+    fileDialog.setDefaultSuffix("csv");
     fileDialog.setAcceptMode(QFileDialog::AcceptSave);
 
     if (fileDialog.exec())

--- a/sdrgui/gui/spectrummarkersdialog.cpp
+++ b/sdrgui/gui/spectrummarkersdialog.cpp
@@ -738,6 +738,7 @@ void SpectrumMarkersDialog::on_aMarkersImport_clicked()
         QStandardPaths::writableLocation(QStandardPaths::AppDataLocation),
         "*.csv"
     );
+    fileDialog.setDefaultSuffix("csv");
 
     if (fileDialog.exec())
     {


### PR DESCRIPTION
Set csv as default filename extension for save file dialogs. For #2506