### PR TITLE
serialutil: Remove dead code in Windows COM port enumeration

### DIFF
--- a/sdrbase/util/serialutil.cpp
+++ b/sdrbase/util/serialutil.cpp
@@ -38,7 +38,6 @@ void SerialUtil::getComPorts(std::vector<std::string>& comPorts, const std::stri
     (void) regexStr;
 	TCHAR lpTargetPath[5000]; // buffer to store the path of the COMPORTS
 	DWORD test;
-	bool gotPort = 0; // in case the port is not found
 
 	char portName[100];
 
@@ -52,12 +51,6 @@ void SerialUtil::getComPorts(std::vector<std::string>& comPorts, const std::stri
 		if (test != 0) //QueryDosDevice returns zero if it didn't find an object
 		{
 			comPorts.push_back(std::string(portName));
-		}
-
-		if (::GetLastError() == ERROR_INSUFFICIENT_BUFFER)
-		{
-			lpTargetPath[10000]; // in case the buffer got filled, increase size of the buffer.
-			continue;
 		}
 	}
 }


### PR DESCRIPTION
Remove an invalid out-of-bounds array access that attempted to handle ERROR_INSUFFICIENT_BUFFER. The statement did not resize the fixed-size buffer and had no effect other than invoking undefined behavior.

The function only uses QueryDosDeviceA() as an existence check for COM ports, so removing the dead error-handling code does not change its behavior.