### PR TITLE
PlutoSDR: Guard against null buddy shared pointers | Fix #2779

### DIFF
--- a/plugins/samplesink/plutosdroutput/plutosdroutput.cpp
+++ b/plugins/samplesink/plutosdroutput/plutosdroutput.cpp
@@ -272,6 +272,11 @@ bool PlutoSDROutput::openDevice()
 
         DeviceAPI *sourceBuddy = m_deviceAPI->getSourceBuddies()[0];
         DevicePlutoSDRShared* buddySharedPtr = (DevicePlutoSDRShared*) sourceBuddy->getBuddySharedPtr();
+        if (!buddySharedPtr)
+        {
+            qCritical("PlutoSDROutput::openDevice: Rx buddy has no shared data");
+            return false;
+        }
         m_deviceShared.m_deviceParams = buddySharedPtr->m_deviceParams;
 
         if (m_deviceShared.m_deviceParams == 0)
@@ -369,7 +374,7 @@ void PlutoSDROutput::suspendBuddies()
         DeviceAPI *buddy = m_deviceAPI->getSourceBuddies()[i];
         DevicePlutoSDRShared *buddyShared = (DevicePlutoSDRShared *) buddy->getBuddySharedPtr();
 
-        if (buddyShared->m_thread) {
+        if (buddyShared && buddyShared->m_thread) {
             buddyShared->m_thread->stopWork();
         }
     }
@@ -384,7 +389,7 @@ void PlutoSDROutput::resumeBuddies()
         DeviceAPI *buddy = m_deviceAPI->getSourceBuddies()[i];
         DevicePlutoSDRShared *buddyShared = (DevicePlutoSDRShared *) buddy->getBuddySharedPtr();
 
-        if (buddyShared->m_thread) {
+        if (buddyShared && buddyShared->m_thread) {
             buddyShared->m_thread->startWork();
         }
     }
@@ -432,6 +437,12 @@ bool PlutoSDROutput::applySettings(const PlutoSDROutputSettings& settings, const
         for (; itSink != sourceBuddies.end(); ++itSink)
         {
             DevicePlutoSDRShared *buddySharedPtr = (DevicePlutoSDRShared *) (*itSink)->getBuddySharedPtr();
+
+            if (!buddySharedPtr)
+            {
+                qWarning("PlutoSDROutput::applySettings: source buddy has no shared data");
+                continue;
+            }
 
             if (buddySharedPtr->m_thread) {
                 buddySharedPtr->m_thread->stopWork();
@@ -571,7 +582,7 @@ bool PlutoSDROutput::applySettings(const PlutoSDROutputSettings& settings, const
         {
             DevicePlutoSDRShared *buddySharedPtr = (DevicePlutoSDRShared *) (*itSource)->getBuddySharedPtr();
 
-            if (buddySharedPtr->m_threadWasRunning) {
+            if (buddySharedPtr && buddySharedPtr->m_threadWasRunning) {
                 buddySharedPtr->m_thread->startWork();
             }
         }

--- a/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
@@ -282,6 +282,11 @@ bool PlutoSDRInput::openDevice()
 
         DeviceAPI *sinkBuddy = m_deviceAPI->getSinkBuddies()[0];
         DevicePlutoSDRShared* buddySharedPtr = (DevicePlutoSDRShared*) sinkBuddy->getBuddySharedPtr();
+        if (!buddySharedPtr)
+        {
+            qCritical("PlutoSDRInput::openDevice: Tx buddy has no shared data");
+            return false;
+        }
         m_deviceShared.m_deviceParams = buddySharedPtr->m_deviceParams;
 
         if (m_deviceShared.m_deviceParams == 0)
@@ -379,7 +384,7 @@ void PlutoSDRInput::suspendBuddies()
         DeviceAPI *buddy = m_deviceAPI->getSinkBuddies()[i];
         DevicePlutoSDRShared *buddyShared = (DevicePlutoSDRShared *) buddy->getBuddySharedPtr();
 
-        if (buddyShared->m_thread) {
+        if (buddyShared && buddyShared->m_thread) {
             buddyShared->m_thread->stopWork();
         }
     }
@@ -394,7 +399,7 @@ void PlutoSDRInput::resumeBuddies()
         DeviceAPI *buddy = m_deviceAPI->getSinkBuddies()[i];
         DevicePlutoSDRShared *buddyShared = (DevicePlutoSDRShared *) buddy->getBuddySharedPtr();
 
-        if (buddyShared->m_thread) {
+        if (buddyShared && buddyShared->m_thread) {
             buddyShared->m_thread->startWork();
         }
     }
@@ -443,6 +448,12 @@ bool PlutoSDRInput::applySettings(const PlutoSDRInputSettings& settings, const Q
         for (; itSink != sinkBuddies.end(); ++itSink)
         {
             DevicePlutoSDRShared *buddySharedPtr = (DevicePlutoSDRShared *) (*itSink)->getBuddySharedPtr();
+
+            if (!buddySharedPtr)
+            {
+                qWarning("PlutoSDRInput::applySettings: sink buddy has no shared data");
+                continue;
+            }
 
             if (buddySharedPtr->m_thread) {
                 buddySharedPtr->m_thread->stopWork();
@@ -624,7 +635,7 @@ bool PlutoSDRInput::applySettings(const PlutoSDRInputSettings& settings, const Q
         {
             DevicePlutoSDRShared *buddySharedPtr = (DevicePlutoSDRShared *) (*itSink)->getBuddySharedPtr();
 
-            if (buddySharedPtr->m_threadWasRunning) {
+            if (buddySharedPtr && buddySharedPtr->m_threadWasRunning) {
                 buddySharedPtr->m_thread->startWork();
             }
         }


### PR DESCRIPTION
Add defensive null checks before dereferencing DeviceAPI::getBuddySharedPtr() in the PlutoSDR input and output plugins.

DeviceAPI initializes the buddy shared pointer to nullptr, so a buddy may exist before its shared state has been attached. This could result in null pointer dereferences during device initialization, buddy thread suspend/resume, or settings application.

Changes include:
- Validate buddy shared pointer in openDevice() and fail gracefully if absent.
- Guard suspendBuddies() and resumeBuddies() against null shared pointers.
- Skip buddies without shared state during applySettings() while logging a warning.
- Prevent dereferencing null buddy shared pointers when restarting buddy threads.

These changes improve robustness during PlutoSDR buddy initialization and avoid crashes caused by partially initialized buddy relationships.

I was not able to re-create the issue, but this should fix (in theory) the trace in #2779 