### PR TITLE
USRP: B210: fix sample rate range upper bound

### DIFF
--- a/devices/usrp/deviceusrpparam.cpp
+++ b/devices/usrp/deviceusrpparam.cpp
@@ -74,8 +74,8 @@ bool DeviceUSRPParams::open(const QString &deviceStr, bool channelNumOnly)
             else if (deviceStr.contains("product=B210"))
             {
                 // Auto-calculation below can be slow, so use hardcoded values for B210
-                m_srRangeRx = uhd::meta_range_t(1e5, 61.444e6);
-                m_srRangeTx = uhd::meta_range_t(1e5, 61.444e6);
+                m_srRangeRx = uhd::meta_range_t(1e5, 61.44e6);
+                m_srRangeTx = uhd::meta_range_t(1e5, 61.44e6);
             }
             else
             {


### PR DESCRIPTION
Ettus B210 has a maximum sampling rate of 61.44MSPS. Exceeding this limit results in unexpected behavior. Prevent this from occurring by decreasing the maximum sample rate by from 61.444MSP to 61.44MSP (-4k).