### PR TITLE
Fix choppy audio for several demods

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemod.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemod.cpp
@@ -54,6 +54,7 @@ ADSBDemod::ADSBDemod(DeviceAPI *devieAPI) :
         ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSink),
         m_deviceAPI(devieAPI),
         m_basebandSampleRate(0),
+        m_centerFrequency(0),
         m_targetAzElValid(false),
         m_targetAzimuth(0.0f),
         m_targetElevation(0.0f)
@@ -134,15 +135,14 @@ void ADSBDemod::start()
 {
     qDebug() << "ADSBDemod::start";
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
-
     m_worker->reset();
     m_worker->startWork();
     m_basebandSink->reset();
     m_basebandSink->startWork();
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     ADSBDemodWorker::MsgConfigureADSBDemodWorker *msg = ADSBDemodWorker::MsgConfigureADSBDemodWorker::create(m_settings, QStringList(), true);
     m_worker->getInputMessageQueue()->push(msg);
@@ -174,6 +174,7 @@ bool ADSBDemod::handleMessage(const Message& cmd)
     {
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         // Forward to the sink
         DSPSignalNotification* rep = new DSPSignalNotification(notif); // make a copy
         qDebug() << "ADSBDemod::handleMessage: DSPSignalNotification";

--- a/plugins/channelrx/demodadsb/adsbdemod.h
+++ b/plugins/channelrx/demodadsb/adsbdemod.h
@@ -188,6 +188,7 @@ private:
     ADSBDemodBaseband* m_basebandSink;
     ADSBDemodSettings m_settings;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
 
     bool m_targetAzElValid;
     float m_targetAzimuth;

--- a/plugins/channelrx/demodam/amdemod.cpp
+++ b/plugins/channelrx/demodam/amdemod.cpp
@@ -57,6 +57,7 @@ AMDemod::AMDemod(DeviceAPI *deviceAPI) :
         m_basebandSink(nullptr),
         m_running(false),
         m_basebandSampleRate(0),
+        m_centerFrequency(0),
         m_lastTs(0)
 {
     setObjectName(m_channelId);

--- a/plugins/channelrx/demodchirpchat/chirpchatdemod.cpp
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemod.cpp
@@ -61,6 +61,7 @@ ChirpChatDemod::ChirpChatDemod(DeviceAPI* deviceAPI) :
         m_running(false),
         m_spectrumVis(SDR_RX_SCALEF),
         m_basebandSampleRate(0),
+        m_centerFrequency(0),
         m_lastMsgSignalDb(0.0),
         m_lastMsgNoiseDb(0.0),
         m_lastMsgSyncWord(0),
@@ -158,12 +159,11 @@ void ChirpChatDemod::start()
     QObject::connect(m_thread, &QThread::finished, m_basebandSink, &QObject::deleteLater);
     QObject::connect(m_thread, &QThread::finished, m_thread, &QThread::deleteLater);
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
-
     m_basebandSink->reset();
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     SpectrumSettings spectrumSettings = m_spectrumVis.getSettings();
     spectrumSettings.m_ssb = true;
@@ -360,6 +360,7 @@ bool ChirpChatDemod::handleMessage(const Message& cmd)
     {
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         qDebug() << "ChirpChatDemod::handleMessage: DSPSignalNotification: m_basebandSampleRate: " << m_basebandSampleRate;
 
         // Forward to the sink

--- a/plugins/channelrx/demodchirpchat/chirpchatdemod.h
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemod.h
@@ -148,6 +148,7 @@ private:
     ChirpChatDemodSettings m_settings;
     SpectrumVis m_spectrumVis;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
     float m_lastMsgSignalDb;
     float m_lastMsgNoiseDb;
     int m_lastMsgSyncWord;

--- a/plugins/channelrx/demoddatv/datvdemod.cpp
+++ b/plugins/channelrx/demoddatv/datvdemod.cpp
@@ -45,7 +45,8 @@ MESSAGE_CLASS_DEFINITION(DATVDemod::MsgConfigureDATVDemod, Message)
 DATVDemod::DATVDemod(DeviceAPI *deviceAPI) :
     ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSink),
     m_deviceAPI(deviceAPI),
-    m_basebandSampleRate(0)
+    m_basebandSampleRate(0),
+    m_centerFrequency(0)
 {
     qDebug("DATVDemod::DATVDemod");
     setObjectName(m_channelId);
@@ -115,13 +116,12 @@ void DATVDemod::start()
 {
 	qDebug("DATVDemod::start");
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
-
     m_basebandSink->reset();
     m_basebandSink->startWork();
     m_thread.start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     DATVDemodBaseband::MsgConfigureDATVDemodBaseband *msg = DATVDemodBaseband::MsgConfigureDATVDemodBaseband::create(QStringList(), m_settings, true);
     m_basebandSink->getInputMessageQueue()->push(msg);
@@ -149,6 +149,7 @@ bool DATVDemod::handleMessage(const Message& cmd)
     {
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate(); // store for init at start
+        m_centerFrequency = notif.getCenterFrequency();
         qDebug() << "DATVDemod::handleMessage: DSPSignalNotification" << m_basebandSampleRate;
 
         // Forward to the sink

--- a/plugins/channelrx/demoddatv/datvdemod.h
+++ b/plugins/channelrx/demoddatv/datvdemod.h
@@ -169,6 +169,7 @@ private:
     DATVDemodBaseband* m_basebandSink;
     DATVDemodSettings m_settings;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;
 

--- a/plugins/channelrx/demoddsd/dsddemod.cpp
+++ b/plugins/channelrx/demoddsd/dsddemod.cpp
@@ -63,6 +63,7 @@ DSDDemod::DSDDemod(DeviceAPI *deviceAPI) :
         m_deviceAPI(deviceAPI),
         m_running(false),
         m_basebandSampleRate(0),
+        m_centerFrequency(0),
         m_scopeXYSink(nullptr)
 {
     qDebug("DSDDemod::DSDDemod");
@@ -176,12 +177,12 @@ void DSDDemod::start()
         &QThread::deleteLater
     );
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
     m_basebandSink->setScopeXYSink(m_scopeXYSink);
 
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     DSDDemodBaseband::MsgConfigureDSDDemodBaseband *msg = DSDDemodBaseband::MsgConfigureDSDDemodBaseband::create(QStringList(), m_settings, true);
     m_basebandSink->getInputMessageQueue()->push(msg);
@@ -229,6 +230,7 @@ bool DSDDemod::handleMessage(const Message& cmd)
         qDebug() << "DSDDemod::handleMessage: DSPSignalNotification";
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         // Forward to the sink
         if (m_running) {
             m_basebandSink->getInputMessageQueue()->push(new DSPSignalNotification(notif));

--- a/plugins/channelrx/demoddsd/dsddemod.h
+++ b/plugins/channelrx/demoddsd/dsddemod.h
@@ -191,6 +191,7 @@ private:
     bool m_running;
 	DSDDemodSettings m_settings;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
     QHash<Feature*, DSDDemodSettings::AvailableAMBEFeature> m_availableAMBEFeatures;
     BasebandSampleSink *m_scopeXYSink;
     QNetworkAccessManager *m_networkManager;

--- a/plugins/channelrx/demodfreedv/freedvdemod.cpp
+++ b/plugins/channelrx/demodfreedv/freedvdemod.cpp
@@ -48,7 +48,9 @@ const char* const FreeDVDemod::m_channelId = "FreeDVDemod";
 FreeDVDemod::FreeDVDemod(DeviceAPI *deviceAPI) :
         ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSink),
         m_deviceAPI(deviceAPI),
-        m_spectrumVis(SDR_RX_SCALEF)
+        m_spectrumVis(SDR_RX_SCALEF),
+        m_basebandSampleRate(0),
+        m_centerFrequency(0)
 {
 	setObjectName(m_channelId);
 
@@ -120,12 +122,11 @@ void FreeDVDemod::start()
 {
     qDebug() << "FreeDVDemod::start";
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
-
     m_basebandSink->reset();
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     SpectrumSettings spectrumSettings = m_spectrumVis.getSettings();
     spectrumSettings.m_ssb = true;
@@ -163,6 +164,7 @@ bool FreeDVDemod::handleMessage(const Message& cmd)
     {
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         // Forward to the sink
         DSPSignalNotification* rep = new DSPSignalNotification(notif); // make a copy
         qDebug() << "FreeDVDemod::handleMessage: DSPSignalNotification";

--- a/plugins/channelrx/demodfreedv/freedvdemod.h
+++ b/plugins/channelrx/demodfreedv/freedvdemod.h
@@ -168,6 +168,7 @@ private:
     FreeDVDemodSettings m_settings;
     SpectrumVis m_spectrumVis;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
 
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channelrx/demodft8/ft8demod.cpp
+++ b/plugins/channelrx/demodft8/ft8demod.cpp
@@ -58,7 +58,8 @@ FT8Demod::FT8Demod(DeviceAPI *deviceAPI) :
         m_deviceAPI(deviceAPI),
         m_running(false),
         m_spectrumVis(SDR_RX_SCALEF),
-        m_basebandSampleRate(0)
+        m_basebandSampleRate(0),
+        m_centerFrequency(0)
 {
 	setObjectName(m_channelId);
 
@@ -181,11 +182,10 @@ void FT8Demod::start()
         &QThread::deleteLater
     );
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
-
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     FT8DemodBaseband::MsgConfigureFT8DemodBaseband *msg = FT8DemodBaseband::MsgConfigureFT8DemodBaseband::create(QStringList(), m_settings, true);
     m_basebandSink->getInputMessageQueue()->push(msg);
@@ -223,6 +223,7 @@ bool FT8Demod::handleMessage(const Message& cmd)
         qDebug() << "FT8Demod::handleMessage: DSPSignalNotification";
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         // Forward to the sink
         if (m_running) {
             m_basebandSink->getInputMessageQueue()->push(new DSPSignalNotification(notif));

--- a/plugins/channelrx/demodft8/ft8demod.h
+++ b/plugins/channelrx/demodft8/ft8demod.h
@@ -162,6 +162,7 @@ private:
     FT8DemodSettings m_settings;
     SpectrumVis m_spectrumVis;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
 
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channelrx/demodm17/m17demod.cpp
+++ b/plugins/channelrx/demodm17/m17demod.cpp
@@ -59,6 +59,7 @@ M17Demod::M17Demod(DeviceAPI *deviceAPI) :
         m_basebandSink(nullptr),
         m_running(false),
         m_basebandSampleRate(0),
+        m_centerFrequency(0),
         m_scopeXYSink(nullptr)
 {
     qDebug("M17Demod::M17Demod");
@@ -140,13 +141,13 @@ void M17Demod::start()
     QObject::connect(m_thread, &QThread::finished, m_basebandSink, &QObject::deleteLater);
     QObject::connect(m_thread, &QThread::finished, m_thread, &QThread::deleteLater);
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
     m_basebandSink->setScopeXYSink(m_scopeXYSink);
 
     m_basebandSink->reset();
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     M17DemodBaseband::MsgConfigureM17DemodBaseband *msg = M17DemodBaseband::MsgConfigureM17DemodBaseband::create(m_settings, QStringList(), true);
     m_basebandSink->getInputMessageQueue()->push(msg);
@@ -182,6 +183,7 @@ bool M17Demod::handleMessage(const Message& cmd)
     {
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         qDebug() << "M17Demod::handleMessage: DSPSignalNotification";
 
         // Forward to the sink

--- a/plugins/channelrx/demodm17/m17demod.h
+++ b/plugins/channelrx/demodm17/m17demod.h
@@ -286,6 +286,7 @@ private:
     bool m_running;
 	M17DemodSettings m_settings;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
     BasebandSampleSink *m_scopeXYSink;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channelrx/demodnfm/nfmdemod.cpp
+++ b/plugins/channelrx/demodnfm/nfmdemod.cpp
@@ -56,7 +56,8 @@ NFMDemod::NFMDemod(DeviceAPI *devieAPI) :
         ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSink),
         m_deviceAPI(devieAPI),
         m_running(false),
-        m_basebandSampleRate(0)
+        m_basebandSampleRate(0),
+        m_centerFrequency(0)
 {
     qDebug("NFMDemod::NFMDemod");
 	setObjectName(m_channelId);
@@ -149,11 +150,10 @@ void NFMDemod::start()
         &QThread::deleteLater
     );
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
-
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     NFMDemodBaseband::MsgConfigureNFMDemodBaseband *msg = NFMDemodBaseband::MsgConfigureNFMDemodBaseband::create(QStringList(), m_settings, true);
     m_basebandSink->getInputMessageQueue()->push(msg);
@@ -189,6 +189,7 @@ bool NFMDemod::handleMessage(const Message& cmd)
         qDebug() << "NFMDemod::handleMessage: DSPSignalNotification";
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         // Forward to the sink if any
         if (m_running) {
             m_basebandSink->getInputMessageQueue()->push(new DSPSignalNotification(notif));

--- a/plugins/channelrx/demodnfm/nfmdemod.h
+++ b/plugins/channelrx/demodnfm/nfmdemod.h
@@ -152,6 +152,7 @@ private:
     bool m_running;
 	NFMDemodSettings m_settings;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
 
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channelrx/demodssb/ssbdemod.cpp
+++ b/plugins/channelrx/demodssb/ssbdemod.cpp
@@ -58,7 +58,8 @@ SSBDemod::SSBDemod(DeviceAPI *deviceAPI) :
         m_basebandSink(nullptr),
         m_running(false),
         m_spectrumVis(SDR_RX_SCALEF),
-        m_basebandSampleRate(0)
+        m_basebandSampleRate(0),
+        m_centerFrequency(0)
 {
 	setObjectName(m_channelId);
 
@@ -166,11 +167,10 @@ void SSBDemod::start()
         &QThread::deleteLater
     );
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
-
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     SSBDemodBaseband::MsgConfigureSSBDemodBaseband *msg = SSBDemodBaseband::MsgConfigureSSBDemodBaseband::create(QStringList(), m_settings, true);
     m_basebandSink->getInputMessageQueue()->push(msg);
@@ -208,6 +208,7 @@ bool SSBDemod::handleMessage(const Message& cmd)
         qDebug() << "SSBDemod::handleMessage: DSPSignalNotification";
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         // Forward to the sink
         if (m_running) {
             m_basebandSink->getInputMessageQueue()->push(new DSPSignalNotification(notif));

--- a/plugins/channelrx/demodssb/ssbdemod.h
+++ b/plugins/channelrx/demodssb/ssbdemod.h
@@ -160,6 +160,7 @@ private:
     SSBDemodSettings m_settings;
     SpectrumVis m_spectrumVis;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
 
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channelrx/demodwfm/wfmdemod.cpp
+++ b/plugins/channelrx/demodwfm/wfmdemod.cpp
@@ -58,7 +58,8 @@ WFMDemod::WFMDemod(DeviceAPI* deviceAPI) :
         m_thread(nullptr),
         m_basebandSink(nullptr),
         m_running(false),
-        m_basebandSampleRate(0)
+        m_basebandSampleRate(0),
+        m_centerFrequency(0)
 {
 	setObjectName(m_channelId);
 	applySettings(QStringList(), m_settings, true);
@@ -138,12 +139,11 @@ void WFMDemod::start()
     QObject::connect(m_thread, &QThread::finished, m_basebandSink, &QObject::deleteLater);
     QObject::connect(m_thread, &QThread::finished, m_thread, &QThread::deleteLater);
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
-
     m_basebandSink->reset();
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     WFMDemodBaseband::MsgConfigureWFMDemodBaseband *msg = WFMDemodBaseband::MsgConfigureWFMDemodBaseband::create(QStringList(), m_settings, true);
     m_basebandSink->getInputMessageQueue()->push(msg);
@@ -178,6 +178,7 @@ bool WFMDemod::handleMessage(const Message& cmd)
     {
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         qDebug() << "WFMDemod::handleMessage: DSPSignalNotification";
 
         // Forward to the sink

--- a/plugins/channelrx/demodwfm/wfmdemod.h
+++ b/plugins/channelrx/demodwfm/wfmdemod.h
@@ -153,6 +153,7 @@ private:
     bool m_running;
     WFMDemodSettings m_settings;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
 
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channelrx/freqtracker/freqtracker.cpp
+++ b/plugins/channelrx/freqtracker/freqtracker.cpp
@@ -56,7 +56,8 @@ FreqTracker::FreqTracker(DeviceAPI *deviceAPI) :
         m_basebandSink(nullptr),
         m_running(false),
         m_spectrumVis(SDR_RX_SCALEF),
-        m_basebandSampleRate(0)
+        m_basebandSampleRate(0),
+        m_centerFrequency(0)
 {
     setObjectName(m_channelId);
 	applySettings(QStringList(), m_settings, true);
@@ -137,12 +138,11 @@ void FreqTracker::start()
     QObject::connect(m_thread, &QThread::finished, m_basebandSink, &QObject::deleteLater);
     QObject::connect(m_thread, &QThread::finished, m_thread, &QThread::deleteLater);
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
-
     m_basebandSink->reset();
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     FreqTrackerBaseband::MsgConfigureFreqTrackerBaseband *msg = FreqTrackerBaseband::MsgConfigureFreqTrackerBaseband::create(QStringList(), m_settings, true);
     m_basebandSink->getInputMessageQueue()->push(msg);
@@ -168,6 +168,7 @@ bool FreqTracker::handleMessage(const Message& cmd)
     {
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         qDebug() << "FreqTracker::handleMessage: DSPSignalNotification";
 
         // Forward to the sink

--- a/plugins/channelrx/freqtracker/freqtracker.h
+++ b/plugins/channelrx/freqtracker/freqtracker.h
@@ -157,6 +157,7 @@ private:
     FreqTrackerSettings m_settings;
     SpectrumVis m_spectrumVis;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
     static const int m_udpBlockSize;
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channelrx/remotesink/remotesink.cpp
+++ b/plugins/channelrx/remotesink/remotesink.cpp
@@ -56,7 +56,8 @@ RemoteSink::RemoteSink(DeviceAPI *deviceAPI) :
         m_basebandSink(nullptr),
         m_running(false),
         m_frequencyOffset(0),
-        m_basebandSampleRate(0)
+        m_basebandSampleRate(0),
+        m_centerFrequency(0)
 {
     setObjectName(m_channelId);
     updateWithDeviceData();
@@ -141,9 +142,8 @@ void RemoteSink::start()
     m_basebandSink->startWork();
     m_thread->start();
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     RemoteSinkBaseband::MsgConfigureRemoteSinkBaseband *msg = RemoteSinkBaseband::MsgConfigureRemoteSinkBaseband::create(QStringList(), m_settings, true);
     m_basebandSink->getInputMessageQueue()->push(msg);
@@ -178,6 +178,7 @@ bool RemoteSink::handleMessage(const Message& cmd)
     {
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         qDebug() << "RemoteSink::handleMessage: DSPSignalNotification: m_basebandSampleRate:" << m_basebandSampleRate;
         calculateFrequencyOffset();
         updateWithDeviceData(); // Device center frequency and/or sample rate has changed

--- a/plugins/channelrx/remotesink/remotesink.h
+++ b/plugins/channelrx/remotesink/remotesink.h
@@ -137,6 +137,7 @@ private:
 
     int64_t m_frequencyOffset;
     int m_basebandSampleRate;
+    qint64 m_centerFrequency;
 
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channelrx/remotetcpsink/remotetcpsink.cpp
+++ b/plugins/channelrx/remotetcpsink/remotetcpsink.cpp
@@ -54,6 +54,7 @@ RemoteTCPSink::RemoteTCPSink(DeviceAPI *deviceAPI) :
         ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSink),
         m_deviceAPI(deviceAPI),
         m_basebandSampleRate(0),
+        m_centerFrequency(0),
         m_clients(0),
         m_removeRequest(nullptr)
 {
@@ -145,9 +146,8 @@ void RemoteTCPSink::start()
     m_basebandSink->startWork();
     m_thread.start();
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     MsgConfigureRemoteTCPSink* msg = MsgConfigureRemoteTCPSink::create(m_settings, QStringList(), true, true);
     m_basebandSink->getInputMessageQueue()->push(msg);
@@ -180,6 +180,7 @@ bool RemoteTCPSink::handleMessage(const Message& cmd)
     {
         const DSPSignalNotification& notif = (const DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         qDebug() << "RemoteTCPSink::handleMessage: DSPSignalNotification: m_basebandSampleRate:" << m_basebandSampleRate;
 
         // Forward to the sink

--- a/plugins/channelrx/remotetcpsink/remotetcpsink.h
+++ b/plugins/channelrx/remotetcpsink/remotetcpsink.h
@@ -288,6 +288,7 @@ private:
     RemoteTCPSinkSettings m_settings;
 
     int m_basebandSampleRate;
+    qint64 m_centerFrequency;
 
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;

--- a/plugins/channelrx/udpsink/udpsink.cpp
+++ b/plugins/channelrx/udpsink/udpsink.cpp
@@ -49,6 +49,8 @@ UDPSink::UDPSink(DeviceAPI *deviceAPI) :
         ChannelAPI(m_channelIdURI, ChannelAPI::StreamSingleSink),
         m_deviceAPI(deviceAPI),
         m_spectrumVis(SDR_RX_SCALEF),
+        m_basebandSampleRate(0),
+        m_centerFrequency(0),
         m_channelSampleRate(48000),
         m_channelFrequencyOffset(0)
 {
@@ -122,12 +124,11 @@ void UDPSink::start()
 {
     qDebug() << "UDPSink::start";
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
-
     m_basebandSink->reset();
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 }
 
 void UDPSink::stop()
@@ -152,6 +153,7 @@ bool UDPSink::handleMessage(const Message& cmd)
     {
         DSPSignalNotification& notif = (DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         // Forward to the sink
         DSPSignalNotification* rep = new DSPSignalNotification(notif); // make a copy
         qDebug() << "UDPSink::handleMessage: DSPSignalNotification";

--- a/plugins/channelrx/udpsink/udpsink.h
+++ b/plugins/channelrx/udpsink/udpsink.h
@@ -150,6 +150,7 @@ protected:
     UDPSinkSettings m_settings;
     SpectrumVis m_spectrumVis;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
 
     int m_channelSampleRate;
     int m_channelFrequencyOffset;

--- a/plugins/channelrx/wdsprx/wdsprx.cpp
+++ b/plugins/channelrx/wdsprx/wdsprx.cpp
@@ -58,7 +58,8 @@ WDSPRx::WDSPRx(DeviceAPI *deviceAPI) :
         m_basebandSink(nullptr),
         m_running(false),
         m_spectrumVis(SDR_RX_SCALEF),
-        m_basebandSampleRate(0)
+        m_basebandSampleRate(0),
+        m_centerFrequency(0)
 {
 	setObjectName(m_channelId);
 
@@ -168,11 +169,10 @@ void WDSPRx::start()
         &QThread::deleteLater
     );
 
-    if (m_basebandSampleRate != 0) {
-        m_basebandSink->setBasebandSampleRate(m_basebandSampleRate);
-    }
-
     m_thread->start();
+
+    DSPSignalNotification *dspMsg = new DSPSignalNotification(m_basebandSampleRate, m_centerFrequency);
+    m_basebandSink->getInputMessageQueue()->push(dspMsg);
 
     WDSPRxBaseband::MsgConfigureWDSPRxBaseband *msg = WDSPRxBaseband::MsgConfigureWDSPRxBaseband::create(QStringList(), m_settings, true);
     m_basebandSink->getInputMessageQueue()->push(msg);
@@ -210,6 +210,7 @@ bool WDSPRx::handleMessage(const Message& cmd)
         qDebug() << "WDSPRx::handleMessage: DSPSignalNotification";
         auto& notif = (const DSPSignalNotification&) cmd;
         m_basebandSampleRate = notif.getSampleRate();
+        m_centerFrequency = notif.getCenterFrequency();
         // Forward to the sink
         if (m_running) {
             m_basebandSink->getInputMessageQueue()->push(new DSPSignalNotification(notif));

--- a/plugins/channelrx/wdsprx/wdsprx.h
+++ b/plugins/channelrx/wdsprx/wdsprx.h
@@ -160,6 +160,7 @@ private:
     WDSPRxSettings m_settings;
     SpectrumVis m_spectrumVis;
     int m_basebandSampleRate; //!< stored from device message used when starting baseband sink
+    qint64 m_centerFrequency;
 
     QNetworkAccessManager *m_networkManager;
     QNetworkRequest m_networkRequest;


### PR DESCRIPTION
Currently, when using NFM or SSB demods with FileInputDevice with a file with >1M sample rate (possibly other devices too), the audio can be choppy if the demod exists before start button is pressed. This is because the demod's baseband FIFOs are initially sized assuming a sample rate of 48k, and thus are too small. 

To fix, we send DSPSignalNotification to the baseband when started, rather than calling m_basebandSink->setBasebandSampleRate, as the former results in the FIFO being resized, whereas the latter doesn't. Several other demods allready work that way.

For #2661 - although there may be another issue too.