### PR TITLE
Improve RadioAstronomyGUI robustnes

### DIFF
--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -2061,31 +2061,32 @@ void RadioAstronomyGUI::onMenuDialogCalled(const QPoint &p)
 
         dialog.move(p);
         new DialogPositioner(&dialog, false);
-        dialog.exec();
-
-        m_settings.m_rgbColor = m_channelMarker.getColor().rgb();
-        m_settings.m_title = m_channelMarker.getTitle();
-        m_settings.m_useReverseAPI = dialog.useReverseAPI();
-        m_settings.m_reverseAPIAddress = dialog.getReverseAPIAddress();
-        m_settings.m_reverseAPIPort = dialog.getReverseAPIPort();
-        m_settings.m_reverseAPIDeviceIndex = dialog.getReverseAPIDeviceIndex();
-        m_settings.m_reverseAPIChannelIndex = dialog.getReverseAPIChannelIndex();
-
-        setWindowTitle(m_settings.m_title);
-        setTitle(m_channelMarker.getTitle());
-        setTitleColor(m_settings.m_rgbColor);
-
-        if (m_deviceUISet->m_deviceMIMOEngine)
+        if (dialog.exec() == QDialog::Accepted)
         {
-            m_settings.m_streamIndex = dialog.getSelectedStreamIndex();
-            m_channelMarker.clearStreamIndexes();
-            m_channelMarker.addStreamIndex(m_settings.m_streamIndex);
-            updateIndexLabel();
-        }
+            m_settings.m_rgbColor = m_channelMarker.getColor().rgb();
+            m_settings.m_title = m_channelMarker.getTitle();
+            m_settings.m_useReverseAPI = dialog.useReverseAPI();
+            m_settings.m_reverseAPIAddress = dialog.getReverseAPIAddress();
+            m_settings.m_reverseAPIPort = dialog.getReverseAPIPort();
+            m_settings.m_reverseAPIDeviceIndex = dialog.getReverseAPIDeviceIndex();
+            m_settings.m_reverseAPIChannelIndex = dialog.getReverseAPIChannelIndex();
 
-        applySettings(QStringList({"title", "rgbColor", "useReverseAPI", "reverseAPIAddress",
-                                    "reverseAPIPort", "reverseAPIDeviceIndex", "reverseAPIChannelIndex",
-                                    "streamIndex"}));
+            setWindowTitle(m_settings.m_title);
+            setTitle(m_channelMarker.getTitle());
+            setTitleColor(m_settings.m_rgbColor);
+
+            if (m_deviceUISet->m_deviceMIMOEngine)
+            {
+                m_settings.m_streamIndex = dialog.getSelectedStreamIndex();
+                m_channelMarker.clearStreamIndexes();
+                m_channelMarker.addStreamIndex(m_settings.m_streamIndex);
+                updateIndexLabel();
+            }
+
+            applySettings(QStringList({"title", "rgbColor", "useReverseAPI", "reverseAPIAddress",
+                                        "reverseAPIPort", "reverseAPIDeviceIndex", "reverseAPIChannelIndex",
+                                        "streamIndex"}));
+        }
     }
 
     resetContextMenuType();

--- a/plugins/channelrx/radioastronomy/radioastronomygui.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.cpp
@@ -5799,7 +5799,9 @@ void RadioAstronomyGUI::spectrumSeries_clicked(const QPointF &point)
             m_spectrumM1Valid = true;
             ui->spectrumMarkerTable->item(SPECTRUM_MARKER_ROW_M1, SPECTRUM_MARKER_COL_FREQ)->setData(Qt::DisplayRole, m_spectrumM1X);
             ui->spectrumMarkerTable->item(SPECTRUM_MARKER_ROW_M1, SPECTRUM_MARKER_COL_VALUE)->setData(Qt::DisplayRole, m_spectrumM1Y);
