### PR TITLE
Fix WebAPI link in About dialog (Display 127.0.0.1 rather than 0.0.0.0)

### DIFF
--- a/sdrgui/gui/aboutdialog.cpp
+++ b/sdrgui/gui/aboutdialog.cpp
@@ -26,12 +26,14 @@ AboutDialog::AboutDialog(const QString& apiHost, int apiPort, const MainSettings
 	QDialog(parent),
 	ui(new Ui::AboutDialog)
 {
+    QString apiHostAddress = apiHost == "0.0.0.0" ? "127.0.0.1" : apiHost;
+
 	ui->setupUi(this);
 	ui->version->setText(QString("Version %1 - Copyright (C) 2015-2026 Edouard Griffiths, F4EXB.").arg(qApp->applicationVersion()));
 	ui->build->setText(QString("Build info: Qt %1 %2 bits").arg(QT_VERSION_STR).arg(QT_POINTER_SIZE*8));
 	ui->dspBits->setText(QString("DSP Rx %1 bits Tx %2 bits").arg(SDR_RX_SAMP_SZ).arg(SDR_TX_SAMP_SZ));
 	ui->pid->setText(QString("PID: %1").arg(qApp->applicationPid()));
-	QString apiUrl = QString("http://%1:%2/").arg(apiHost).arg(apiPort);
+	QString apiUrl = QString("http://%1:%2/").arg(apiHostAddress).arg(apiPort);
 	ui->restApiUrl->setText(QString("REST API server and documentation: <a href=\"%1\">%2</a>").arg(apiUrl).arg(apiUrl));
 	ui->restApiUrl->setOpenExternalLinks(true);
 	ui->settingsFile->setText(QString("Settings: %1").arg(mainSettings.getFileLocation()));


### PR DESCRIPTION
Fix WebAPI link in About dialog (Display 127.0.0.1 rather than 0.0.0.0) so it opens the example docs when you click on it.