### PR TITLE
Remove redundant ui null check in MeshcoreDemodGUI

### DIFF
--- a/plugins/channelrx/demodmeshcore/meshcoredemodgui.cpp
+++ b/plugins/channelrx/demodmeshcore/meshcoredemodgui.cpp
@@ -2350,7 +2350,7 @@ void MeshcoreDemodGUI::setDechirpInspectionMode(bool enabled)
     {
         m_dechirpSelectedMessageKey.clear();
 
-        if (m_spectrumVis && ui && ui->glSpectrum)
+        if (m_spectrumVis && ui->glSpectrum)
         {
             m_spectrumVis->setGLSpectrum(ui->glSpectrum);
 

--- a/plugins/channelrx/demodmeshtastic/meshtasticdemodgui.cpp
+++ b/plugins/channelrx/demodmeshtastic/meshtasticdemodgui.cpp
@@ -2350,7 +2350,7 @@ void MeshtasticDemodGUI::setDechirpInspectionMode(bool enabled)
     {
         m_dechirpSelectedMessageKey.clear();
 
-        if (m_spectrumVis && ui && ui->glSpectrum)
+        if (m_spectrumVis && ui->glSpectrum)
         {
             m_spectrumVis->setGLSpectrum(ui->glSpectrum);
 


### PR DESCRIPTION
The ui object is created during MeshcoreDemodGUI construction and remains valid for the lifetime of the widget. Remove the unnecessary null check to avoid misleading static analysis tools into assuming ui can be null.

This resolves a Coverity false positive where the later call to updateDechirpModeUI() was reported as a possible null dereference.