### PR TITLE
ft8: Fix CRC message length type causing memcpy overflow warning

### DIFF
--- a/ft8/libldpc.cpp
+++ b/ft8/libldpc.cpp
@@ -363,7 +363,7 @@ void LDPC::ldpc_decode_log(float codeword[], int iters, int plain[], int *ok)
 // check the FT8 CRC-14
 //
 
-void LDPC::ft8_crc(int msg1[], int msglen, int out[14])
+void LDPC::ft8_crc(int msg1[], uint32_t msglen, int out[14])
 {
     // the old FT8 polynomial for 12-bit CRC, 0xc06.
     // int div[] = { 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0 };
@@ -375,7 +375,7 @@ void LDPC::ft8_crc(int msg1[], int msglen, int out[14])
     std::vector<int> msg(msglen + 14);
     std::memcpy(msg.data(), msg1, msglen * sizeof(int));
 
-    for (int i = 0; i < msglen; i++)
+    for (uint32_t i = 0; i < msglen; i++)
     {
         if (msg[i])
         {

--- a/ft8/libldpc.h
+++ b/ft8/libldpc.h
@@ -22,13 +22,15 @@
 #ifndef libldpc_h
 #define libldpc_h
 
+#include <cstdint>
+
 namespace FT8 {
 
 class LDPC {
 public:
     static void ldpc_decode(const float llcodeword[], int iters, int plain[], int *ok);
     static void ldpc_decode_log(float codeword[], int iters, int plain[], int *ok);
-    static void ft8_crc(int msg1[], int msglen, int out[14]);
+    static void ft8_crc(int msg1[], uint32_t msglen, int out[14]);
     static void gauss_jordan(int rows, int cols, int m[174][2 * 91], int which[91], int *ok);
 
 private:


### PR DESCRIPTION
Change the ft8_crc message length parameter from signed int to uint32_t since it represents a non-negative FT8 message bit count.

GCC reported a potential buffer overflow in the memcpy() call:
    warning: ‘__builtin_memcpy’ specified bound between
    18446744073709551560 and 18446744073709551564 exceeds maximum object size
    [-Wstringop-overflow=]

The warning was caused by the signed message length allowing negative values to be converted into a very large unsigned size when calculating the memcpy() byte count.

Using an unsigned fixed-width type better represents the valid range of the FT8 message length and prevents invalid negative lengths from being interpreted as extremely large memory operations.