### PR TITLE
Fix saving/restoring of SSB demod mute and BFM demod de-emphasis settings

### DIFF
--- a/plugins/channelrx/demodbfm/bfmdemodgui.cpp
+++ b/plugins/channelrx/demodbfm/bfmdemodgui.cpp
@@ -518,6 +518,8 @@ void BFMDemodGUI::displaySettings()
     ui->afBW->setValue(m_settings.m_afBandwidth/1000.0);
     ui->afBWText->setText(QString("%1 kHz").arg(m_settings.m_afBandwidth/1000.0));
 
+	ui->deEmphasis->setCurrentIndex((int) m_settings.m_deEmphasis);
+
     ui->volume->setValue(m_settings.m_volume * 10.0);
     ui->volumeText->setText(QString("%1").arg(m_settings.m_volume, 0, 'f', 1));
 

--- a/plugins/channelrx/demodssb/ssbdemodsettings.cpp
+++ b/plugins/channelrx/demodssb/ssbdemodsettings.cpp
@@ -117,6 +117,7 @@ QByteArray SSBDemodSettings::serialize() const
     s.writeFloat(33, m_dnrSigmaFactor);
     s.writeS32(34, m_dnrNbPeaks);
     s.writeFloat(35, m_dnrAlpha);
+    s.writeBool(36, m_audioMute);
 
     for (unsigned int i = 0; i <  10; i++)
     {
@@ -206,6 +207,7 @@ bool SSBDemodSettings::deserialize(const QByteArray& data)
         d.readFloat(33, &m_dnrSigmaFactor, 4.0f);
         d.readS32(34, &m_dnrNbPeaks, 20);
         d.readFloat(35, &m_dnrAlpha, 1.0);
+        d.readBool(36, &m_audioMute, false);
 
         for (unsigned int i = 0; (i < 10); i++)
         {


### PR DESCRIPTION
Fix saving/restoring of SSB demod audio mute and BFM demod de-emphasis settings. #2607
