### PR TITLE
NFMMod: Fix center frequency display.

### DIFF
--- a/plugins/channeltx/modnfm/nfmmod.cpp
+++ b/plugins/channeltx/modnfm/nfmmod.cpp
@@ -281,10 +281,10 @@ bool NFMMod::handleMessage(const Message& cmd)
             auto* rep = new DSPSignalNotification(notif); // make a copy
             qDebug() << "NFMMod::handleMessage: DSPSignalNotification";
             m_basebandSource->getInputMessageQueue()->push(rep);
-            // Forward to GUI if any
-            if (getMessageQueueToGUI()) {
-                getMessageQueueToGUI()->push(new DSPSignalNotification(notif));
-            }
+        }
+        // Forward to GUI if any
+        if (getMessageQueueToGUI()) {
+            getMessageQueueToGUI()->push(new DSPSignalNotification(notif));
         }
 
         return true;


### PR DESCRIPTION
Fix center frequency display in NFM modulator, as some times it only shows the offset.