### PR TITLE
DATV: Convert leansdr fail and fatal errors into C++ exceptions

### DIFF
--- a/plugins/channelrx/demoddatv/datvdemodsink.cpp
+++ b/plugins/channelrx/demoddatv/datvdemodsink.cpp
@@ -1281,16 +1281,28 @@ void DATVDemodSink::feed(const SampleVector::const_iterator& begin, const Sample
 
         qDebug("DATVDemodSink::feed: Settings applied. Standard : %d...", m_settings.m_standard);
         m_blnNeedConfigUpdate = false;
-
-        if(m_settings.m_standard==DATVDemodSettings::DVB_S2)
+        try
         {
-            qDebug("DATVDemodSink::feed: init DVBS-2");
-            InitDATVS2Framework();
+            if(m_settings.m_standard==DATVDemodSettings::DVB_S2)
+            {
+                qDebug("DATVDemodSink::feed: init DVBS-2");
+                InitDATVS2Framework();
+            }
+            else
+            {
+                qDebug("DATVDemodSink::feed: init DVBS");
+                InitDATVFramework();
+            }
         }
-        else
+        catch (const std::exception& e)
         {
-            qDebug("DATVDemodSink::feed: init DVBS");
-            InitDATVFramework();
+            // leansdr uses fail() for unrecoverable internal errors.
+            // Convert these into a DATV initialization failure instead of
+            // allowing them to terminate the application.
+            qCritical("DATVDemodSink::feed: DATV framework initialization failed: %s", e.what());
+
+            CleanUpDATVFramework();
+            return;
         }
     }
 

--- a/plugins/channelrx/demoddatv/leansdr/framework.cpp
+++ b/plugins/channelrx/demoddatv/leansdr/framework.cpp
@@ -14,17 +14,23 @@
 // You should have received a copy of the GNU General Public License                 //
 // along with this program. If not, see <http://www.gnu.org/licenses/>.              //
 ///////////////////////////////////////////////////////////////////////////////////////
+
+#include <stdexcept>
+#include <string>
+
 #include "framework.h"
 
 namespace leansdr
 {
 
-void fatal(const char *s) {
+[[noreturn]] void fatal(const char *s) {
     perror(s);
+    throw std::runtime_error(std::string("leansdr fatal: ") + s);
 }
 
-void fail(const char *s) {
-    fprintf(stderr, "** %s\n", s);
+[[noreturn]] void fail(const char *s) {
+    fprintf(stderr, "** leansdr fail: %s\n", s);
+    throw std::runtime_error(std::string("leansdr fail: ") + s);
 }
 
 } // leansdr

--- a/plugins/channelrx/demoddatv/leansdr/framework.h
+++ b/plugins/channelrx/demoddatv/leansdr/framework.h
@@ -35,8 +35,8 @@
 namespace leansdr
 {
 
-void fatal(const char *s);
-void fail(const char *s);
+[[noreturn]] void fatal(const char *s);
+[[noreturn]] void fail(const char *s);
 
 //////////////////////////////////////////////////////////////////////
 // DSP framework


### PR DESCRIPTION
The original leansdr code uses `fatal()` and `fail()` for unrecoverable errors by terminating execution. When integrated into SDRangel, these error paths did not provide a mechanism for the plugin to handle failures locally, allowing initialization failures to escape the normal plugin lifecycle.

Convert leansdr `fatal()` and `fail()` handling into C++ exceptions so DATV can detect framework initialization failures, report them, and cleanly return control to SDRangel instead of allowing the error to terminate the application. This behavior is desirable because a DATV framework configuration failure should not bring down the entire application.

Catch initialization exceptions in `DATVDemodSink::feed()`, report the failure, clean up the partially initialized framework, and return to the caller.

Add noreturn annotations to the leansdr error functions and include the leansdr source in exception messages to make failures easier to diagnose.

This does not redesign leansdr error handling or provide recovery from runtime DSP failures. It only adds an exception boundary between the leansdr library code and the SDRangel plugin lifecycle.

noticed via cppcheck indicating many Array indexes could go out of bounds due to fail and fatal returning.

fixes #2835