### PR TITLE
Don't show a double minus sign per pilot power dB value

### DIFF
--- a/plugins/channelrx/demodbfm/bfmdemodgui.cpp
+++ b/plugins/channelrx/demodbfm/bfmdemodgui.cpp
@@ -567,8 +567,7 @@ void BFMDemodGUI::tick()
     ui->channelPower->setText(QString::number(powDbAvg, 'f', 1));
 
 	Real pilotPowDb =  CalcDb::dbPower(m_bfmDemod->getPilotLevel());
-	QString pilotPowDbStr = QString("%1%2").arg(pilotPowDb < 0 ? '-' : '+').arg(pilotPowDb, 3, 'f', 1, QLatin1Char('0'));
-	ui->pilotPower->setText(pilotPowDbStr);
+    ui->pilotPower->setText(QString::number(pilotPowDb, 'f', 1));
 
     if (m_bfmDemod->getAudioSampleRate() < 0)
     {


### PR DESCRIPTION
Use for `pilotPower` the same C++ code used above for `channelPower`.

Before:
<img width="83" height="33" alt="Schermata_20260101_155712" src="https://github.com/user-attachments/assets/9910fd28-aa44-4bd7-b758-79472292646f" />

After:
<img width="83" height="33" alt="Schermata_20260101_161703" src="https://github.com/user-attachments/assets/e0a8d113-3f0b-49e5-9d35-ae2d7220603d" />