### PR TITLE
chirpchat: Fix FT8 message type 0.4 reply detection

### DIFF
--- a/plugins/channelrx/demodchirpchat/chirpchatdemoddecoderft.cpp
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemoddecoderft.cpp
@@ -115,7 +115,7 @@ void ChirpChatDemodDecoderFT::decodeSymbols(
     msg = packing.unpack(r174, call1, call2, loc, msgType);
     reply = false;
 
-    if ((msgType == "0.3") || (msgType == "0.3")) {
+    if ((msgType == "0.3") || (msgType == "0.4")) {
         reply = r174[56] != 0;
     }
     if ((msgType == "1") || (msgType == "2")) {


### PR DESCRIPTION
Fix a copy/paste error in decodeSymbols() where FT8 message type 0.3 was checked twice, preventing type 0.4 messages from being recognized as replies.

FT8::Packing supports both 0.3 and 0.4 message types using the same reply bit location.

Detected by cppcheck as a redundant condition.