### PR TITLE
step2 : reduce vlas 

### DIFF
--- a/plugins/channelrx/demoddatv/ldpctool/algorithms.h
+++ b/plugins/channelrx/demoddatv/ldpctool/algorithms.h
@@ -191,12 +191,13 @@ struct OffsetMinSumAlgorithm<SIMD<VALUE, WIDTH>, UPDATE, FACTOR>
 	static void finalp(TYPE *links, int cnt)
 	{
 		TYPE beta = vdup<TYPE>(0.5 * FACTOR);
-		TYPE mags[cnt], mins[cnt];
+		std::vector<TYPE> mags(cnt);
+		std::vector<TYPE> mins(cnt);
 		for (int i = 0; i < cnt; ++i)
 			mags[i] = vmax(vsub(vabs(links[i]), beta), vzero<TYPE>());
 		CODE::exclusive_reduce(mags, mins, cnt, min);
 
-		TYPE signs[cnt];
+		std::vector<TYPE> signs(cnt);
 		CODE::exclusive_reduce(links, signs, cnt, sign);
 
 		for (int i = 0; i < cnt; ++i)

--- a/plugins/channelrx/demoddatv/ldpctool/algorithms.h
+++ b/plugins/channelrx/demoddatv/ldpctool/algorithms.h
@@ -257,7 +257,7 @@ struct OffsetMinSumAlgorithm<SIMD<int8_t, WIDTH>, UPDATE, FACTOR>
 	static void finalp(TYPE *links, int cnt)
 	{
 		auto beta = vunsigned(vdup<TYPE>(std::nearbyint(0.5 * FACTOR)));
-		TYPE mags[cnt];
+		std::vector<TYPE> mags(cnt);
 		for (int i = 0; i < cnt; ++i)
 			mags[i] = vsigned(vqsub(vunsigned(vqabs(links[i])), beta));
 

--- a/plugins/channelrx/demoddatv/ldpctool/algorithms.h
+++ b/plugins/channelrx/demoddatv/ldpctool/algorithms.h
@@ -23,6 +23,8 @@ Copyright 2018 Ahmet Inan <xdsopl@gmail.com>
 #ifndef ALGORITHMS_HH
 #define ALGORITHMS_HH
 
+#include <vector>
+
 #include "generic.h"
 #include "exclusive_reduce.h"
 
@@ -60,12 +62,13 @@ struct MinSumAlgorithm<SIMD<VALUE, WIDTH>, UPDATE>
 	}
 	static void finalp(TYPE *links, int cnt)
 	{
-		TYPE mags[cnt], mins[cnt];
+		std::vector<TYPE> mags(cnt);
+		std::vector<TYPE> mins(cnt);
 		for (int i = 0; i < cnt; ++i)
 			mags[i] = vabs(links[i]);
 		CODE::exclusive_reduce(mags, mins, cnt, min);
 
-		TYPE signs[cnt];
+		std::vector<TYPE> signs(cnt);
 		CODE::exclusive_reduce(links, signs, cnt, sign);
 
 		for (int i = 0; i < cnt; ++i)

--- a/plugins/channelrx/demoddatv/ldpctool/algorithms.h
+++ b/plugins/channelrx/demoddatv/ldpctool/algorithms.h
@@ -127,7 +127,7 @@ struct MinSumAlgorithm<SIMD<int8_t, WIDTH>, UPDATE>
 	}
 	static void finalp(TYPE *links, int cnt)
 	{
-		TYPE mags[cnt];
+		std::vector<TYPE> mags(cnt);
 		for (int i = 0; i < cnt; ++i)
 			mags[i] = vqabs(links[i]);
 

--- a/plugins/channelrx/demoddatv/ldpctool/algorithms.h
+++ b/plugins/channelrx/demoddatv/ldpctool/algorithms.h
@@ -337,7 +337,7 @@ struct MinSumCAlgorithm<SIMD<VALUE, WIDTH>, UPDATE, FACTOR>
 	}
 	static void finalp(TYPE *links, int cnt)
 	{
-		TYPE tmp[cnt];
+		std::vector<TYPE> tmp(cnt);
 		CODE::exclusive_reduce(links, tmp, cnt, minc);
 		for (int i = 0; i < cnt; ++i)
 			links[i] = tmp[i];


### PR DESCRIPTION
This PR continues the effort to remove dependencies on compiler-specific variable length array (VLA) extensions within the DATV code.

The affected code uses temporary arrays whose size is determined at runtime. While GCC accepts these as an extension, they are not part of standard C++ and generate -Wvla warnings.

Replacing these temporary arrays with std::vector preserves the existing algorithms while reducing reliance on non-standard language extensions and improving portability.

These are small, mechanical changes with no intended functional impact.

Trying to do things as small atomic changes, so it's easier to bisect later if there are any issues.

Part of #2830