### PR TITLE
NFMDemod: Correct FM scaling.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -49,22 +49,21 @@
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        //"CMAKE_BUILD_TYPE": "Debug",
         "DEBUG_OUTPUT": "ON",
         "RX_SAMPLE_24BIT": "ON",
         "ARCH_OPT": "SSE4_2",
         "HIDE_CONSOLE": "OFF",
-        "ENABLE_AIRSPY": "OFF",
+        "ENABLE_AIRSPY": "ON",
         "ENABLE_AIRSPYHF": "ON",
-        "ENABLE_BLADERF": "OFF",
+        "ENABLE_BLADERF": "ON",
         "ENABLE_HACKRF": "ON",
-        "ENABLE_IIO": "OFF",
+        "ENABLE_IIO": "ON",
         "ENABLE_MIRISDR": "OFF",
-        "ENABLE_PERSEUS": "OFF",
+        "ENABLE_PERSEUS": "ON",
         "ENABLE_RTLSDR": "ON",
         "ENABLE_SDRPLAY": "ON",
         "ENABLE_SOAPYSDR": "ON",
-        "ENABLE_XTRX": "OFF",
+        "ENABLE_XTRX": "ON",
         "ENABLE_USRP": "ON",
         "BUILD_SERVER": "OFF",
         "CMAKE_PREFIX_PATH": "C:/Qt/5.15.2/msvc2019_64;C:/Applications/boost_1_81_0"
@@ -92,8 +91,7 @@
       "binaryDir": "${sourceDir}/build-qt6",
       "cacheVariables": {
         "ENABLE_QT6": "ON",
-        "CMAKE_PREFIX_PATH": "C:/Qt/6.10.2/msvc2022_64;C:/Applications/boost_1_81_0",
-        "ENABLE_PROFILER": "ON"
+        "CMAKE_PREFIX_PATH": "C:/Qt/6.7.3/msvc2022_64;C:/Applications/boost_1_81_0"
       }
     }
   ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -49,21 +49,22 @@
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        //"CMAKE_BUILD_TYPE": "Debug",
         "DEBUG_OUTPUT": "ON",
         "RX_SAMPLE_24BIT": "ON",
         "ARCH_OPT": "SSE4_2",
         "HIDE_CONSOLE": "OFF",
-        "ENABLE_AIRSPY": "ON",
+        "ENABLE_AIRSPY": "OFF",
         "ENABLE_AIRSPYHF": "ON",
-        "ENABLE_BLADERF": "ON",
+        "ENABLE_BLADERF": "OFF",
         "ENABLE_HACKRF": "ON",
-        "ENABLE_IIO": "ON",
+        "ENABLE_IIO": "OFF",
         "ENABLE_MIRISDR": "OFF",
-        "ENABLE_PERSEUS": "ON",
+        "ENABLE_PERSEUS": "OFF",
         "ENABLE_RTLSDR": "ON",
         "ENABLE_SDRPLAY": "ON",
         "ENABLE_SOAPYSDR": "ON",
-        "ENABLE_XTRX": "ON",
+        "ENABLE_XTRX": "OFF",
         "ENABLE_USRP": "ON",
         "BUILD_SERVER": "OFF",
         "CMAKE_PREFIX_PATH": "C:/Qt/5.15.2/msvc2019_64;C:/Applications/boost_1_81_0"
@@ -91,7 +92,8 @@
       "binaryDir": "${sourceDir}/build-qt6",
       "cacheVariables": {
         "ENABLE_QT6": "ON",
-        "CMAKE_PREFIX_PATH": "C:/Qt/6.7.3/msvc2022_64;C:/Applications/boost_1_81_0"
+        "CMAKE_PREFIX_PATH": "C:/Qt/6.10.2/msvc2022_64;C:/Applications/boost_1_81_0",
+        "ENABLE_PROFILER": "ON"
       }
     }
   ],

