### PR TITLE
testmi: Fix missing m_title copy in TestMISettings

### DIFF
--- a/plugins/samplemimo/testmi/testmisettings.cpp
+++ b/plugins/samplemimo/testmi/testmisettings.cpp
@@ -58,6 +58,7 @@ TestMISettings::TestMISettings()
 }
 
 TestMISettings::TestMISettings(const TestMISettings& other) :
+    m_title(other.m_title),
     m_streams(other.m_streams)
 {
     m_useReverseAPI = other.m_useReverseAPI;


### PR DESCRIPTION
cppcheck reported that the TestMISettings copy constructor did not initialize member variable m_title:
  Member variable 'TestMISettings::m_title' is not assigned in the copy
  constructor. Should it be copied?

m_title is part of the serialized settings state, so ensure copied TestMISettings instances preserve the configured title value.