### PR TITLE
bump UHD to 4.9.0.1

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -36,7 +36,7 @@ set(SOAPYSDR_REMOTE_TAG "soapy-remote-0.5.1")
 set(AIRSPY_TAG "cmake4")
 set(HACKRF_TAG "adc537331c5bc3165f47648043c570063518ef79")
 set(LIBXML2_TAG "v2.10.4")
-set(UHD_TAG "v4.9.0.0")
+set(UHD_TAG "v4.9.0.1")
 set(BOOST_TAG "1.86.0")
 set(BOOST_TAG2 "1_86_0")
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -574,7 +574,7 @@ parts:
         plugin: cmake
         source: https://github.com/EttusResearch/uhd.git
         source-type: git
-        source-commit: v4.7.0.0
+        source-commit: v4.9.0.1
         source-subdir: host
         build-packages:
             - libusb-1.0-0-dev


### PR DESCRIPTION
Bumps UHD version for snap and CMakeLists to 4.9.0.1 to allow for usrp b206mini-i support.

Fixes #2628 