--- a/plugins/channelrx/demodais/aisdemodgui.cpp
+++ b/plugins/channelrx/demodais/aisdemodgui.cpp
@@ -575,7 +575,7 @@ void AISDemodGUI::on_rfBW_valueChanged(int value)
 
 void AISDemodGUI::on_fmDev_valueChanged(int value)
 {
-    ui->fmDevText->setText(QString("%1k").arg(value / 10.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(value / 10.0, 0, 'f', 1));
     m_settings.m_fmDeviation = value * 100.0;
     applySettings(QStringList({"fmDeviation"}));
 }
@@ -894,7 +894,7 @@ void AISDemodGUI::displaySettings()
     ui->rfBWText->setText(QString("%1k").arg(m_settings.m_rfBandwidth / 1000.0, 0, 'f', 1));
     ui->rfBW->setValue(m_settings.m_rfBandwidth / 100.0);
 
-    ui->fmDevText->setText(QString("%1k").arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
     ui->fmDev->setValue(m_settings.m_fmDeviation / 100.0);
 
     ui->thresholdText->setText(QString("%1").arg(m_settings.m_correlationThreshold));

--- a/plugins/channelrx/demodais/aisdemodgui.ui
+++ b/plugins/channelrx/demodais/aisdemodgui.ui
@@ -301,7 +301,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Frequency deviation</string>
+         <string>Peak frequency deviation</string>
         </property>
         <property name="minimum">
          <number>10</number>

--- a/plugins/channelrx/demodais/aisdemodsettings.h
+++ b/plugins/channelrx/demodais/aisdemodsettings.h
@@ -36,7 +36,7 @@ struct AISDemodSettings
     qint32 m_baud;
     qint32 m_inputFrequencyOffset;
     Real m_rfBandwidth;
-    Real m_fmDeviation;
+    Real m_fmDeviation; //!< Peak deviation to give modulation index of 0.5 for 9600 baud
     Real m_correlationThreshold;
     QString m_filterMMSI;
     bool m_udpEnabled;

--- a/plugins/channelrx/demodais/readme.md
+++ b/plugins/channelrx/demodais/readme.md
@@ -40,7 +40,7 @@ This specifies the bandwidth of a LPF that is applied to the input signal to lim
 
 <h3>5: Dev - Frequency deviation</h3>
 
-Adjusts the expected frequency deviation in 0.1 kHz steps from 1 to 6 kHz. Typical values are 4.8 kHz, corresponding to a modulation index of 0.5 at 9,600 baud.
+Adjusts the expected peak frequency deviation in 0.1 kHz steps from 1 to 6 kHz. Typical values are 4.8 kHz, corresponding to a modulation index of 0.5 at 9,600 baud.
 
 <h3>6: TH - Correlation Threshold</h3>
 

--- a/plugins/channelrx/demodendoftrain/endoftraindemodgui.cpp
+++ b/plugins/channelrx/demodendoftrain/endoftraindemodgui.cpp
@@ -305,7 +305,7 @@ void EndOfTrainDemodGUI::on_rfBW_valueChanged(int value)
 
 void EndOfTrainDemodGUI::on_fmDev_valueChanged(int value)
 {
-    ui->fmDevText->setText(QString("%1k").arg(value / 10.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(value / 10.0, 0, 'f', 1));
     m_settings.m_fmDeviation = value * 100.0;
     applySetting("fmDeviation");
 }
@@ -584,7 +584,7 @@ void EndOfTrainDemodGUI::displaySettings()
     ui->rfBWText->setText(QString("%1k").arg(m_settings.m_rfBandwidth / 1000.0, 0, 'f', 1));
     ui->rfBW->setValue(m_settings.m_rfBandwidth / 100.0);
 
-    ui->fmDevText->setText(QString("%1k").arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
     ui->fmDev->setValue(m_settings.m_fmDeviation / 100.0);
 
     updateIndexLabel();

--- a/plugins/channelrx/demodendoftrain/endoftraindemodgui.ui
+++ b/plugins/channelrx/demodendoftrain/endoftraindemodgui.ui
@@ -321,7 +321,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Frequency deviation</string>
+         <string>Peak frequency deviation</string>
         </property>
         <property name="minimum">
          <number>10</number>
@@ -349,7 +349,7 @@
          </size>
         </property>
         <property name="text">
-         <string>5.0k</string>
+         <string>±3.0k</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/plugins/channelrx/demodendoftrain/readme.md
+++ b/plugins/channelrx/demodendoftrain/readme.md
@@ -7,7 +7,7 @@ that can be found on some trains.
 It transmits information about whether motion is detected, brake pressure, whether the marker light is on and battery information.
 
 * Frequency: 457.9375 MHz (North America, India), 477.7 MHz (Australia) and 450.2625 MHz (New Zealand).
-* Modulation: FSK, 1800Hz space, 1200 mark, +-3kHz deviation.
+* Modulation: FSK, 1800Hz space, 1200 mark, ±3kHz deviation.
 * Baud rate: 1200 baud.
 
 The End-of-train packet specification is defined in:
@@ -40,7 +40,7 @@ This specifies the bandwidth of a LPF that is applied to the input signal to lim
 
 <h3>5: Frequency deviation</h3>
 
-Adjusts the expected frequency deviation in 0.1 kHz steps from 1 to 6 kHz. Typical value is 3 kHz.
+Adjusts the expected peak frequency deviation in 0.1 kHz steps from 1 to 6 kHz. Typical value is ±3 kHz.
 
 <h3>6: Filter Address</h3>
 

--- a/plugins/channelrx/demodm17/m17demodsink.cpp
+++ b/plugins/channelrx/demodm17/m17demodsink.cpp
@@ -308,7 +308,7 @@ void M17DemodSink::applySettings(const M17DemodSettings& settings, const QList<Q
     }
 
     if (settingsKeys.contains("fmDeviation") || force) {
-        m_phaseDiscri.setFMScaling(48000.0f / (2.0f*M_PI*settings.m_fmDeviation));
+        m_phaseDiscri.setFMScaling(48000.0f / (2.0f*settings.m_fmDeviation));
     }
 
     if (settingsKeys.contains("squelchGate") || force)

--- a/plugins/channelrx/demodnfm/nfmdemodsettings.h
+++ b/plugins/channelrx/demodnfm/nfmdemodsettings.h
@@ -38,7 +38,7 @@ struct NFMDemodSettings
     int32_t m_inputFrequencyOffset;
     Real m_rfBandwidth;
     Real m_afBandwidth;
-    Real m_fmDeviation;
+    Real m_fmDeviation; //!< Full deviation in Hz (UI shows peak deviation)
     int  m_squelchGate;
     bool m_deltaSquelch;
     Real m_squelch; //!< deci-Bels

--- a/plugins/channelrx/demodnfm/nfmdemodsink.cpp
+++ b/plugins/channelrx/demodnfm/nfmdemodsink.cpp
@@ -317,7 +317,7 @@ void NFMDemodSink::applySettings(const QStringList& settingsKeys, const NFMDemod
         Real lowCut = -Real(settings.m_fmDeviation) / m_channelSampleRate;
         Real hiCut  = Real(settings.m_fmDeviation) / m_channelSampleRate;
         m_rfFilter.create_filter(lowCut, hiCut);
-        m_phaseDiscri.setFMScaling(Real(m_audioSampleRate) / (2.0f * settings.m_fmDeviation));
+        m_phaseDiscri.setFMScaling(Real(m_audioSampleRate) / settings.m_fmDeviation);
     }
 
     if ((settingsKeys.contains("afBandwidth") && (settings.m_afBandwidth != m_settings.m_afBandwidth)) || force)
@@ -386,7 +386,7 @@ void NFMDemodSink::applyAudioSampleRate(unsigned int sampleRate)
     }
 
     m_afSquelch.setThreshold(m_squelchLevel);
-    m_phaseDiscri.setFMScaling(Real(sampleRate) / (2.0f * m_settings.m_fmDeviation));
+    m_phaseDiscri.setFMScaling(Real(sampleRate) / m_settings.m_fmDeviation); // m_fmDeviation is full rather than peak deviation, so the usual factor of 2 is cancelled
     m_audioFifo.setSize(sampleRate);
     m_squelchDelayLine.resize(sampleRate/2);
     m_interpolatorDistance = Real(m_channelSampleRate) / Real(sampleRate);

--- a/plugins/channelrx/demodpacket/packetdemodgui.cpp
+++ b/plugins/channelrx/demodpacket/packetdemodgui.cpp
@@ -276,7 +276,7 @@ void PacketDemodGUI::on_rfBW_valueChanged(int value)
 
 void PacketDemodGUI::on_fmDev_valueChanged(int value)
 {
-    ui->fmDevText->setText(QString("%1k").arg(value / 10.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(value / 10.0, 0, 'f', 1));
     m_settings.m_fmDeviation = value * 100.0;
     applySettings(QStringList({"fmDeviation"}));
 }
@@ -538,7 +538,7 @@ void PacketDemodGUI::displaySettings()
     ui->rfBWText->setText(QString("%1k").arg(m_settings.m_rfBandwidth / 1000.0, 0, 'f', 1));
     ui->rfBW->setValue(m_settings.m_rfBandwidth / 100.0);
 
-    ui->fmDevText->setText(QString("%1k").arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
     ui->fmDev->setValue(m_settings.m_fmDeviation / 100.0);
 
     updateIndexLabel();

--- a/plugins/channelrx/demodpacket/packetdemodgui.ui
+++ b/plugins/channelrx/demodpacket/packetdemodgui.ui
@@ -339,7 +339,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Frequency deviation</string>
+         <string>Peak frequency deviation</string>
         </property>
         <property name="minimum">
          <number>10</number>
@@ -367,7 +367,7 @@
          </size>
         </property>
         <property name="text">
-         <string>5.0k</string>
+         <string>±5.0k</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/plugins/channelrx/demodpacket/readme.md
+++ b/plugins/channelrx/demodpacket/readme.md
@@ -34,7 +34,7 @@ This specifies the bandwidth of a LPF that is applied to the input signal to lim
 
 <h3>6: Frequency deviation</h3>
 
-Adjusts the expected frequency deviation in 0.1 kHz steps from 1 to 6 kHz. Typical values are 2.5 kHz and 5 kHz.
+Adjusts the expected peak frequency deviation in 0.1 kHz steps from 1 to 6 kHz. Typical values are ±2.5 kHz and ±5 kHz.
 
 <h3>7: Filter Packets From</h3>
 

--- a/plugins/channelrx/demodpager/pagerdemodgui.cpp
+++ b/plugins/channelrx/demodpager/pagerdemodgui.cpp
@@ -368,7 +368,7 @@ void PagerDemodGUI::on_rfBW_valueChanged(int value)
 
 void PagerDemodGUI::on_fmDev_valueChanged(int value)
 {
-    ui->fmDevText->setText(QString("%1k").arg(value / 10.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(value / 10.0, 0, 'f', 1));
     m_settings.m_fmDeviation = value * 100.0;
     applySettings(QStringList("fmDeviation"));
 }
@@ -665,7 +665,7 @@ void PagerDemodGUI::displaySettings()
     ui->rfBWText->setText(QString("%1k").arg(m_settings.m_rfBandwidth / 1000.0, 0, 'f', 1));
     ui->rfBW->setValue(m_settings.m_rfBandwidth / 100.0);
 
-    ui->fmDevText->setText(QString("%1k").arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
     ui->fmDev->setValue(m_settings.m_fmDeviation / 100.0);
 
     updateIndexLabel();

--- a/plugins/channelrx/demodpager/pagerdemodgui.ui
+++ b/plugins/channelrx/demodpager/pagerdemodgui.ui
@@ -301,7 +301,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Frequency deviation</string>
+         <string>Peak frequency deviation</string>
         </property>
         <property name="minimum">
          <number>10</number>
@@ -329,7 +329,7 @@
          </size>
         </property>
         <property name="text">
-         <string>2.4k</string>
+         <string>±2.4k</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>

--- a/plugins/channelrx/demodpager/readme.md
+++ b/plugins/channelrx/demodpager/readme.md
@@ -30,7 +30,7 @@ This specifies the bandwidth of a LPF that is applied to the input signal to lim
 
 <h3>5: Dev - Frequency deviation</h3>
 
-Adjusts the expected frequency deviation in 0.1 kHz steps from 1 to 6 kHz. POCSAG uses FSK with a +/- 4.5 kHz shift.
+Adjusts the expected peak frequency deviation in 0.1 kHz steps from 1 to 6 kHz. POCSAG uses FSK with a ±4.5 kHz shift.
 
 <h3>6: Mod - Modulation</h3>
 

--- a/plugins/channelrx/demodradiosonde/radiosondedemodgui.cpp
+++ b/plugins/channelrx/demodradiosonde/radiosondedemodgui.cpp
@@ -398,7 +398,7 @@ void RadiosondeDemodGUI::on_rfBW_valueChanged(int value)
 
 void RadiosondeDemodGUI::on_fmDev_valueChanged(int value)
 {
-    ui->fmDevText->setText(QString("%1k").arg(value / 10.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(value / 10.0, 0, 'f', 1));
     m_settings.m_fmDeviation = value * 100.0;
     applySettings(QStringList("fmDeviation"));
 }
@@ -748,7 +748,7 @@ void RadiosondeDemodGUI::displaySettings()
     ui->rfBWText->setText(QString("%1k").arg(m_settings.m_rfBandwidth / 1000.0, 0, 'f', 1));
     ui->rfBW->setValue(m_settings.m_rfBandwidth / 100.0);
 
-    ui->fmDevText->setText(QString("%1k").arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
     ui->fmDev->setValue(m_settings.m_fmDeviation / 100.0);
 
     ui->thresholdText->setText(QString("%1").arg(m_settings.m_correlationThreshold));

--- a/plugins/channelrx/demodradiosonde/radiosondedemodgui.ui
+++ b/plugins/channelrx/demodradiosonde/radiosondedemodgui.ui
@@ -298,7 +298,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Frequency deviation</string>
+         <string>Peak frequency deviation</string>
         </property>
         <property name="minimum">
          <number>10</number>

--- a/plugins/channelrx/demodradiosonde/radiosondedemodsettings.h
+++ b/plugins/channelrx/demodradiosonde/radiosondedemodsettings.h
@@ -36,7 +36,7 @@ struct RadiosondeDemodSettings
     qint32 m_baud;
     qint32 m_inputFrequencyOffset;
     Real m_rfBandwidth;
-    Real m_fmDeviation;
+    Real m_fmDeviation; // Peak frequency deviation in Hz
     Real m_correlationThreshold;
     QString m_filterSerial;
     bool m_udpEnabled;

--- a/plugins/channelrx/demodradiosonde/readme.md
+++ b/plugins/channelrx/demodradiosonde/readme.md
@@ -34,7 +34,7 @@ This specifies the bandwidth of a LPF that is applied to the input signal to lim
 
 <h3>5: Dev - Frequency deviation</h3>
 
-Adjusts the expected frequency deviation in 0.1 kHz steps from 1 to 5 kHz. Typical value to RS41 is 2.4kHz.
+Adjusts the expected peak frequency deviation in 0.1 kHz steps from 1 to 5 kHz. Typical value to RS41 is ±2.4kHz.
 
 <h3>6: TH - Correlation Threshold</h3>
 

--- a/plugins/channeltx/modais/aismodgui.cpp
+++ b/plugins/channeltx/modais/aismodgui.cpp
@@ -156,7 +156,7 @@ void AISModGUI::on_mode_currentIndexChanged(int value)
 
     ui->rfBWText->setText(QString("%1k").arg(m_settings.m_rfBandwidth / 1000.0, 0, 'f', 1));
     ui->rfBW->setValue(m_settings.m_rfBandwidth / 100.0);
-    ui->fmDevText->setText(QString("%1k").arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
     ui->fmDev->setValue(m_settings.m_fmDeviation / 100.0);
     ui->btText->setText(QString("%1").arg(m_settings.m_bt, 0, 'f', 1));
     ui->bt->setValue(m_settings.m_bt * 10);
@@ -174,7 +174,7 @@ void AISModGUI::on_rfBW_valueChanged(int value)
 
 void AISModGUI::on_fmDev_valueChanged(int value)
 {
-    ui->fmDevText->setText(QString("%1k").arg(value / 10.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(value / 10.0, 0, 'f', 1));
     m_settings.m_fmDeviation = value * 100.0;
     applySettings(QStringList("fmDeviation"));
 }
@@ -556,7 +556,7 @@ void AISModGUI::displaySettings()
     ui->rfBWText->setText(QString("%1k").arg(m_settings.m_rfBandwidth / 1000.0, 0, 'f', 1));
     ui->rfBW->setValue(m_settings.m_rfBandwidth / 100.0);
 
-    ui->fmDevText->setText(QString("%1k").arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
     ui->fmDev->setValue(m_settings.m_fmDeviation / 100.0);
 
     ui->btText->setText(QString("%1").arg(m_settings.m_bt, 0, 'f', 1));

--- a/plugins/channeltx/modais/aismodgui.ui
+++ b/plugins/channeltx/modais/aismodgui.ui
@@ -304,7 +304,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Frequency deviation</string>
+         <string>Peak frequency deviation</string>
         </property>
         <property name="minimum">
          <number>10</number>
@@ -332,7 +332,7 @@
          </size>
         </property>
         <property name="text">
-         <string>4.8k</string>
+         <string>±4.8k</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/plugins/channeltx/modais/aismodsettings.cpp
+++ b/plugins/channeltx/modais/aismodsettings.cpp
@@ -35,7 +35,7 @@ void AISModSettings::resetToDefaults()
     m_inputFrequencyOffset = 0;
     m_baud = 9600; // nominal value
     m_rfBandwidth = 25000.0f; // 12.5k for narrow, 25k for wide (narrow is obsolete)
-    m_fmDeviation = 4800.0f; // To give modulation index of 0.5 for 9600 baud
+    m_fmDeviation = 4800.0f; // Peak deviation - To give modulation index of 0.5 for 9600 baud
     m_gain = -1.0f; // To avoid overflow, which results in out-of-band RF
     m_channelMute = false;
     m_repeat = false;

--- a/plugins/channeltx/modais/readme.md
+++ b/plugins/channeltx/modais/readme.md
@@ -34,7 +34,7 @@ This specifies the bandwidth of a LPF that is applied to the output signal to li
 
 <h3>6: FM Deviation</h3>
 
-This specifies the maximum frequency deviation. Typically this should be 4.8kHz, giving a modulation index of 0.5 at 9,600 baud.
+This specifies the peak frequency deviation. Typically this should be ±4.8kHz, giving a modulation index of 0.5 at 9,600 baud.
 
 <h3>7: BT Bandwidth</h3>
 

--- a/plugins/channeltx/modnfm/nfmmodsettings.h
+++ b/plugins/channeltx/modnfm/nfmmodsettings.h
@@ -48,7 +48,7 @@ struct NFMModSettings
     qint64 m_inputFrequencyOffset;
     Real m_rfBandwidth;
     Real m_afBandwidth;
-    float m_fmDeviation;
+    float m_fmDeviation; //!< Full deviation in Hz (UI shows peak deviation)
     float m_toneFrequency;
     float m_volumeFactor;
     bool m_channelMute;

--- a/plugins/channeltx/modnfm/nfmmodsource.cpp
+++ b/plugins/channeltx/modnfm/nfmmodsource.cpp
@@ -171,6 +171,7 @@ void NFMModSource::modulateSample()
         t1 = m_lowpass.filter(t);
     }
 
+    // The usual factor of 2*pi is cancelled by m_fmDeviation being the full rather than peak deviation
     m_modPhasor += (float) ((M_PI * m_settings.m_fmDeviation / (float) m_audioSampleRate) * t1);
 
     // limit phasor range to ]-pi,pi]

--- a/plugins/channeltx/modpacket/packetmodgui.cpp
+++ b/plugins/channeltx/modpacket/packetmodgui.cpp
@@ -151,7 +151,7 @@ void PacketModGUI::on_mode_currentIndexChanged(int value)
         m_settings.setMode(mode);
 
     ui->rfBWText->setText(QString("%1k").arg(m_settings.m_rfBandwidth / 1000.0, 0, 'f', 1));
-    ui->fmDevText->setText(QString("%1k").arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
     ui->fmDev->setValue(m_settings.m_fmDeviation / 100.0);
     ui->glSpectrum->setCenterFrequency(m_settings.m_spectrumRate/4);
     ui->glSpectrum->setSampleRate(m_settings.m_spectrumRate/2);
@@ -173,7 +173,7 @@ void PacketModGUI::on_rfBW_valueChanged(int value)
 
 void PacketModGUI::on_fmDev_valueChanged(int value)
 {
-    ui->fmDevText->setText(QString("%1k").arg(value / 10.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(value / 10.0, 0, 'f', 1));
     m_settings.m_fmDeviation = value * 100.0;
     applySettings(QStringList("fmDeviation"));
 }
@@ -593,7 +593,7 @@ void PacketModGUI::displaySettings()
     ui->rfBWText->setText(QString("%1k").arg(m_settings.m_rfBandwidth / 1000.0, 0, 'f', 1));
     ui->rfBW->setValue(m_settings.m_rfBandwidth / 100.0);
 
-    ui->fmDevText->setText(QString("%1k").arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 1000.0, 0, 'f', 1));
     ui->fmDev->setValue(m_settings.m_fmDeviation / 100.0);
 
     ui->gainText->setText(QString("%1").arg((double)m_settings.m_gain, 0, 'f', 1));

--- a/plugins/channeltx/modpacket/packetmodgui.ui
+++ b/plugins/channeltx/modpacket/packetmodgui.ui
@@ -304,7 +304,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Frequency deviation</string>
+         <string>Peak frequency deviation</string>
         </property>
         <property name="minimum">
          <number>10</number>
@@ -332,7 +332,7 @@
          </size>
         </property>
         <property name="text">
-         <string>5.0k</string>
+         <string>±5.0k</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/plugins/channeltx/modpacket/readme.md
+++ b/plugins/channeltx/modpacket/readme.md
@@ -32,7 +32,7 @@ This specifies the bandwidth of a LPF that is applied to the output signal to li
 
 <h3>6: Frequency deviation</h3>
 
-Adjusts the frequency deviation in 0.1 kHz steps from 1 to 6 kHz. Typical values are 2.5 kHz and 5 kHz.
+Adjusts the frequency peak deviation in 0.1 kHz steps from 1 to 6 kHz. Typical values are ±2.5 kHz and ±5 kHz.
 
 <h3>7: Gain</h3>
 

--- a/plugins/channeltx/modwfm/readme.md
+++ b/plugins/channeltx/modwfm/readme.md
@@ -32,7 +32,7 @@ This is the bandwidth in kHz of the modulating signal filtered before modulation
 
 <h3>7: Frequency deviation</h3>
 
-Adjusts the frequency deviation in 1 kHz steps from 0 to 100 kHz
+Adjusts the peak frequency deviation in 1 kHz steps from 0 to 100 kHz
 
 <h3>8: Volume</h3>
 

--- a/plugins/channeltx/modwfm/wfmmodgui.cpp
+++ b/plugins/channeltx/modwfm/wfmmodgui.cpp
@@ -172,7 +172,7 @@ void WFMModGUI::on_afBW_valueChanged(int value)
 
 void WFMModGUI::on_fmDev_valueChanged(int value)
 {
-	ui->fmDevText->setText(QString("%1k").arg(value));
+	ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(value));
 	m_settings.m_fmDeviation = value * 1000.0;
 	applySettings(QStringList("fmDeviation"));
 }
@@ -476,7 +476,7 @@ void WFMModGUI::displaySettings()
     ui->afBWText->setText(QString("%1k").arg(m_settings.m_afBandwidth / 1000.0));
     ui->afBW->setValue(m_settings.m_afBandwidth / 1000.0);
 
-    ui->fmDevText->setText(QString("%1k").arg(m_settings.m_fmDeviation / 1000.0));
+    ui->fmDevText->setText(QString("%1%2k").arg(QChar(0xB1, 0x00)).arg(m_settings.m_fmDeviation / 1000.0));
     ui->fmDev->setValue(m_settings.m_fmDeviation / 1000.0);
 
     ui->volumeText->setText(QString("%1").arg(m_settings.m_volumeFactor, 0, 'f', 1));

--- a/plugins/channeltx/modwfm/wfmmodgui.ui
+++ b/plugins/channeltx/modwfm/wfmmodgui.ui
@@ -302,7 +302,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Modulation percentage</string>
+         <string>Peak frequency deviation</string>
         </property>
         <property name="maximum">
          <number>100</number>
@@ -327,7 +327,7 @@
          </size>
         </property>
         <property name="text">
-         <string>50k</string>
+         <string>±50k</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/plugins/channeltx/modwfm/wfmmodsettings.h
+++ b/plugins/channeltx/modwfm/wfmmodsettings.h
@@ -45,7 +45,7 @@ struct WFMModSettings
     qint64 m_inputFrequencyOffset;
     Real m_rfBandwidth;
     Real m_afBandwidth;
-    float m_fmDeviation;
+    float m_fmDeviation; //!< Peak frequency deviation in Hz
     float m_toneFrequency;
     float m_volumeFactor;
     bool m_channelMute;

--- a/sdrgui/gui/rollupcontents.cpp
+++ b/sdrgui/gui/rollupcontents.cpp
@@ -122,7 +122,7 @@ int RollupContents::arrangeRollups()
                 }
                 int h = 0;
                 if (r->hasHeightForWidth()) {
-                    h = r->heightForWidth(width() - 4);
+                    h = r->heightForWidth(width() - 4); // FIXME: This is preferred height for the given width, not the minimum height.
                 } else {
                     h = r->minimumSizeHint().height();
                 }


### PR DESCRIPTION
This PR should correct the FM scaling in the NFM Demod, so that the amplitude of a demodulated full scale signal is (-1,1) rather than (-0.5,0.5).

I was testing NFMMod to NFMDemod using the tone generator in the NFM Mod, whose amplitude is (-1,1), but only getting (-0.5,0.5) out of the demod, even though deviation was identical.

The problem I think is that m_fmDeviation is the full deviation rather than peak, so the factor of 2 isn't needed when calling m_phaseDiscri.setFMScaling.

We have a bit of an inconsistency between the different modems, where m_fmDeviation is sometimes the full deviation and sometimes peak.