### PR TITLE
Spectrum: Enable save/restore of zoom settings. 

### DIFF
--- a/sdrbase/dsp/spectrumsettings.cpp
+++ b/sdrbase/dsp/spectrumsettings.cpp
@@ -87,6 +87,8 @@ void SpectrumSettings::resetToDefaults()
 #else
     m_showAllControls = true;
 #endif
+	m_frequencyZoomFactor = 1.0f;
+	m_frequencyZoomPos = 0.5f;
 }
 
 QByteArray SpectrumSettings::serialize() const
@@ -131,7 +133,7 @@ QByteArray SpectrumSettings::serialize() const
     s.writeS32(37, m_measurementChSpacing);
     s.writeS32(38, m_measurementAdjChBandwidth);
     s.writeS32(39, m_measurementHarmonics);
-    // 41, 42 used below
+    // 40, 41 used below
     s.writeBool(42, m_measurementHighlight);
     s.writeS32(43, m_measurementPeaks);
     s.writeS32(44, (int)m_measurementsPosition);
@@ -140,6 +142,8 @@ QByteArray SpectrumSettings::serialize() const
     s.writeBool(47, m_findHistogramPeaks);
     s.writeBool(48, m_truncateFreqScale);
     s.writeBool(49, m_showAllControls);
+	s.writeFloat(50, m_frequencyZoomFactor);
+    s.writeFloat(51, m_frequencyZoomPos);
     s.writeS32(100, m_histogramMarkers.size());
 
 	for (int i = 0; i < m_histogramMarkers.size(); i++) {
@@ -249,6 +253,8 @@ bool SpectrumSettings::deserialize(const QByteArray& data)
 #else
         d.readBool(49, &m_showAllControls, true);
 #endif
+		d.readFloat(50, &m_frequencyZoomFactor, 1.0f);
+		d.readFloat(51, &m_frequencyZoomPos, 0.5f);
 
 		int histogramMarkersSize;
 		d.readS32(100, &histogramMarkersSize, 0);

--- a/sdrbase/dsp/spectrumsettings.h
+++ b/sdrbase/dsp/spectrumsettings.h
@@ -142,6 +142,8 @@ public:
     MeasurementsPosition m_measurementsPosition;
     int m_measurementPrecision;
     bool m_showAllControls;
+    float m_frequencyZoomFactor;
+    float m_frequencyZoomPos;
 
 	static const int m_log2FFTSizeMin = 6;   // 64
 	static const int m_log2FFTSizeMax = 15;  // 32k

--- a/sdrbase/dsp/spectrumvis.cpp
+++ b/sdrbase/dsp/spectrumvis.cpp
@@ -52,8 +52,6 @@ SpectrumVis::SpectrumVis(Real scalef) :
     m_psd(4096),
 	m_fftBufferFill(0),
 	m_needMoreSamples(false),
-    m_frequencyZoomFactor(1.0f),
-    m_frequencyZoomPos(0.5f),
 	m_scalef(scalef),
 	m_glSpectrum(nullptr),
     m_specMax(0.0f),
@@ -119,10 +117,10 @@ void SpectrumVis::feed(const Complex *begin, unsigned int length)
 
     Complex c;
     Real v;
-    int fftMin = (m_frequencyZoomFactor == 1.0f) ?
-        0 : (m_frequencyZoomPos - (0.5f / m_frequencyZoomFactor)) * m_settings.m_fftSize;
-    int fftMax = (m_frequencyZoomFactor == 1.0f) ?
-        m_settings.m_fftSize : (m_frequencyZoomPos + (0.5f / m_frequencyZoomFactor)) * m_settings.m_fftSize;
+    int fftMin = (m_settings.m_frequencyZoomFactor == 1.0f) ?
+        0 : (m_settings.m_frequencyZoomPos - (0.5f / m_settings.m_frequencyZoomFactor)) * m_settings.m_fftSize;
+    int fftMax = (m_settings.m_frequencyZoomFactor == 1.0f) ?
+        m_settings.m_fftSize : (m_settings.m_frequencyZoomPos + (0.5f / m_settings.m_frequencyZoomFactor)) * m_settings.m_fftSize;
 
     if (m_settings.m_averagingMode == SpectrumSettings::AvgModeNone)
     {
@@ -422,10 +420,10 @@ void SpectrumVis::feed(const SampleVector::const_iterator& cbegin, const SampleV
 
 void SpectrumVis::processFFT(bool positiveOnly)
 {
-    int fftMin = (m_frequencyZoomFactor == 1.0f) ?
-        0 : (m_frequencyZoomPos - (0.5f / m_frequencyZoomFactor)) * m_settings.m_fftSize;
-    int fftMax = (m_frequencyZoomFactor == 1.0f) ?
-        m_settings.m_fftSize : (m_frequencyZoomPos + (0.5f / m_frequencyZoomFactor)) * m_settings.m_fftSize;
+    int fftMin = (m_settings.m_frequencyZoomFactor == 1.0f) ?
+        0 : (m_settings.m_frequencyZoomPos - (0.5f / m_settings.m_frequencyZoomFactor)) * m_settings.m_fftSize;
+    int fftMax = (m_settings.m_frequencyZoomFactor == 1.0f) ?
+        m_settings.m_fftSize : (m_settings.m_frequencyZoomPos + (0.5f / m_settings.m_frequencyZoomFactor)) * m_settings.m_fftSize;
 
     // apply fft window (and copy from m_fftBuffer to m_fftIn)
     m_window.apply(&m_fftBuffer[0], m_fft->in());
@@ -736,10 +734,10 @@ void SpectrumVis::processFFT(bool positiveOnly)
 
 void SpectrumVis::getZoomedPSDCopy(std::vector<Real>& copy) const
 {
-    int fftMin = (m_frequencyZoomFactor == 1.0f) ?
-        0 : (m_frequencyZoomPos - (0.5f / m_frequencyZoomFactor)) * m_settings.m_fftSize;
-    int fftMax = (m_frequencyZoomFactor == 1.0f) ?
-        m_settings.m_fftSize : (m_frequencyZoomPos + (0.5f / m_frequencyZoomFactor)) * m_settings.m_fftSize;
+    int fftMin = (m_settings.m_frequencyZoomFactor == 1.0f) ?
+        0 : (m_settings.m_frequencyZoomPos - (0.5f / m_settings.m_frequencyZoomFactor)) * m_settings.m_fftSize;
+    int fftMax = (m_settings.m_frequencyZoomFactor == 1.0f) ?
+        m_settings.m_fftSize : (m_settings.m_frequencyZoomPos + (0.5f / m_settings.m_frequencyZoomFactor)) * m_settings.m_fftSize;
     copy.assign(m_psd.begin() + fftMin, m_psd.begin() + fftMax);
 }
 
@@ -832,8 +830,8 @@ bool SpectrumVis::handleMessage(const Message& message)
     else if (MsgFrequencyZooming::match(message))
     {
         MsgFrequencyZooming& cmd = (MsgFrequencyZooming&) message;
-        m_frequencyZoomFactor = cmd.getFrequencyZoomFactor();
-        m_frequencyZoomPos = cmd.getFrequencyZoomPos();
+        m_settings.m_frequencyZoomFactor = cmd.getFrequencyZoomFactor();
+        m_settings.m_frequencyZoomPos = cmd.getFrequencyZoomPos();
         return true;
     }
 	else

--- a/sdrbase/dsp/spectrumvis.h
+++ b/sdrbase/dsp/spectrumvis.h
@@ -228,9 +228,6 @@ private:
 	int m_fftBufferFill;
 	bool m_needMoreSamples;
 
-    float m_frequencyZoomFactor;
-    float m_frequencyZoomPos;
-
 	Real m_scalef;
 	GLSpectrumInterface* m_glSpectrum;
     WSSpectrum m_wsSpectrum;

--- a/sdrgui/gui/glspectrum.h
+++ b/sdrgui/gui/glspectrum.h
@@ -110,6 +110,7 @@ public:
     void setCalibrationInterpMode(SpectrumSettings::CalibrationInterpolationMode mode) { m_spectrum->setCalibrationInterpMode(mode); }
     void setIsDeviceSpectrum(bool isDeviceSpectrum) { m_spectrum->setIsDeviceSpectrum(isDeviceSpectrum); }
     bool isDeviceSpectrum() const { return m_spectrum->isDeviceSpectrum(); }
+    void setFrequencyZooming(float frequencyZoomFactor, float frequencyZoomPos) { m_spectrum->setFrequencyZooming(frequencyZoomFactor, frequencyZoomPos); }
 
 private:
     QSplitter *m_splitter;

--- a/sdrgui/gui/glspectrumgui.cpp
+++ b/sdrgui/gui/glspectrumgui.cpp
@@ -146,6 +146,7 @@ bool GLSpectrumGUI::deserialize(const QByteArray& data)
     {
         m_glSpectrum->setHistogramMarkers(m_settings.getHistogramMarkers());
         m_glSpectrum->setWaterfallMarkers(m_settings.getWaterfallMarkers());
+        m_glSpectrum->setFrequencyZooming(m_settings.m_frequencyZoomFactor, m_settings.m_frequencyZoomPos);
         setAveragingCombo();
         displaySettings(); // ends with blockApplySettings(false)
         applySettings();
@@ -997,6 +998,13 @@ bool GLSpectrumGUI::handleMessage(const Message& message)
         if (m_markersDialog) {
             m_markersDialog->updateWaterfallMarkersDisplay();
         }
+        return true;
+    }
+    else if (SpectrumVis::MsgFrequencyZooming::match(message))
+    {
+        const SpectrumVis::MsgFrequencyZooming& report = (const SpectrumVis::MsgFrequencyZooming&) message;
+        m_settings.m_frequencyZoomFactor = report.getFrequencyZoomFactor();
+        m_settings.m_frequencyZoomPos = report.getFrequencyZoomPos();
         return true;
     }
     else if (SpectrumVis::MsgStartStop::match(message))

--- a/sdrgui/gui/glspectrumview.cpp
+++ b/sdrgui/gui/glspectrumview.cpp
@@ -53,7 +53,7 @@ MESSAGE_CLASS_DEFINITION(GLSpectrumView::MsgReportCalibrationShift, Message)
 MESSAGE_CLASS_DEFINITION(GLSpectrumView::MsgReportHistogramMarkersChange, Message)
 MESSAGE_CLASS_DEFINITION(GLSpectrumView::MsgReportWaterfallMarkersChange, Message)
 
-const float GLSpectrumView::m_maxFrequencyZoom = 10.0f;
+const float GLSpectrumView::m_maxFrequencyZoom = 50.0f;
 const float GLSpectrumView::m_annotationMarkerHeight = 20.0f;
 
 GLSpectrumView::GLSpectrumView(QWidget* parent) :
@@ -4541,16 +4541,27 @@ void GLSpectrumView::resetFrequencyZoom()
 
 void GLSpectrumView::updateFFTLimits()
 {
-    if (!m_spectrumVis) {
-        return;
+    if (m_spectrumVis)
+    {
+        m_spectrumVis->getInputMessageQueue()->push(SpectrumVis::MsgFrequencyZooming::create(
+            m_frequencyZoomFactor, m_frequencyZoomPos
+        ));
     }
 
-    SpectrumVis::MsgFrequencyZooming *msg = SpectrumVis::MsgFrequencyZooming::create(
-        m_frequencyZoomFactor, m_frequencyZoomPos
-    );
+    if (m_messageQueueToGUI)
+    {
+        m_messageQueueToGUI->push(SpectrumVis::MsgFrequencyZooming::create(
+            m_frequencyZoomFactor, m_frequencyZoomPos
+        ));
+    }
 
-    m_spectrumVis->getInputMessageQueue()->push(msg);
     m_changesPending = true;
+}
+
+void GLSpectrumView::setFrequencyZooming(float frequencyZoomFactor, float frequencyZoomPos)
+{
+    m_frequencyZoomFactor = frequencyZoomFactor;
+    frequencyZoom(frequencyZoomPos);
 }
 
 void GLSpectrumView::setFrequencyScale()

--- a/sdrgui/gui/glspectrumview.h
+++ b/sdrgui/gui/glspectrumview.h
@@ -236,6 +236,7 @@ public:
     void setCalibrationInterpMode(SpectrumSettings::CalibrationInterpolationMode mode);
     void setIsDeviceSpectrum(bool isDeviceSpectrum) { m_isDeviceSpectrum = isDeviceSpectrum; }
     bool isDeviceSpectrum() const { return m_isDeviceSpectrum; }
+    void setFrequencyZooming(float frequencyZoomFactor, float frequencyZoomPos);
 
 private:
     struct ChannelMarkerState {


### PR DESCRIPTION
Spectrum: Enable save/restore of zoom settings, as requested on the forum.

Also, increase max zoom to 50x, as is useful for larger FFT sizes.