### PR TITLE
WDSP: Fix invalid iterator ranges in SPHP flush

### DIFF
--- a/wdsp/sphp.cpp
+++ b/wdsp/sphp.cpp
@@ -72,9 +72,9 @@ SPHP::SPHP(
 void SPHP::flush()
 {
     std::fill(x0.begin(), x0.end(), 0);
-    std::fill(x1.begin(), x0.end(), 0);
-    std::fill(y0.begin(), x0.end(), 0);
-    std::fill(y1.begin(), x0.end(), 0);
+    std::fill(x1.begin(), x1.end(), 0);
+    std::fill(y0.begin(), y0.end(), 0);
+    std::fill(y1.begin(), y1.end(), 0);
 }
 
 void SPHP::execute()


### PR DESCRIPTION
Correct std::fill() calls in SPHP::flush() that used x0.end() as the end iterator when clearing x1, y0, and y1.

The incorrect ranges were likely introduced by a copy/paste error and resulted in iterator pairs from different containers being used together, causing undefined behavior.

Use each buffer's own end iterator when clearing its contents.

Detected by cppcheck's mismatchingContainer check.

fixes #2826