### PR TITLE
Fix missing YAML-to-SWG mappings for MeshCore plugins

### DIFF
--- a/sdrbase/webapi/webapirequestmapper.cpp
+++ b/sdrbase/webapi/webapirequestmapper.cpp
@@ -4855,6 +4855,11 @@ bool WebAPIRequestMapper::getChannelActions(
             channelActions->setIeee802154ModActions(new SWGSDRangel::SWGIEEE_802_15_4_ModActions());
             channelActions->getIeee802154ModActions()->fromJsonObject(actionsJsonObject);
         }
+        else if (channelActionsKey == "MeshcoreModActions")
+        {
+            channelActions->setMeshcoreModActions(new SWGSDRangel::SWGMeshcoreModActions());
+            channelActions->getMeshcoreModActions()->fromJsonObject(actionsJsonObject);
+        }
         else if (channelActionsKey == "RadioAstronomyActions")
         {
             channelActions->setRadioAstronomyActions(new SWGSDRangel::SWGRadioAstronomyActions());

--- a/sdrbase/webapi/webapiutils.cpp
+++ b/sdrbase/webapi/webapiutils.cpp
@@ -39,6 +39,8 @@ const QMap<QString, QString> WebAPIUtils::m_channelURIToSettingsKey = {
     {"sdrangel.channel.chirpchatdemod", "ChirpChatDemodSettings"},
     {"sdrangel.channel.meshtasticdemod", "ChirpChatDemodSettings"}, // alias: Meshtastic uses ChirpChatDemodSettings schema
     {"sdrangel.channel.modchirpchat", "ChirpChatModSettings"},
+    {"sdrangel.channel.meshcoredemod", "MeshcoreDemodSettings"},
+    {"sdrangel.channeltx.modmeshcore", "MeshcoreModSettings"},
     {"sdrangel.channel.demodatv", "ATVDemodSettings"},
     {"sdrangel.channel.demoddatv", "DATVDemodSettings"},
     {"sdrangel.channel.dabdemod", "DABDemodSettings"},
@@ -165,6 +167,8 @@ const QMap<QString, QString> WebAPIUtils::m_channelTypeToSettingsKey = {
     {"ChirpChatDemod", "ChirpChatDemodSettings"},
     {"MeshtasticDemod", "ChirpChatDemodSettings"}, // alias: Meshtastic uses ChirpChatDemodSettings schema
     {"ChirpChatMod", "ChirpChatModSettings"},
+    {"MeshcoreDemod", "MeshcoreDemodSettings"},
+    {"MeshcoreMod", "MeshcoreModSettings"},
     {"ChannelPower", "ChannelPowerSettings"},
     {"DATVDemod", "DATVDemodSettings"},
     {"DATVMod", "DATVModSettings"},

--- a/swagger/sdrangel/api/swagger/include/ChannelActions.yaml
+++ b/swagger/sdrangel/api/swagger/include/ChannelActions.yaml
@@ -29,6 +29,8 @@ ChannelActions:
       $ref: "http://swgserver:8081/api/swagger/include/FreqScanner.yaml#/FreqScannerActions"
     IEEE_802_15_4_ModActions:
       $ref: "http://swgserver:8081/api/swagger/include/IEEE_802_15_4_Mod.yaml#/IEEE_802_15_4_ModActions"
+    MeshcoreModActions:
+      $ref: "http://swgserver:8081/api/swagger/include/MeshcoreMod.yaml#/MeshcoreModActions"
     PacketModActions:
       $ref: "http://swgserver:8081/api/swagger/include/PacketMod.yaml#/PacketModActions"
     PSK31ModActions:

--- a/swagger/sdrangel/api/swagger/include/MeshcoreMod.yaml
+++ b/swagger/sdrangel/api/swagger/include/MeshcoreMod.yaml
@@ -126,3 +126,13 @@ MeshcoreModReport:
         Boolean - modulator is active (playing) including idle time
           * 0 - Modulator not active
           * 1 - Modulator active
+
+MeshcoreModActions:
+  description: MeshcoreMod
+  properties:
+    sendNow:
+      type: integer
+      description: >
+        Send packet immediately
+          * 0 - Do nothing
+          * 1 - Send packet

--- a/swagger/sdrangel/code/qt5/client/SWGModelFactory.h
+++ b/swagger/sdrangel/code/qt5/client/SWGModelFactory.h
@@ -234,6 +234,7 @@
 #include "SWGMeshtasticModSettings.h"
 #include "SWGMeshcoreDemodReport.h"
 #include "SWGMeshcoreDemodSettings.h"
+#include "SWGMeshcoreModActions.h"
 #include "SWGMeshcoreModReport.h"
 #include "SWGMeshcoreModSettings.h"
 #include "SWGMetisMISOSettings.h"
@@ -1513,6 +1514,11 @@ namespace SWGSDRangel {
     }
     if(QString("SWGMeshcoreModSettings").compare(type) == 0) {
       SWGMeshcoreModSettings *obj = new SWGMeshcoreModSettings();
+      obj->init();
+      return obj;
+    }
+    if(QString("SWGMeshcoreModActions").compare(type) == 0) {
+      SWGMeshcoreModActions *obj = new SWGMeshcoreModActions();
       obj->init();
       return obj;
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/f4exb/sdrangel/issues/2822:

- Add missing YAML-to-SWG mappings for the MeshCore channel plugins. The MeshCore mod plugin (`meshcoremod.cpp`) references `SWGMeshcoreModActions` — but `MeshcoreMod.yaml` had no corresponding `MeshcoreModActions` section.
- If the swagger code generator is re-run, the auto-generated `SWGChannelActions.h/cpp` loses the `meshcore_mod_actions` member and accessors, breaking compilation of `meshcoremod.cpp`.
- Also fixes four companion integration gaps found in the same sweep: `ChannelActions.yaml`, `SWGModelFactory.h`, `webapirequestmapper.cpp`, and `webapiutils.cpp` were all missing entries.