### PR TITLE
NAVTEX: Flush CSV after each message

### DIFF
--- a/plugins/channelrx/demodnavtex/navtexdemod.cpp
+++ b/plugins/channelrx/demodnavtex/navtexdemod.cpp
@@ -217,6 +217,7 @@ bool NavtexDemod::handleMessage(const Message& cmd)
                     << report.getErrors() << ","
                     << report.getRSSI()
                     << "\n";
+                m_logStream.flush();
             }
         }
 


### PR DESCRIPTION
I'd like to watch for Navtex messages in an external application, though the file is only flushed whenever I restart SDRAngel or change the CSV writing settings. I'd like it to write out after each message so that I can continuously watch for new messages.

As such, I've added a flush after writing a message to the log file. This is not a huge burden on the filesystem as messages typically take around a minute to be received, and no less than 10 seconds.