### PR TITLE
GLScope: Fix missing freerun setting copy in assignment operator

### DIFF
--- a/sdrbase/dsp/glscopesettings.cpp
+++ b/sdrbase/dsp/glscopesettings.cpp
@@ -489,6 +489,7 @@ GLScopeSettings& GLScopeSettings::operator=(const GLScopeSettings& t)
         m_timeOfs = t.m_timeOfs;
         m_traceLenMult = t.m_traceLenMult;
         m_trigPre = t.m_trigPre;
+        m_freerun = t.m_freerun;
     }
 
     return *this;


### PR DESCRIPTION
cppcheck reported that GLScopeSettings::operator=() did not assign the m_freerun member variable.

m_freerun is part of the GLScope configuration state: it is initialized in resetToDefaults(), and is persisted through serialize()/deserialize(). However, when a GLScopeSettings object was copied using the assignment operator, the freerun state was not transferred from the source object.

This could result in two GLScopeSettings instances having different freerun values after assignment, with the destination object retaining its previous value instead of matching the source object.

Add the missing m_freerun assignment to ensure operator=() performs a complete copy of the settings state and matches the existing serialization behavior.