-            calcVrAndDistanceToPeak(m_spectrumM1X*1e6, fft, SPECTRUM_MARKER_ROW_M1);
+            if (fft) {
+                calcVrAndDistanceToPeak(m_spectrumM1X*1e6, fft, SPECTRUM_MARKER_ROW_M1);
+            }
         }
         else if (selection == "M2")
         {
@@ -5808,7 +5810,9 @@ void RadioAstronomyGUI::spectrumSeries_clicked(const QPointF &point)
             m_spectrumM2Valid = true;
             ui->spectrumMarkerTable->item(SPECTRUM_MARKER_ROW_M2, SPECTRUM_MARKER_COL_FREQ)->setData(Qt::DisplayRole, m_spectrumM2X);
             ui->spectrumMarkerTable->item(SPECTRUM_MARKER_ROW_M2, SPECTRUM_MARKER_COL_VALUE)->setData(Qt::DisplayRole, m_spectrumM2Y);
-            calcVrAndDistanceToPeak(m_spectrumM2X*1e6, fft, SPECTRUM_MARKER_ROW_M2);
+            if (fft) {
+                calcVrAndDistanceToPeak(m_spectrumM2X*1e6, fft, SPECTRUM_MARKER_ROW_M2);
+            }
         }
         calcSpectrumMarkerDelta();
 

--- a/plugins/channelrx/radioastronomy/radioastronomygui.h
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.h
@@ -186,7 +186,9 @@ class RadioAstronomyGUI : public ChannelGUI {
 
         SensorMeasurements() :
             m_series(nullptr),
-            m_yAxis(nullptr)
+            m_yAxis(nullptr),
+            m_max(-std::numeric_limits<double>::max()),
+            m_min(std::numeric_limits<double>::max())
         {
         }
 

--- a/plugins/channelrx/radioastronomy/radioastronomygui.h
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.h
@@ -96,7 +96,7 @@ class RadioAstronomyGUI : public ChannelGUI {
         float m_solarFlux;
         float m_airTemp;
         float m_skyTemp;
-        float m_sensor[RADIOASTRONOMY_SENSORS];
+        float m_sensor[RADIOASTRONOMY_SENSORS] {0.0f};
 
         bool m_rotValid;
         float m_rotAz;
@@ -107,6 +107,10 @@ class RadioAstronomyGUI : public ChannelGUI {
         int m_sweepIndex;
 
         FFTMeasurement() :
+            m_centerFrequency(0),
+            m_sampleRate(0),
+            m_integration(0),
+            m_rfBandwidth(0),
             m_fftSize(0),
             m_fftData(nullptr),
             m_db(nullptr),
@@ -124,7 +128,18 @@ class RadioAstronomyGUI : public ChannelGUI {
             m_sigmaS(0.0f),
             m_tempMin(0.0f),
             m_baseline(RadioAstronomySettings::SBL_TSYS0),
+            m_omegaA(0.0f),
+            m_omegaS(0.0f),
             m_coordsValid(false),
+            m_ra(0.0f),
+            m_dec(0.0f),
+            m_azimuth(0.0f),
+            m_elevation(0.0f),
+            m_l(0.0f),
+            m_b(0.0f),
+            m_vBCRS(0.0f),
+            m_vLSR(0.0f),
+            m_solarFlux(0.0f),
             m_airTemp(0.0),
             m_skyTemp(0.0),
             m_rotValid(false),


### PR DESCRIPTION
Improve RadioAstronomyGUI robustness by addressing several issues identified through static analysis. The changes ensure objects are fully initialized, prevent invalid pointer usage, and make dialog handling follow the expected Qt acceptance/rejection model.

- Initialize FFT measurement members with deterministic default values to ensure newly constructed measurement objects start in a valid state.
- Initialize sensor measurement range values during construction rather than relying on later initialization paths.
- Guard FFT measurement access in `spectrumSeries_clicked()` to avoid calling processing functions with a null measurement object.
- Apply channel settings only after the channel settings dialog is accepted, preventing discarded dialog changes from being applied.

These changes address Coverity findings related to:
- `UNINIT_CTOR` warnings from scalar members left uninitialized during  construction.
- Potential null pointer dereference when no FFT measurement is available.
- `CHECKED_RETURN` warning from ignoring the result of `QDialog::exec()`.

Beyond resolving static analysis warnings, the fixes improve the reliability of the RadioAstronomy plugin by ensuring objects have well-defined initial states, validating object availability before use (even before init), and preserving expected dialog behavior when users cancel configuration changes.