### PR TITLE
Fix coverity int handling issues

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -3970,7 +3970,7 @@ void ADSBDemodGUI::decodeCommB(const QByteArray data, const QDateTime dateTime, 
         c[2] = ((data[5] & 0x7) << 3) | ((data[6] >> 5) & 0x7);
         c[3] = ((data[6] & 0x1f) << 1) | ((data[7] >> 7) & 0x1);
         c[4] = ((data[7] >> 1) & 0x1f);
-        c[5] = ((data[7] & 0x1) >> 3) | ((data[8] >> 3) & 0x1f);
+        c[5] = ((data[7] & 0x1) << 5) | ((data[8] >> 3) & 0x1f);
         c[6] = ((data[8] & 0x7) << 3) | ((data[9] >> 5) & 0x7);
         c[7] = ((data[9] & 0x1f) << 1) | ((data[10] >> 7) & 0x1);
         c[8] = ((data[10] >> 1) & 0x3f);

--- a/plugins/channelrx/demodft8/ft8demodgui.cpp
+++ b/plugins/channelrx/demodft8/ft8demodgui.cpp
@@ -453,7 +453,7 @@ void FT8DemodGUI::on_applyBandPreset_clicked()
     int bandPresetIndex = ui->bandPreset->currentIndex();
     int channelShift = m_settings.getBandPresets(m_settings.m_decoderMode)[bandPresetIndex].m_channelOffset; // kHz
     int baseFrequency = m_settings.getBandPresets(m_settings.m_decoderMode)[bandPresetIndex].m_baseFrequency; // kHz
-    quint64 deviceFrequency = (baseFrequency - channelShift)*1000; // Hz
+    quint64 deviceFrequency = static_cast<quint64>(baseFrequency - channelShift) * 1000; // Hz
     m_ft8Demod->setDeviceCenterFrequency(deviceFrequency, m_settings.m_streamIndex);
 
     if (channelShift * 1000 != m_settings.m_inputFrequencyOffset)

--- a/plugins/channelrx/noisefigure/noisefiguregui.cpp
+++ b/plugins/channelrx/noisefigure/noisefiguregui.cpp
@@ -102,7 +102,7 @@ void NoiseFigureGUI::plotChart()
 
     // Create reference data series
     QLineSeries *ref = nullptr;
-    if ((m_refData.size() > 0) && (ui->chartSelect->currentIndex() < m_refCols-1)) {
+    if ((m_refData.size() > 0) && (m_refCols > 0) && (ui->chartSelect->currentIndex() < m_refCols-1)) {
         ref = new QLineSeries();
         for (int i = 0; i < m_refData.size() / m_refCols; i++) {
             ref->append(m_refData[i*m_refCols], m_refData[i*m_refCols+ui->chartSelect->currentIndex()+1]);

--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -3255,6 +3255,14 @@ void RadioAstronomyGUI::update2DSettingsFromSweep()
         float sweep1Start, sweep1Stop;
         sweep1Start = m_settings.m_sweep1Start;
         sweep1Stop = m_settings.m_sweep1Stop;
+
+        if (qFuzzyIsNull(m_settings.m_sweep1Step) || qFuzzyIsNull(m_settings.m_sweep2Step))
+        {
+            ui->power2DWidth->setValue(0);
+            ui->power2DHeight->setValue(0);
+            return;
+        }
+
         // Handle azimuth/l sweep through 0. E.g. 340deg -> 20deg with +vs step, or 20deg -> 340deg with -ve step
         if ((m_settings.m_sweep1Stop < m_settings.m_sweep1Start) && (m_settings.m_sweep1Step > 0)) {
             sweep1Stop = m_settings.m_sweep1Stop + 360.0;
@@ -6347,6 +6355,31 @@ void RadioAstronomyGUI::on_startStop_clicked(bool checked)
 {
     if (checked)
     {
+        QString errorMessage;
+        if (qFuzzyIsNull(m_settings.m_sweep1Step) && qFuzzyIsNull(m_settings.m_sweep2Step))
+        {
+            errorMessage = tr("Azimuth and elevation sweep steps cannot be zero.");
+        }
+        else if (qFuzzyIsNull(m_settings.m_sweep1Step))
+        {
+            errorMessage = tr("Azimuth sweep step cannot be zero.");
+        }
+        else if (qFuzzyIsNull(m_settings.m_sweep2Step))
+        {
+            errorMessage = tr("Elevation sweep step cannot be zero.");
+        }
+        if (!errorMessage.isEmpty())
+        {
+            QMessageBox::warning(this,
+                tr("Invalid Sweep Configuration"),
+                errorMessage);
+
+            ui->startStop->blockSignals(true);
+            ui->startStop->setChecked(false);
+            ui->startStop->blockSignals(false);
+            return;
+        }
+
         ui->startStop->setStyleSheet("QToolButton { background-color : green; }");
         applySettings(QStringList("startStop"));
         if (m_settings.m_power2DLinkSweep)

--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -1424,27 +1424,46 @@ void RadioAstronomyGUI::recalibrate()
 // Calculate Trx using Y-factor method
 void RadioAstronomyGUI::calcCalTrx()
 {
-    if ((m_calHot && m_calCold) && (m_calHot->m_fftSize == m_calCold->m_fftSize))
-    {
-        // y=Ph/Pc
-        double sumH = 0.0;
-        double sumC = 0.0;
-        for (int i = 0; i < m_calHot->m_fftSize; i++)
-        {
-            sumH += m_calHot->m_fftData[i];
-            sumC += m_calCold->m_fftData[i];
-        }
-        double y = sumH/sumC;
-        // Use y to calculate Trx, which should be the same for both calibration points
-        double Trx = (m_settings.m_tCalHot - (m_settings.m_tCalCold * y)) / (y - 1.0);
-        ui->calYFactor->setText(QString::number(y, 'f', 2));
-        ui->calTrx->setText(QString::number(Trx, 'f', 1));
-    }
-    else
-    {
+    auto clearCalibration = [this]() {
         ui->calYFactor->setText("");
         ui->calTrx->setText("");
+    };
+
+    if (!m_calHot || !m_calCold || (m_calHot->m_fftSize != m_calCold->m_fftSize))
+    {
+        clearCalibration();
+        return;
     }
+
+    // y=Ph/Pc
+    double sumH = 0.0;
+    double sumC = 0.0;
+    for (int i = 0; i < m_calHot->m_fftSize; i++)
+    {
+        sumH += m_calHot->m_fftData[i];
+        sumC += m_calCold->m_fftData[i];
+    }
+
+    if (sumC == 0.0)
+    {
+        clearCalibration();
+        return;
+    }
+
+    double y = sumH/sumC;
+
+    // The Y-factor method is undefined when hot and cold measurements have the same power
+    // (y == 1). Use qFuzzyCompare to account for floating-point rounding near unity.
+    if (qFuzzyCompare(y, 1.0))
+    {
+        clearCalibration();
+        return;
+    }
+
+    // Use y to calculate Trx, which should be the same for both calibration points.
+    double Trx = (m_settings.m_tCalHot - (m_settings.m_tCalCold * y)) / (y - 1.0);
+    ui->calYFactor->setText(QString::number(y, 'f', 2));
+    ui->calTrx->setText(QString::number(Trx, 'f', 1));
 }
 
 // Estimate spillover temperature (This is typically very Az/El dependent as ground noise will vary)


### PR DESCRIPTION
This PR addresses several Coverity findings related to unsafe arithmetic, invalid state handling, and bit manipulation across multiple channel plugins.

The changes:
- Fix invalid bit extraction in ADS-B BDS 4,1 waypoint decoding. (another one that was not flagged last week).
- Prevent potential integer overflow during FT8 frequency conversion.
- Add validation around division operations in Noise Figure and Radio Astronomy calculations.
- Improve Radio Astronomy validation for calibration and sweep configuration edge cases.

These changes eliminate the reported Coverity issues while preserving existing behavior and making invalid runtime states fail safely.

Built all affected components, and run time tested the ADS-B ones.