### PR TITLE
wdsp: Prevent potential out-of-bounds array access

### DIFF
--- a/wdsp/emnr.cpp
+++ b/wdsp/emnr.cpp
@@ -233,7 +233,7 @@ void EMNR::NP::interpM (
         double xlhigh;
         double frac;
 
-        while ((x >= xvals[idx]) && (idx < nvals - 1))
+        while ((idx < nvals - 1) && (x >= xvals[idx]))
             idx++;
 
         xllow = log10 (xvals[idx - 1]);

--- a/wdsp/snba.cpp
+++ b/wdsp/snba.cpp
@@ -620,7 +620,7 @@ int SNBA::scanFrame(
 
     if (nimp > 0)
     {
-        while (merit[i] == merit[0] && i < nimp)
+        while (i < nimp && merit[i] == merit[0])
             i++;
     }
 


### PR DESCRIPTION
Fix cppcheck warnings where array elements were accessed before validating their indices. Reorder conditional expressions to ensure bounds checks are performed before array accesses, taking advantage of C++ short-circuit evaluation.

In EMNR::NP::interpM(), check the index limit before accessing xvals[idx]. In SNBA::scanFrame(), verify i is within the merit array bounds before evaluating merit[i].

These changes improve defensive programming practices and prevent potential undefined behavior if an index exceeds the valid range. No functional changes.