### PR TITLE
Fix package rebuild in pbuilder

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -56,7 +56,21 @@ Build-Depends: debhelper (>= 9),
  libuhd-dev,
  libhamlib-dev,
  zlib1g-dev,
- libunwind-dev
+ libunwind-dev,
+ git,
+ ca-certificates,
+ libavahi-client-dev,
+ libavahi-common-dev,
+ libaio-dev,
+ xxd,
+ libpostproc-dev,
+ libcodec2-dev,
+ libbladerf-dev,
+ libsoapysdr-dev,
+ libiio-dev,
+ python3-mako,
+ python3-cheetah,
+ python3-numpy
 # TODO:
 #   - more dependencies based on version; newer has more devices
 #   - manage dependencies not present upstream


### PR DESCRIPTION
Update control with missing dependencies from Github workflow for Linux and ensure clean rebuild using pbuilder with `USENETWORK=yes`.