### PR TITLE
SSBMod: Initialise baseband settings when device is started. 

### DIFF
--- a/plugins/channeltx/modssb/ssbmod.cpp
+++ b/plugins/channeltx/modssb/ssbmod.cpp
@@ -126,6 +126,9 @@ void SSBMod::start()
     DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
     m_basebandSource->getInputMessageQueue()->push(dspMsg);
 
+    SSBModBaseband::MsgConfigureSSBModBaseband *msg = SSBModBaseband::MsgConfigureSSBModBaseband::create(m_settings, true);
+    m_basebandSource->getInputMessageQueue()->push(msg);
+
     m_running = true;
 }
 


### PR DESCRIPTION
SSBMod: Initialise baseband settings when device is started. Fixes #2539