### PR TITLE
FT8/FT4: Remove uninitialized value warnings

### DIFF
--- a/ft8/ft4.cpp
+++ b/ft8/ft4.cpp
@@ -21,6 +21,7 @@
 #include <array>
 #include <cmath>
 #include <algorithm>
+#include <limits>
 #include <random>
 #include <functional>
 #include <cstdio>
@@ -140,8 +141,7 @@ float FT4::one_coarse_strength(const FFTEngine::ffts_t &bins, int bi0, int si0) 
     {
         for (int si = 0; si < 103; si++)
         {
-            float mx;
-            int mxi = -1;
+            float mx = -std::numeric_limits<float>::infinity();
             float sum = 0;
 
             for (int i = 0; i < 4; i++)
@@ -149,9 +149,8 @@ float FT4::one_coarse_strength(const FFTEngine::ffts_t &bins, int bi0, int si0) 
                 float x = std::abs(bins[si0 + si][bi0 + i]);
                 sum += x;
 
-                if (mxi < 0 || x > mx)
+                if (x > mx)
                 {
-                    mxi = i;
                     mx = x;
                 }
             }
@@ -1452,8 +1451,7 @@ std::vector<std::vector<float>> FT4::soft_c2m(const FFTEngine::ffts_t &c103) con
     for (int si = 0; si < 103; si++)
     {
         m103[si].resize(4);
-        int mxi = -1;
-        float mx;
+        float mx = -std::numeric_limits<float>::infinity();
         float mx_phase;
 
         for (int bi = 0; bi < 4; bi++)
@@ -1461,9 +1459,8 @@ std::vector<std::vector<float>> FT4::soft_c2m(const FFTEngine::ffts_t &c103) con
             float x = std::abs(c103[si][bi]);
             m103[si][bi] = x;
 
-            if (mxi < 0 || x > mx)
+            if (x > mx)
             {
-                mxi = bi;
                 mx = x;
                 mx_phase = std::arg(c103[si][bi]); // -pi .. pi
             }

--- a/ft8/ft8.cpp
+++ b/ft8/ft8.cpp
@@ -33,6 +33,7 @@
 #include <fftw3.h>
 #include <algorithm>
 #include <complex>
+#include <limits>
 #include <random>
 #include <functional>
 #include <map>
@@ -138,8 +139,7 @@ float FT8::one_coarse_strength(const FFTEngine::ffts_t &bins, int bi0, int si0) 
     {
         for (int si = 0; si < 79; si++)
         {
-            float mx;
-            int mxi = -1;
+            float mx = -std::numeric_limits<float>::infinity();
             float sum = 0;
 
             for (int i = 0; i < 8; i++)
@@ -147,9 +147,8 @@ float FT8::one_coarse_strength(const FFTEngine::ffts_t &bins, int bi0, int si0) 
                 float x = std::abs(bins[si0 + si][bi0 + i]);
                 sum += x;
 
-                if (mxi < 0 || x > mx)
+                if (x > mx)
                 {
-                    mxi = i;
                     mx = x;
                 }
             }
@@ -1562,8 +1561,7 @@ std::vector<std::vector<float>> FT8::soft_c2m(const FFTEngine::ffts_t &c79) cons
     for (int si = 0; si < 79; si++)
     {
         m79[si].resize(8);
-        int mxi = -1;
-        float mx;
+        float mx = -std::numeric_limits<float>::infinity();
         float mx_phase;
 
         for (int bi = 0; bi < 8; bi++)
@@ -1571,9 +1569,8 @@ std::vector<std::vector<float>> FT8::soft_c2m(const FFTEngine::ffts_t &c79) cons
             float x = std::abs(c79[si][bi]);
             m79[si][bi] = x;
 
-            if (mxi < 0 || x > mx)
+            if (x > mx)
             {
-                mxi = bi;
                 mx = x;
                 mx_phase = std::arg(c79[si][bi]); // -pi .. pi
             }


### PR DESCRIPTION
Fix cppcheck warnings about uninitialized mx variables in coarse strength and soft symbol conversion calculations.

Replace the mxi sentinel logic with an explicit -infinity initial maximum value, allowing the maximum search to operate directly on the value being tracked. This removes reliance on short-circuit evaluation for initialization and simplifies the code.