### PR TITLE
cmake: enforce minimum versions for CM256cc and Codec2 dependencies

### DIFF
--- a/cmake/Modules/FindCM256cc.cmake
+++ b/cmake/Modules/FindCM256cc.cmake
@@ -1,11 +1,29 @@
+# If CM256CC_DIR is specified, treat it as an explicit user override and
+# search that installation directly. Otherwise, use pkg-config to verify
+# the minimum supported libcm256cc version, since the library itself does
+# not expose version information through its headers or shared library.
+
 if (NOT CM256CC_FOUND)
-    INCLUDE(FindPkgConfig)
-    PKG_CHECK_MODULES(PC_CM256cc "libcm256cc")
+    if(CM256CC_DIR)
+        message(STATUS "Using CM256CC_DIR: ${CM256CC_DIR}")
+    else()
+        find_package(PkgConfig QUIET)
+        if(NOT PKG_CONFIG_FOUND)
+            message(STATUS "CM256CC support disabled: pkg-config is required to verify libcm256cc.")
+            return()
+        endif()
+
+        pkg_check_modules(PC_CM256CC QUIET libcm256cc>=1.1.2)
+        if(NOT PC_CM256CC_FOUND)
+            message(STATUS "CM256CC support disabled: libcm256cc >= 1.1.2 was not found.")
+            return()
+        endif()
+    endif()
 
     FIND_PATH(CM256CC_INCLUDE_DIR
         NAMES cm256cc/cm256.h
         HINTS ${CM256CC_DIR}/include
-              ${PC_CM256CC_INCLUDE_DIR}
+              ${PC_CM256CC_INCLUDE_DIRS}
               ${CMAKE_INSTALL_PREFIX}/include
         PATHS /usr/local/include
               /usr/include
@@ -15,7 +33,7 @@ if (NOT CM256CC_FOUND)
         NAMES cm256cc libcm256cc
         HINTS ${CM256CC_DIR}/lib
               ${CM256CC_DIR}/lib64
-              ${PC_CM256CC_LIBDIR}
+              ${PC_CM256CC_LIBRARY_DIRS}
               ${CMAKE_INSTALL_PREFIX}/lib
               ${CMAKE_INSTALL_PREFIX}/lib64
         PATHS /usr/local/lib

--- a/cmake/Modules/FindCodec2.cmake
+++ b/cmake/Modules/FindCodec2.cmake
@@ -1,11 +1,29 @@
+# If CODEC2_DIR is specified, treat it as an explicit user override and
+# search that installation directly. Otherwise use pkg-config to verify
+# the minimum supported codec2 version before locating the headers and
+# library.
+
 if (NOT CODEC2_FOUND)
-    INCLUDE(FindPkgConfig)
-    PKG_CHECK_MODULES(PC_CODEC2 "codec2")
+    if (CODEC2_DIR)
+        message(STATUS "Using CODEC2_DIR: ${CODEC2_DIR}")
+    else()
+        find_package(PkgConfig QUIET)
+        if(NOT PKG_CONFIG_FOUND)
+            message(STATUS "codec2 support disabled: pkg-config is required to verify codec2 version.")
+            return()
+        endif()
+
+        pkg_check_modules(PC_CODEC2 QUIET codec2>=1.1.1)
+        if(NOT PC_CODEC2_FOUND)
+            message(STATUS "codec2 support disabled: codec2 >= 1.1.1 was not found.")
+            return()
+        endif()
+    endif()
 
     FIND_PATH(CODEC2_INCLUDE_DIR
         NAMES codec2/codec2.h
         HINTS ${CODEC2_DIR}/include
-              ${PC_CODEC2_INCLUDE_DIR}
+              ${PC_CODEC2_INCLUDE_DIRS}
               ${CMAKE_INSTALL_PREFIX}/include
         PATHS /usr/local/include
               /usr/include
@@ -15,7 +33,7 @@ if (NOT CODEC2_FOUND)
         NAMES codec2 libcodec2
         HINTS ${CODEC2_DIR}/lib
               ${CODEC2_DIR}/lib64
-              ${PC_CODEC2_LIBDIR}
+              ${PC_CODEC2_LIBRARY_DIRS}
               ${CMAKE_INSTALL_PREFIX}/lib
               ${CMAKE_INSTALL_PREFIX}/lib64
         PATHS /usr/local/lib


### PR DESCRIPTION
Improve dependency discovery for CM256cc and Codec2 by making version requirements explicit during CMake configuration.

Previously, the Find modules could locate an installed library without verifying that the version met the minimum requirements expected by SDRangel. This could (and did for me) allow unsupported library versions to be selected and result in later puzzling build failures.

Changes
- Update the CM256cc finder to verify `libcm256cc >= 1.1.2` through pkg-config when no explicit installation override is provided.
- Update the Codec2 finder to verify `codec2 >= 1.1.1` through pkg-config when no explicit installation override is provided.
- Preserve existing `CM256CC_DIR` and `CODEC2_DIR` override behavior so custom installations can still be selected explicitly.
- Improve use of pkg-config metadata by using the standard include and library directory variables generated by `pkg_check_modules()`.
- Keep missing or unsupported optional dependencies from stopping the overall CMake configuration; CM256 and Codec2 support are disabled when suitable dependencies are unavailable.

Both dependencies have minimum versions required by SDRangel, but the previous discovery logic only checked whether headers and libraries existed. That made it possible to configure against older installations that did not satisfy the expected API or behavior.

This change moves the compatibility check earlier in the configuration process and provides clearer feedback when optional features are unavailable. The tradeoff is that the minimum supported versions are now maintained in the
CMake modules and must be updated when dependency requirements change. 
