### PR TITLE
Update github Mac/Intel runner to macos-15-intel

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_mac_x64:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       MACOSX_DEPLOYMENT_TARGET: 12.0
     steps:


### PR DESCRIPTION
Update github Mac/Intel runner to macos-15-intel as macos-13 is no longer available. For #2583 