### PR TITLE
Fix build with Qt 6.10.1.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,7 +657,8 @@ if(ENABLE_QT6)
                      MultimediaWidgets
                      Positioning
                      Charts
-                     SerialPort)
+                     SerialPort
+                     CorePrivate)
 else()
     find_package(Qt5 5.15
                    REQUIRED COMPONENTS

--- a/plugins/feature/map/mapmodel.cpp
+++ b/plugins/feature/map/mapmodel.cpp
@@ -575,8 +575,10 @@ bool ObjectMapModel::isTarget(const ObjectMapItem *mapItem) const
 
 // FIXME: This should use Z order - rather than adding/removing
 // but I couldn't quite get it to work
+// Causes a crash with Qt 6.10+
 Q_INVOKABLE void ObjectMapModel::moveToFront(int oldRow)
 {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 10, 0))
     // Last item in list is drawn on top, so remove than add to end of list
     if (oldRow < m_items.size() - 1)
     {
@@ -593,10 +595,12 @@ Q_INVOKABLE void ObjectMapModel::moveToFront(int oldRow)
         QModelIndex idx = index(newRow);
         emit dataChanged(idx, idx);
     }
+#endif
 }
 
 Q_INVOKABLE void ObjectMapModel::moveToBack(int oldRow)
 {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 10, 0))
     // First item in list is drawn first, so remove item then add to front of list
     if ((oldRow < m_items.size()) && (oldRow > 0))
     {
@@ -617,6 +621,7 @@ Q_INVOKABLE void ObjectMapModel::moveToBack(int oldRow)
         endResetModel();
         //emit dataChanged(index(oldRow), index(newRow));
     }
+#endif
 }
 
 Q_INVOKABLE void ObjectMapModel::link(const QString& url)


### PR DESCRIPTION
Fix build with Qt 6.10.1 (Need to specify CorePrivate as a component).
Temporarily disable 2D Map move to front, as it causes a crash with Qt 6.10.x.