### PR TITLE
Fix built-in device selection regression

### DIFF
--- a/sdrgui/gui/samplingdevicedialog.cpp
+++ b/sdrgui/gui/samplingdevicedialog.cpp
@@ -91,7 +91,8 @@ void SamplingDeviceDialog::displayDevices()
                     samplingDevice = DeviceEnumerator::instance()->getMIMOSamplingDevice(coreDeviceIndex);
                 }
 
-                if (samplingDevice && samplingDevice->claimed >= 0) {
+                if (samplingDevice && samplingDevice->claimed >= 0 &&
+                        samplingDevice->type != PluginInterface::SamplingDevice::BuiltInDevice) {
                     QStandardItem *item = model->item(idx);
                     if (item) {
                         // Deactivate to block selection clicks


### PR DESCRIPTION
Built-in devices were previously always selectable regardless of their claimed state. The "show devices in use" change https://github.com/f4exb/sdrangel/commit/964bc0994d1e5c54ef8b08eb9102e0ee4f7d744e inadvertently disabled all claimed devices in the selection dialog, preventing multiple instances of FileInput, RemoteTCPInput, AudioInput, TestSource and other built-in sources from being opened. :(

Only claimed physical devices are now disabled and marked "[in use]". Built-in devices remain selectable as before.

Fixes: #2761 #2770
Details: https://github.com/f4exb/sdrangel/pull/2770#issuecomment-5032265611