### PR TITLE
Inmarsat: Improve frequency offset estimation and fix address coordinates

### DIFF
--- a/plugins/channelrx/demodinmarsat/inmarsatdemodgui.cpp
+++ b/plugins/channelrx/demodinmarsat/inmarsatdemodgui.cpp
@@ -506,8 +506,8 @@ QString MultipartMessage::decodeAddress(QString serviceCode, QString addressHex,
 
             if (coordinates)
             {
-                int lat1Deg = west ? -latDeg : latDeg;
-                int lon1Deg = south ? -lonDeg : lonDeg;
+                int lat1Deg = south ? -latDeg : latDeg;
+                int lon1Deg = west ? -lonDeg : lonDeg;
                 int lat2Deg = lat1Deg + latExtentEast;
                 int lon2Deg = lon1Deg + latExtentNorth;
                 *latitude = lat1Deg + lat2Deg / 2;
@@ -545,8 +545,8 @@ QString MultipartMessage::decodeAddress(QString serviceCode, QString addressHex,
 
             if (coordinates)
             {
-                int lat1Deg = west ? -latDeg : latDeg;
-                int lon1Deg = south ? -lonDeg : lonDeg;
+                int lat1Deg = south ? -latDeg : latDeg;
+                int lon1Deg = west ? -lonDeg : lonDeg;
                 QGeoCoordinate centre(lat1Deg, lon1Deg);
 
                 *latitude = lat1Deg;

--- a/plugins/channelrx/demodinmarsat/inmarsatdemodsink.cpp
+++ b/plugins/channelrx/demodinmarsat/inmarsatdemodsink.cpp
@@ -325,7 +325,6 @@ InmarsatDemodSink::InmarsatDemodSink(InmarsatDemod *stdCDemod) :
 
     m_adjustedSPS = MAX_SAMPLES_PER_SYMBOL;
     m_adjustment = 0;
-    m_totalSampleCount = 0;
     m_error = 0;
     m_errorSum = 0;
     m_mu = 0.0;
@@ -512,7 +511,6 @@ void InmarsatDemodSink::processOneSample(Complex &ci)
 
                 m_adjustedSPS = SAMPLES_PER_SYMBOL - m_adjustment; // Positve mu indicates late, so reduce time to next sample
                 m_adjustment = adjustment;
-                m_prevTotalSampleCount = m_totalSampleCount;
 
                 // Costas loop for fine phase/freq correction - runs at symbol rate
 

--- a/plugins/channelrx/demodinmarsat/inmarsatdemodsink.h
+++ b/plugins/channelrx/demodinmarsat/inmarsatdemodsink.h
@@ -232,8 +232,6 @@ private:
     Real m_mu;
     int m_adjustedSPS;
     int m_adjustment;
-    qint64 m_totalSampleCount;
-    qint64 m_prevTotalSampleCount;
     int m_bit;
     uint8_t m_bits[DEMODULATOR_SYMBOLSPERCHUNK];
     int m_bitCount;


### PR DESCRIPTION
A couple of changes to Inmarsat demod:  

Improve frequency offset estimation by using Hann windowing and quadratic interpolation.
Fix bug in rectangular and circular address decoding for coordinates sent to map.
