### PR TITLE
Disable AVX instructions in limesuite for flatpak and snap

### DIFF
--- a/flatpak/org.sdrangel.SDRangel.yaml
+++ b/flatpak/org.sdrangel.SDRangel.yaml
@@ -415,6 +415,7 @@ modules:
       - -DENABLE_EXAMPLES=OFF
       - -DENABLE_UTILITIES=OFF
       - -DENABLE_HEADERS=ON
+      - -DENABLE_SIMD_FLAGS=SSE4.2
       - -Wno-dev
     sources:
       - type: archive

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -568,7 +568,7 @@ parts:
         stage-packages:
             - libstdc++6
         cmake-parameters:
-            - -DCMAKE_INSTALL_PREFIX=/opt/install/sdrangel
+            - -DCMAKE_INSTALL_PREFIX=/opt/install/sdrangel -DENABLE_SIMD_FLAGS=SSE4.2
 
     airspyhf:
         plugin: cmake

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -568,7 +568,8 @@ parts:
         stage-packages:
             - libstdc++6
         cmake-parameters:
-            - -DCMAKE_INSTALL_PREFIX=/opt/install/sdrangel -DENABLE_SIMD_FLAGS=SSE4.2
+            - -DCMAKE_INSTALL_PREFIX=/opt/install/sdrangel
+            - -DENABLE_SIMD_FLAGS=SSE4.2
 
     airspyhf:
         plugin: cmake


### PR DESCRIPTION
Disable AVX instructions in limesuite for flatpak and snap - Hopefully fix #2771 
