### PR TITLE
Improve PlutoSDR discovery robustness and identitection mgr

### DIFF
--- a/devices/plutosdr/deviceplutosdrbox.cpp
+++ b/devices/plutosdr/deviceplutosdrbox.cpp
@@ -899,12 +899,12 @@ void DevicePlutoSDRBox::getRxLORange(uint64_t& minLimit, uint64_t& maxLimit)
     if (get_param(DEVICE_PHY, buff, rangeStr))
     {
         std::istringstream instream(rangeStr.substr(1, rangeStr.size() - 2));
-	    instream >> minLimit >> stepLimit >> maxLimit;
+        instream >> minLimit >> stepLimit >> maxLimit;
     }
     else
     {
         minLimit = DevicePlutoSDR::rxLOLowLimitFreq;
-	    maxLimit = DevicePlutoSDR::rxLOHighLimitFreq;
+        maxLimit = DevicePlutoSDR::rxLOHighLimitFreq;
     }
 }
 
@@ -920,12 +920,12 @@ void DevicePlutoSDRBox::getTxLORange(uint64_t& minLimit, uint64_t& maxLimit)
     if (get_param(DEVICE_PHY, buff, rangeStr))
     {
         std::istringstream instream(rangeStr.substr(1, rangeStr.size() - 2));
-	    instream >> minLimit >> stepLimit >> maxLimit;
+        instream >> minLimit >> stepLimit >> maxLimit;
     }
     else
     {
         minLimit = DevicePlutoSDR::txLOLowLimitFreq;
-	    maxLimit = DevicePlutoSDR::txLOHighLimitFreq;
+        maxLimit = DevicePlutoSDR::txLOHighLimitFreq;
     }
 }
 
@@ -940,13 +940,13 @@ void DevicePlutoSDRBox::getbbLPRxRange(uint32_t& minLimit, uint32_t& maxLimit)
 
     if (get_param(DEVICE_PHY, buff, rangeStr))
     {
-	std::istringstream instream(rangeStr.substr(1, rangeStr.size() - 2));
-	instream >> minLimit >> stepLimit >> maxLimit;
+        std::istringstream instream(rangeStr.substr(1, rangeStr.size() - 2));
+        instream >> minLimit >> stepLimit >> maxLimit;
     }
     else
     {
-	minLimit = DevicePlutoSDR::bbLPRxLowLimitFreq;
-	maxLimit = DevicePlutoSDR::bbLPRxHighLimitFreq;
+        minLimit = DevicePlutoSDR::bbLPRxLowLimitFreq;
+        maxLimit = DevicePlutoSDR::bbLPRxHighLimitFreq;
     }
 }
 
@@ -966,8 +966,8 @@ void DevicePlutoSDRBox::getbbLPTxRange(uint32_t& minLimit, uint32_t& maxLimit)
     }
     else
     {
-	minLimit = DevicePlutoSDR::bbLPTxLowLimitFreq;
-	maxLimit = DevicePlutoSDR::bbLPTxHighLimitFreq;
+        minLimit = DevicePlutoSDR::bbLPTxLowLimitFreq;
+        maxLimit = DevicePlutoSDR::bbLPTxHighLimitFreq;
     }
 }
 

--- a/devices/plutosdr/deviceplutosdrscan.cpp
+++ b/devices/plutosdr/deviceplutosdrscan.cpp
@@ -90,7 +90,9 @@ void DevicePlutoSDRScan::scan()
 
             if (desc_match.size() == 2)
             {
-                m_scans.back()->m_serial = desc_match[1];
+                // A device can be discovered through multiple backends (e.g. USB and IP).
+                // Keep the backend in the serial key so each scanned entry remains unique.
+                m_scans.back()->m_serial = desc_match[1].str() + createBackendSuffix(uri);
                 m_serialMap[m_scans.back()->m_serial] = m_scans.back();
             }
         }
