### PR TITLE
Correct null PID behaviour for DVB-S modulator

### DIFF
--- a/plugins/channeltx/moddatv/datvmodsource.cpp
+++ b/plugins/channeltx/moddatv/datvmodsource.cpp
@@ -377,12 +377,11 @@ void DATVModSource::modulateSample()
             else
             {
                 // Insert null packet. PID=0x1fff
-                memset(m_mpegTS, 0, sizeof(m_mpegTS));
+                memset(m_mpegTS, 0xFF, sizeof(m_mpegTS));
                 m_mpegTS[0] = 0x47; // Sync byte
-                m_mpegTS[1] = 0x01;
-                m_mpegTS[2] = 0xff;
-                m_mpegTS[3] = 0xff;
-                m_mpegTS[4] = 0x10;
+                m_mpegTS[1] = 0x1F;
+                m_mpegTS[2] = 0xFF;
+                m_mpegTS[3] = 0x10;
 
                 if (tsFileReady) {
                     m_frameCount++;


### PR DESCRIPTION
The current implementation is incorrect and uses a packet with a PID of 0x01FF, while this should be 0x1FFF, and the FF is duplicated, since a MPEG-TS header is only 4 bytes and not 5, and this ends up setting some reserved bits, this seems like a bug since it disagrees with the comments in the source, also changed the payload of null packets to 0xFF which is common.