### PR TITLE
Attempt to fix corrupt spectrum on Mac when MSAA enabled.

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -6971,7 +6971,7 @@ ADSBDemodGUI::ADSBDemodGUI(PluginAPI* pluginAPI, DeviceUISet *deviceUISet, Baseb
     int multisamples = MainCore::instance()->getSettings().getMapMultisampling();
     if (multisamples > 0)
     {
-        QSurfaceFormat format;
+        QSurfaceFormat format = QSurfaceFormat::defaultFormat();
         format.setSamples(multisamples);
 #ifdef QT_LOCATION_FOUND
         ui->map->setFormat(format);

--- a/plugins/feature/map/mapgui.cpp
+++ b/plugins/feature/map/mapgui.cpp
@@ -222,7 +222,7 @@ MapGUI::MapGUI(PluginAPI* pluginAPI, FeatureUISet *featureUISet, Feature *featur
     int multisamples = MainCore::instance()->getSettings().getMapMultisampling();
     if (multisamples > 0)
     {
-        QSurfaceFormat format;
+        QSurfaceFormat format = QSurfaceFormat::defaultFormat();
         format.setSamples(multisamples);
         ui->map->setFormat(format);
     }

--- a/sdrgui/gui/glspectrumview.cpp
+++ b/sdrgui/gui/glspectrumview.cpp
@@ -172,7 +172,7 @@ GLSpectrumView::GLSpectrumView(QWidget* parent) :
     int multisamples = MainCore::instance()->getSettings().getMultisampling();
     if (multisamples > 0)
     {
-        QSurfaceFormat format;
+        QSurfaceFormat format = QSurfaceFormat::defaultFormat();
         format.setSamples(multisamples);
         setFormat(format);
     }


### PR DESCRIPTION
Use default QSurfaceFormat when MSAA enabled. May fix #2788, #2022 and #1616