@@ -145,13 +147,42 @@ void DevicePlutoSDRScan::enumOriginDevices(const QString& hardwareId, PluginInte
     std::vector<std::string> serials;
     getSerials(serials);
 
+    // Multiple backends can refer to the same physical device.
+    // Keep a separate list of physical serials for stable display numbering.
+    // Example: Pluto[0] (ip) and Pluto[0] (usb) refer to the same hardware.
+    std::map<std::string, int> physicalSerialIndexes;
     std::vector<std::string>::const_iterator it = serials.begin();
     int i;
 
     for (i = 0; it != serials.end(); ++it, ++i)
     {
+        // Keep the backend-qualified serial as the device identifier.
         QString serial_str = QString::fromLocal8Bit(it->c_str());
-        QString displayableName(QString("PlutoSDR[%1] %2").arg(i).arg(serial_str));
+        // Remove backend suffix for display and grouping.
+        std::string physicalSerial = getPhysicalSerial(*it);
+
+        // Find the existing physical device index so USB/IP instances share a label.
+        auto pos = physicalSerialIndexes.find(physicalSerial);
+
+        // Display index is based on physical devices, not backend instances.
+        int physical_idx;
+
+        if (pos == physicalSerialIndexes.end())
+        {
+            physical_idx = physicalSerialIndexes.size();
+            physicalSerialIndexes[physicalSerial] = physical_idx;
+        }
+        else
+        {
+            physical_idx = pos->second;
+        }
+
+        // Show backend information to distinguish multiple connections to the same device.
+        QString displayableName(
+           QString("PlutoSDR%1%2 %3")
+                .arg(physical_idx)
+                .arg(getBackendLabel(*it))
+                .arg(QString::fromLocal8Bit(physicalSerial.c_str())));
 
         originDevices.append(PluginInterface::OriginDevice(
             displayableName,
@@ -165,4 +196,91 @@ void DevicePlutoSDRScan::enumOriginDevices(const QString& hardwareId, PluginInte
         qDebug("DevicePlutoSDRScan::enumOriginDevices: enumerated PlutoSDR device #%d", i);
     }
 
+}
+
+/**
+ * @brief Creates a backend prefix from a libiio URI.
+ *
+ * The backend is converted into a serial suffix so that devices
+ * discovered through different backends remain unique.
+ *
+ * Examples:
+ *   ip:192.168.2.1       -> "_ip"
+ *   usb:3.32.5           -> "_usb"
+ *   serial:/dev/ttyUSB0  -> "_serial"
+ *   local:               -> "_local"
+ *
+ * @param uri Device URI returned by libiio.
+ *
+ * @return iio backend suffix including the separator, or an empty string
+ *         if no backend prefix is present.
+ */
+std::string DevicePlutoSDRScan::createBackendSuffix(const char *uri) const
+{
+    if (!uri) {
+        return {};
+    }
+
+    const char *sep = std::strchr(uri, ':');
+
+    if (!sep) {
+        return {};
+    }
+
+    return std::string(1, BACKEND_SEPARATOR)  + std::string(uri, sep - uri);
+}
+
+/**
+ * @brief Creates a display string for the backend portion of a serial.
+ *
+ * The scan process appends the backend to make serial numbers unique.
+ * This function recovers the backend suffix into a user-facing label for
+ * display purposes.
+ *
+ * Examples:
+ *   ABC123_ip  -> " (ip)"
+ *   ABC123_usb -> " (usb)"
+ *
+ * @param serial backend-qualified serial number.
+ *
+ * @return Display label suffix.
+ */
+QString DevicePlutoSDRScan::getBackendLabel(const std::string& serial) const
+{
+    size_t sep = serial.rfind(BACKEND_SEPARATOR);
+
+    if (sep == std::string::npos)
+    {
+        return {};
+    }
+
+    return QString(" (%1)").arg(
+        QString::fromStdString(serial.substr(sep + 1)));
+}
+
+/**
+ * @brief Removes the backend suffix from a serial number.
+ *
+ * The scan process appends the backend to make serial numbers unique.
+ * This function recovers the physical device serial for grouping and
+ * display purposes.
+ *
+ * Examples:
+ *   ABC123_ip  -> ABC123
+ *   ABC123_usb -> ABC123
+ *
+ * @param serial backend-qualified serial number.
+ *
+ * @return Physical device serial number.
+ */
+std::string DevicePlutoSDRScan::getPhysicalSerial(const std::string& serial) const
+{
+    size_t sep = serial.rfind(BACKEND_SEPARATOR);
+
+    if (sep == std::string::npos)
+    {
+        return serial;
+    }
+
+    return serial.substr(0, sep);
 }

--- a/devices/plutosdr/deviceplutosdrscan.cpp
+++ b/devices/plutosdr/deviceplutosdrscan.cpp
@@ -65,7 +65,10 @@ void DevicePlutoSDRScan::scan()
             continue;
         }
 
-        qDebug("PlutoSDRScan::scan: %d: %s [%s]", i, description, uri);
+        // For uri which are ip:*.local replace with the ip address
+        std::string fixedUri = replaceHostnameWithIP(uri, description);
+
+        qDebug("PlutoSDRScan::scan: %d: %s [%s] [%s]", i, description, uri, fixedUri.c_str());
         const std::string_view descriptionView = description ? std::string_view{description} : std::string_view{};
         const bool isPlutoDescription =
             (descriptionView.find("PlutoSDR") != std::string_view::npos) ||
@@ -79,7 +82,7 @@ void DevicePlutoSDRScan::scan()
                 DeviceScan({
                     std::string(description),
                     std::string("TBD"),
-                    std::string(uri)
+                    fixedUri
                 }));
             m_scans.push_back(dev_scan);
             m_urilMap[m_scans.back()->m_uri] = m_scans.back();
@@ -196,6 +199,83 @@ void DevicePlutoSDRScan::enumOriginDevices(const QString& hardwareId, PluginInte
         qDebug("DevicePlutoSDRScan::enumOriginDevices: enumerated PlutoSDR device #%d", i);
     }
 
+}
+
+/**
+ * @brief Replaces an mDNS hostname with the discovered endpoint.
+ *
+ * Older libiio versions may return the advertised mDNS hostname (for example
+ * "ip:pluto.local") rather than the endpoint that was actually discovered.
+ * This becomes ambiguous when identical mDNS hostnames exist on different
+ * network segments, since multiple devices can legitimately advertise the
+ * same ".local" hostname.
+ *
+ * Since the scan description begins with the discovered endpoint (IPv4 or IPv6),
+ * followed by " (". For ".local" URIs, substitute the endpoint while
+ * preserving the backend and optional port number.
+ *
+ * Examples:
+ *   URI:         ip:pluto.local
+ *   Description: 192.168.2.1 (...)
+ *   Result:      ip:192.168.2.1
+ *
+ *   URI:         ip:pluto.local:30431
+ *   Description: fe80::205:f7ff:fe75:9c4f%eth1 (...)
+ *   Result:      ip:[fe80::205:f7ff:fe75:9c4f%eth1]:30431
+ */
+std::string DevicePlutoSDRScan::replaceHostnameWithIP(
+    const std::string& uri,
+    const char *description) const
+{
+    if (!description) {
+        return uri;
+    }
+
+    // Only applies to IP backends.
+    if (uri.rfind("ip:", 0) != 0) {
+        return uri;
+    }
+
+    // Only rewrite mDNS hostnames.
+    if (uri.find(".local") == std::string::npos) {
+        return uri;
+    }
+
+    // Description starts with "<endpoint> (".
+    const std::string desc(description);
+    const size_t endpointEnd = desc.find(" (");
+
+    if (endpointEnd == std::string::npos) {
+        return uri;
+    }
+
+    const std::string endpoint = desc.substr(0, endpointEnd);
+
+    // Preserve any optional port.
+    std::string port;
+    const size_t localPos = uri.find(".local");
+
+    if (localPos != std::string::npos)
+    {
+        const size_t afterLocal = localPos + 6; // strlen(".local")
+
+        if (afterLocal < uri.size() && uri[afterLocal] == ':') {
+            port = uri.substr(afterLocal);
+        }
+    }
+
+    std::string newUri = "ip:";
+
+    // RFC2732 requires brackets around IPv6 literals when a port is present.
+    if (!port.empty() && endpoint.find(':') != std::string::npos) {
+        newUri += "[" + endpoint + "]";
+    } else {
+        newUri += endpoint;
+    }
+
+    newUri += port;
+
+    return newUri;
 }
 
 /**

--- a/devices/plutosdr/deviceplutosdrscan.cpp
+++ b/devices/plutosdr/deviceplutosdrscan.cpp
@@ -148,10 +148,10 @@ void DevicePlutoSDRScan::enumOriginDevices(const QString& hardwareId, PluginInte
     std::vector<std::string>::const_iterator it = serials.begin();
     int i;
 
-	for (i = 0; it != serials.end(); ++it, ++i)
-	{
-	    QString serial_str = QString::fromLocal8Bit(it->c_str());
-	    QString displayableName(QString("PlutoSDR[%1] %2").arg(i).arg(serial_str));
+    for (i = 0; it != serials.end(); ++it, ++i)
+    {
+        QString serial_str = QString::fromLocal8Bit(it->c_str());
+        QString displayableName(QString("PlutoSDR[%1] %2").arg(i).arg(serial_str));
 
         originDevices.append(PluginInterface::OriginDevice(
             displayableName,
@@ -163,6 +163,6 @@ void DevicePlutoSDRScan::enumOriginDevices(const QString& hardwareId, PluginInte
         ));
 
         qDebug("DevicePlutoSDRScan::enumOriginDevices: enumerated PlutoSDR device #%d", i);
-	}
+    }
 
 }

--- a/devices/plutosdr/deviceplutosdrscan.h
+++ b/devices/plutosdr/deviceplutosdrscan.h
@@ -52,6 +52,9 @@ public:
 private:
     static constexpr char BACKEND_SEPARATOR = '_';
 
+    std::string replaceHostnameWithIP(
+        const std::string& uri,
+        const char *description) const;
     std::string createBackendSuffix(const char *uri) const;
     QString getBackendLabel(const std::string& serial) const;
     std::string getPhysicalSerial(const std::string& serial) const;

--- a/devices/plutosdr/deviceplutosdrscan.h
+++ b/devices/plutosdr/deviceplutosdrscan.h
@@ -50,6 +50,12 @@ public:
     void enumOriginDevices(const QString& hardwareId, PluginInterface::OriginDevices& originDevices);
 
 private:
+    static constexpr char BACKEND_SEPARATOR = '_';
+
+    std::string createBackendSuffix(const char *uri) const;
+    QString getBackendLabel(const std::string& serial) const;
+    std::string getPhysicalSerial(const std::string& serial) const;
+
     std::vector<std::shared_ptr<DeviceScan>> m_scans;
     std::map<std::string, std::shared_ptr<DeviceScan>> m_serialMap;
     std::map<std::string, std::shared_ptr<DeviceScan>> m_urilMap;


### PR DESCRIPTION
This change improves PlutoSDR device discovery reliability in multi-backend and multi-network environments by addressing two related issues in libiio-based scanning:

- Ambiguous device identity when the same hardware is exposed through multiple backends (IP, USB, etc.)
- Unstable or misleading URIs when mDNS (*.local) names are reused across different network segments

Together, these changes make device enumeration deterministic, uniquely identifiable, and more robust in heterogeneous network setups. (fixes issues where things like multiple plutos plugged in didn't work over IP, and if a local usb pluto would interfere with one using a USB<->Ethernet dongle).