### PR TITLE
Fix Coverity UNINIT warnings in RadioAstronomy and VOR Localizer

### DIFF
--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -3365,6 +3365,9 @@ void RadioAstronomyGUI::update2DImage(FFTMeasurement* fft, bool skipCalcs)
                 intensity = fft->m_tSys;
                 break;
             default:
+                qWarning() << "Unexpected power unit:" << m_settings.m_powerYUnits
+                     << "Falling back to totalPowerdBFS";
+                intensity = fft->m_totalPowerdBFS;
                 break;
             }
 

--- a/plugins/feature/vorlocalizer/vorlocalizergui.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizergui.cpp
@@ -304,8 +304,10 @@ bool VORModel::findIntersection(float &lat, float &lon)
 {
     if (m_vors.count() > 2)
     {
-        float lat1, lon1, bearing1, valid1 = false;
-        float lat2, lon2, bearing2, valid2 = false;
+        float lat1 = 0.0f, lon1 = 0.0f, bearing1 = 0.0f;
+        bool valid1 = false;
+        float lat2 = 0.0f, lon2 = 0.0f, bearing2 = 0.0f;
+        bool valid2 = false;
 
         for (int i = 0; i < m_vors.count(); i++)
         {


### PR DESCRIPTION
This PR resolves two Coverity-reported UNINIT warnings.

The changes ensure variables are always initialized before use, improve the robustness of the code against unexpected conditions, and strengthen type correctness by using appropriate boolean validity flags where applicable.

These changes do not alter the intended behavior of either feature but eliminate potential undefined behavior and improve the clarity of the code.

