### PR TITLE
PlutoSDR: keep device open state consistent after close

### DIFF
--- a/plugins/samplesink/plutosdroutput/plutosdroutput.cpp
+++ b/plugins/samplesink/plutosdroutput/plutosdroutput.cpp
@@ -363,6 +363,8 @@ void PlutoSDROutput::closeDevice()
         delete m_deviceShared.m_deviceParams;
         m_deviceShared.m_deviceParams = 0;
     }
+
+    m_open = false;
 }
 
 void PlutoSDROutput::suspendBuddies()

--- a/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
+++ b/plugins/samplesource/plutosdrinput/plutosdrinput.cpp
@@ -373,6 +373,8 @@ void PlutoSDRInput::closeDevice()
         delete m_deviceShared.m_deviceParams;
         m_deviceShared.m_deviceParams = 0;
     }
+
+    m_open = false;
 }
 
 void PlutoSDRInput::suspendBuddies()


### PR DESCRIPTION
Clear the m_open flag when closing PlutoSDR input and output devices. Previously closeDevice() released m_deviceParams but left m_open set, leaving the object in an inconsistent state where code could treat a closed device as still valid.

This was exposed when reloading a running PlutoSDR device, where GUI updates could access the partially torn-down device state.

Hopefully fixes #2833 (I don't have a windows machine to test).

This is constant with other devices.