### PR TITLE
LocalSink: fix crash when adding channel with no Local Input device (#2764)

### DIFF
--- a/plugins/channelrx/localsink/localsink.cpp
+++ b/plugins/channelrx/localsink/localsink.cpp
@@ -819,7 +819,7 @@ void LocalSink::updateDeviceSetList()
     LocalSinkSettings settings = m_settings;
     int newIndexInList;
 
-    if (it != deviceSets.begin())
+    if (!m_localInputDeviceIndexes.empty()) // there are some local input devices
     {
         if (m_settings.m_localDeviceIndex < 0) {
             newIndexInList = 0;


### PR DESCRIPTION
Fixes #2764.

Adding a Local Sink channel crashes when no Local Input device set is open. The stack in the issue points at `LocalSink::updateDeviceSetList`, which runs from the LocalSink constructor.

The problem is the guard on the index selection:

```cpp
if (it != deviceSets.begin())
```

By this point `it` has walked the whole device set list, so it equals `deviceSets.end()`. That makes the condition true whenever any device set exists at all, LocalInput or not. A freshly created channel has `m_localDeviceIndex = -1` (the settings default), so `newIndexInList` gets set to 0 and `m_localInputDeviceIndexes[0]` reads past the end of an empty QList. In a release build that's the access violation from the report.

The interferometer plugin has the same function with a correct guard (interferometer.cpp line 405), so this change just copies it over:

```cpp
if (!m_localInputDeviceIndexes.empty()) // there are some local input devices
```

With the list empty, `newIndexInList` stays -1 and `m_localDeviceIndex` resolves to -1, meaning no device, which the rest of the function already handles.

To check the behavior I pulled the index-selection logic into a small standalone program using Qt6's QList, with one non-LocalInput device set and the default -1 index. The old guard trips QList's bounds assert (an out-of-bounds read in release builds), the new one settles at -1. I wasn't able to run a full SDRangel build here, but the change is a one-line condition swap matching the existing interferometer code.
