### PR TITLE
ADSB Demod: Fix incorrect iterator range when restoring column sizes

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodsettings.cpp
@@ -531,7 +531,7 @@ void ADSBDemodSettings::applySettings(const QStringList& settingsKeys, const ADS
         std::copy(std::begin(settings.m_columnIndexes), std::end(settings.m_columnIndexes), std::begin(m_columnIndexes));
     }
     if (settingsKeys.contains("columnSizes")) {
-        std::copy(std::begin(settings.m_columnSizes), std::end(settings.m_columnIndexes), std::begin(m_columnSizes));
+        std::copy(std::begin(settings.m_columnSizes), std::end(settings.m_columnSizes), std::begin(m_columnSizes));
     }
     if (settingsKeys.contains("airportRange")) {
         m_airportRange = settings.m_airportRange;


### PR DESCRIPTION
cppcheck reported that the std::copy() call used iterators from different containers when restoring ADSB demod table column sizes.

The copy operation used settings.m_columnSizes as the source start iterator but settings.m_columnIndexes as the source end iterator. This was likely a copy/paste error and resulted in an invalid iterator range.

Use settings.m_columnSizes for both source iterators so column size settings are restored correctly.