### PR TITLE
ft8: replace temporary malloc buffer with std::vector

### DIFF
--- a/ft8/libldpc.cpp
+++ b/ft8/libldpc.cpp
@@ -35,7 +35,8 @@
 
 #include <stdio.h>
 #include <math.h>
-#include <stdlib.h>
+#include <cstring>
+#include <vector>
 #include "arrays.h"
 #include "libldpc.h"
 
@@ -371,19 +372,8 @@ void LDPC::ft8_crc(int msg1[], int msglen, int out[14])
     // with leading 1 bit.
     int div[] = {1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1};
     // append 14 zeros.
-    int *msg = (int *)malloc(sizeof(int) * (msglen + 14));
-
-    for (int i = 0; i < msglen + 14; i++)
-    {
-        if (i < msglen)
-        {
-            msg[i] = msg1[i];
-        }
-        else
-        {
-            msg[i] = 0;
-        }
-    }
+    std::vector<int> msg(msglen + 14);
+    std::memcpy(msg.data(), msg1, msglen * sizeof(int));
 
     for (int i = 0; i < msglen; i++)
     {
@@ -400,8 +390,6 @@ void LDPC::ft8_crc(int msg1[], int msglen, int out[14])
     {
         out[i] = msg[msglen + i];
     }
-
-    free(msg);
 }
 
 // rows is 91, cols is 174.


### PR DESCRIPTION
Replace the temporary CRC working buffer in `LDPC::ft8_crc()` with a `std::vector<int>`.

The vector is value-initialized, preserving the existing zero-padding behavior, while `std::memcpy()` copies the input message into the front of the buffer. This removes the manual `malloc()`/`free()` pair, simplifies the implementation, and uses RAII for temporary storage.

This change also addresses a cppcheck warning about a possible null pointer dereference following malloc() failure. If memory allocation now fails, std::vector will throw std::bad_alloc rather than returning a null pointer that would be dereferenced. The algorithm and behavior are otherwise unchanged.