### PR TITLE
bump bundled faad2 to 2.10.1, fixes heap overflow (#2766)

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -300,9 +300,15 @@ if (NOT ZLIB_FOUND AND NOT USE_PRECOMPILED_LIBS)
 endif (NOT ZLIB_FOUND AND NOT USE_PRECOMPILED_LIBS)
 
 if (NOT FAAD_FOUND AND NOT USE_PRECOMPILED_LIBS)
+    # faad2 2.8.8 is the last version SourceForge ever hosted, and it predates the 2.9.0 fix
+    # for a heap overflow in excluded_channels() (knik0/faad2@942c3e0a: unbounded exclude_mask
+    # write in the DRC parser). Later releases only live on GitHub, whose source archives don't
+    # include a pre-built configure script (only configure.ac), so bootstrap it first -- same
+    # reason libusb above fetches a release tarball instead of a bare git checkout.
     ExternalProject_Add(faad
-            URL https://downloads.sourceforge.net/project/faac/faad2-src/faad2-2.8.0/faad2-2.8.8.tar.gz
+            URL https://github.com/knik0/faad2/archive/refs/tags/2.10.1.tar.gz
             PREFIX "${EXTERNAL_BUILD_LIBRARIES}/faad"
+            PATCH_COMMAND <SOURCE_DIR>/bootstrap
             CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
             TEST_COMMAND ""
             )

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -302,14 +302,14 @@ endif (NOT ZLIB_FOUND AND NOT USE_PRECOMPILED_LIBS)
 if (NOT FAAD_FOUND AND NOT USE_PRECOMPILED_LIBS)
     # faad2 2.8.8 is the last version SourceForge ever hosted, and it predates the 2.9.0 fix
     # for a heap overflow in excluded_channels() (knik0/faad2@942c3e0a: unbounded exclude_mask
-    # write in the DRC parser). Later releases only live on GitHub, whose source archives don't
-    # include a pre-built configure script (only configure.ac), so bootstrap it first -- same
-    # reason libusb above fetches a release tarball instead of a bare git checkout.
+    # write in the DRC parser). Later releases only live on GitHub; 2.11.0 added CMake support,
+    # so build it like opus above. FAAD_BUILD_CLI=OFF skips the faad frontend executable --
+    # only libfaad is used.
     ExternalProject_Add(faad
-            URL https://github.com/knik0/faad2/archive/refs/tags/2.10.1.tar.gz
+            GIT_REPOSITORY https://github.com/knik0/faad2.git
+            GIT_TAG 2.11.2
             PREFIX "${EXTERNAL_BUILD_LIBRARIES}/faad"
-            PATCH_COMMAND <SOURCE_DIR>/bootstrap
-            CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
+            CMAKE_ARGS ${COMMON_CMAKE_ARGS} -DBUILD_SHARED_LIBS=ON -DFAAD_BUILD_CLI=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
             TEST_COMMAND ""
             )
     ExternalProject_Get_Property(faad source_dir binary_dir install_dir)


### PR DESCRIPTION
Fixes #2766.

`external/CMakeLists.txt` fetches faad2 2.8.8 from SourceForge for the bundled build (used when there's no system faad2, i.e. the macOS build and any source-fallback build). 2.8.8 is the last version SourceForge ever hosted, and it predates 2.9.0's fix for a heap overflow in `excluded_channels()` (upstream commit knik0/faad2@942c3e0a): the DRC parser's `exclude_mask` write loop has no `MAX_CHANNELS` bound, so a FIL/DRC extension payload with enough `additional_excluded_chns=1` bits writes past the `drc_info` allocation. `dab-cmdline` (the DAB decoder sdrangel's DAB+ demod links against) feeds AAC access units straight into `NeAACDecDecode()`, so this runs on attacker-controlled broadcast/recorded input.

Two things came up bumping this that are worth spelling out:

1. faad2 only shipped 2.8.8 on SourceForge — anything newer only exists as a GitHub tag on knik0/faad2. I went with 2.10.1 rather than the minimum 2.9.0: it's the last release before the 2.11.0 CMake rewrite (so the existing autotools `CONFIGURE_COMMAND` still applies unchanged), and the commit range between 2.9.0 and 2.10.1 has a few more real memory-safety fixes (a stack-buffer-overflow in `mp4read.c`'s `stringin()`/`ftypin()`, a heap-buffer-overflow from an integer overflow in `stszin()`). Library/header names (`libfaad`, `faad.h`/`neaacdec.h`) are unchanged, so nothing downstream needed to change.
2. GitHub's auto-generated source archive for a tag doesn't include a pre-built `configure` script — only `configure.ac` and a `bootstrap` script that runs the usual `aclocal && autoheader && libtoolize && automake && autoconf`. The old SourceForge tarball had `configure` pre-generated, which is why the existing `CONFIGURE_COMMAND` just worked. I added a `PATCH_COMMAND <SOURCE_DIR>/bootstrap` step ahead of it (same fix `libusb` above already applies for the same reason — its comment even says so: "cloning git repo doesn't include configure, so we download the bz2 which does"). autoconf/automake/libtool are already in the Linux CI dependency list, and they're part of the default Homebrew toolchain on GitHub's macOS runners, so this shouldn't add any new setup on CI.

What I verified: the fix commit is genuinely present in the 2.10.1 tree, the URL resolves and the tarball has the executable bit set on `bootstrap`, and the library/header layout is unchanged from 2.8.8. I don't have a Qt/CMake toolchain here to actually run a full sdrangel build, so I can't confirm the ExternalProject step end to end — flagging that honestly rather than claiming it's been built.
