### PR TITLE
Fix kiwiSDRs on Map

### DIFF
--- a/plugins/feature/map/mapgui.cpp
+++ b/plugins/feature/map/mapgui.cpp
@@ -673,7 +673,7 @@ void MapGUI::kiwiSDRUpdated(const QList<KiwiSDRList::KiwiSDR>& sdrs)
         QString band = "HF";
         if (sdr.m_highFrequency > 300000000) {
             band = "UHF";
-        } else if (sdr.m_highFrequency > 320000000) { // Technically 30MHz, but many HF Kiwis list up to 32MHz
+        } else if (sdr.m_highFrequency > 32000000) { // Technically 30MHz, but many HF Kiwis list up to 32MHz
             band = "VHF";
         }
         QString label = QString("Kiwi %1").arg(band);

--- a/sdrbase/util/kiwisdrlist.cpp
+++ b/sdrbase/util/kiwisdrlist.cpp
@@ -56,9 +56,9 @@ void KiwiSDRList::getData()
 {
 #ifdef __EMSCRIPTEN__
     // kiwisdr.com doesn't support https, but it's needed for Emscripten - our CORS proxy handles it
-    QUrl url = CORSProxy::adjustHost(QUrl("https://kiwisdr.com/.public/"));
+    QUrl url = CORSProxy::adjustHost(QUrl("https://kiwisdr.com/public/"));
 #else
-    QUrl url = CORSProxy::adjustHost(QUrl("http://kiwisdr.com/.public/"));
+    QUrl url = CORSProxy::adjustHost(QUrl("http://kiwisdr.com/public/"));
 #endif
     m_networkManager->get(QNetworkRequest(url));
 }

--- a/sdrbase/util/kiwisdrlist.h
+++ b/sdrbase/util/kiwisdrlist.h
@@ -27,7 +27,7 @@ class QNetworkAccessManager;
 class QNetworkReply;
 class QNetworkDiskCache;
 
-// Gets a list of public Kiwi SDRs from http://kiwisdr.com/.public/
+// Gets a list of public Kiwi SDRs from http://kiwisdr.com/public/
 class SDRBASE_API KiwiSDRList : public QObject
 {
     Q_OBJECT


### PR DESCRIPTION
Fix VHF frequency to be 32MHz, rather than 320MHz. Should fix #2801.
Use latest kiwiSDR public list URL so kiwiSDRs reappear on map.
