### PR TITLE
sdrsrv: fix null-deref in MainServer::addMIMODevice()

### DIFF
--- a/sdrsrv/mainserver.cpp
+++ b/sdrsrv/mainserver.cpp
@@ -377,6 +377,8 @@ void MainServer::addMIMODevice()
         deviceAPI->setHardwareUserArguments(userArgs);
     }
 
+    m_mainCore->m_deviceSets.back()->m_deviceAPI = deviceAPI;
+
     DeviceSampleMIMO *mimo = deviceAPI->getPluginInterface()->createSampleMIMOPluginInstance(
             deviceAPI->getSamplingDeviceId(), deviceAPI);
     m_mainCore->m_deviceSets.back()->m_deviceAPI->setSampleMIMO(mimo);


### PR DESCRIPTION
## Summary

`MainServer::addMIMODevice()` never assigns `m_deviceSets.back()->m_deviceAPI` before dereferencing it via `setSampleMIMO()`, so the very first `POST /sdrangel/deviceset?direction=2` against a fresh headless `sdrangelsrv` SIGSEGVs in `DeviceAPI::setSampleMIMO()`'s vtable lookup.

`DeviceSet`'s constructor initializes `m_deviceAPI` to `nullptr` (`sdrbase/device/deviceset.cpp:38`), and the sibling helpers `addSinkDevice()` (line 283) and `addSourceDevice()` (line 323) both assign the new `DeviceAPI*` into `m_deviceSets.back()->m_deviceAPI` before any later dereference. `addMIMODevice()` omits this assignment, so today's line:

```cpp
m_mainCore->m_deviceSets.back()->m_deviceAPI->setSampleMIMO(mimo);
```

dereferences `nullptr`.

The fix performs the same assignment as the Sink/Source paths, immediately before the `createSampleMIMOPluginInstance()` call — matching the existing pattern.

## Backtrace (pre-fix)

Captured against `v7.25.1` headless build with `gdb -batch` wrapping `sdrangelsrv`:

```
Thread 1 "sdrangelsrv" received signal SIGSEGV, Segmentation fault.
#0  DeviceAPI::setSampleMIMO(DeviceSampleMIMO*)   in libsdrbase.so
#1  MainServer::addMIMODevice()                   in libsdrsrv.so
#2  MainServer::handleMessage(Message const&)     in libsdrsrv.so
#3  MainServer::handleMessages()                  in libsdrsrv.so
```

## Verification

Custom headless build (`BUILD_SERVER=ON BUILD_GUI=OFF ENABLE_QT6=ON ENABLE_LIMESUITE=ON`) on Ubuntu 24.04 / Qt 6.4.2 / GCC 13, with a LimeSDR-USB attached:

- **Pre-patch:** `POST /sdrangel/deviceset?direction=2` → HTTP 202, then immediate SIGSEGV (backtrace above).
- **Post-patch:** `POST` → HTTP 202, container healthy. Follow-up `PUT /sdrangel/deviceset/0/device` with `hwType=LimeSDR direction=2` → HTTP 202, and `GET /sdrangel/deviceset/0` correctly reports the LimeSDR bound as a MIMO device.

## Test plan

- [x] Verified the diff is a one-line addition that mirrors `addSinkDevice` / `addSourceDevice` exactly.
- [x] Verified post-patch: MIMO deviceset creation + LimeSDR-USB attachment both succeed against headless `sdrangelsrv`.
- [ ] Maintainer to review whether any other MIMO entry points (e.g. `MainCore::addMIMODevice` in the GUI path) suffer the same omission — a quick `grep` suggests the GUI path is structured differently and already initializes `m_deviceAPI` via a different code path, but worth a second look.