### PR TITLE
Fix missing 0 on waterfall time scale

### DIFF
--- a/sdrgui/gui/scaleengine.cpp
+++ b/sdrgui/gui/scaleengine.cpp
@@ -94,7 +94,8 @@ QString ScaleEngine::formatTick(double value, int decimalPlaces)
 		}
 
 		tmp = m_makeOpposite ? -actual : actual;
-		str += QString("%1").arg(tmp, 2, 'f', decimalPlaces, QChar('0'));
+		const int fieldWidth = (str.isEmpty() ? 1 : 2) + (decimalPlaces == 0 ? 0 : 1 + decimalPlaces);
+		str += QString("%1").arg(tmp, fieldWidth, 'f', decimalPlaces, QChar('0'));
 
 		return str;
 	}


### PR DESCRIPTION
For longer times, a 0 can be missing in the waterfall time scale:

<img width="98" height="466" alt="image" src="https://github.com/user-attachments/assets/5dae626a-9b09-4c63-85f7-5d613f9b4fd9" />

Hopefully this PR fixes it.