### PR TITLE
Fix RollupState::serialize for Qt 6.

### DIFF
--- a/sdrbase/settings/rollupstate.cpp
+++ b/sdrbase/settings/rollupstate.cpp
@@ -33,7 +33,7 @@ QByteArray RollupState::serialize() const
     QDataStream stream(&state, QIODevice::WriteOnly);
     stream << VersionMarker;
     stream << m_version;
-    stream << m_childrenStates.size();
+    stream << (int) m_childrenStates.size();
 
     for (const auto &child : m_childrenStates)
     {


### PR DESCRIPTION
Rollup state isn't restored with Qt 6 builds, as per #2462

This is because QList::size is qsizetype (64-bit) on Qt 6, whereas it was int for Qt 5, and the deserialization function expects an int.
