### PR TITLE
cleanup printf format specifiers

### DIFF
--- a/devices/plutosdr/deviceplutosdrbox.cpp
+++ b/devices/plutosdr/deviceplutosdrbox.cpp
@@ -708,9 +708,9 @@ void DevicePlutoSDRBox::setSampleRate(uint32_t sampleRate)
 {
     char buff[100];
     std::vector<std::string> params;
-    snprintf(buff, sizeof(buff), "in_voltage_sampling_frequency=%d", sampleRate);
+    snprintf(buff, sizeof(buff), "in_voltage_sampling_frequency=%u", sampleRate);
     params.push_back(std::string(buff));
-    snprintf(buff, sizeof(buff), "out_voltage_sampling_frequency=%d", sampleRate);
+    snprintf(buff, sizeof(buff), "out_voltage_sampling_frequency=%u", sampleRate);
     params.push_back(std::string(buff));
     set_params(DEVICE_PHY, params);
     m_devSampleRate = sampleRate;
@@ -844,7 +844,7 @@ bool DevicePlutoSDRBox::getRxGain(int& gaindB, unsigned int chan)
 {
     chan = chan % 2;
     char buff[30];
-    snprintf(buff, sizeof(buff), "in_voltage%d_hardwaregain", chan);
+    snprintf(buff, sizeof(buff), "in_voltage%u_hardwaregain", chan);
     std::string gainStr;
     get_param(DEVICE_PHY, buff, gainStr);
 
@@ -875,7 +875,7 @@ bool DevicePlutoSDRBox::getRxRSSI(std::string& rssiStr, unsigned int chan)
 {
     chan = chan % 2;
     char buff[20];
-    snprintf(buff, sizeof(buff), "in_voltage%d_rssi", chan);
+    snprintf(buff, sizeof(buff), "in_voltage%u_rssi", chan);
     return get_param(DEVICE_PHY, buff, rssiStr);
 }
 
@@ -883,7 +883,7 @@ bool DevicePlutoSDRBox::getTxRSSI(std::string& rssiStr, unsigned int chan)
 {
     chan = chan % 2;
     char buff[20];
-    snprintf(buff, sizeof(buff), "out_voltage%d_rssi", chan);
+    snprintf(buff, sizeof(buff), "out_voltage%u_rssi", chan);
     return get_param(DEVICE_PHY, buff, rssiStr);
 }
 

--- a/plugins/channelrx/demoddatv/leansdr/framework.h
+++ b/plugins/channelrx/demoddatv/leansdr/framework.h
@@ -193,7 +193,7 @@ struct scheduler
             pipes[i]->dump(&total_bufs);
         }
 
-        fprintf(stderr, "Total buffer memory: %ld KiB\n",
+        fprintf(stderr, "Total buffer memory: %lu KiB\n",
                 (unsigned long)total_bufs / 1024);
     }
 };
@@ -287,23 +287,23 @@ struct pipebuf : pipebuf_common
     {
         if (total_written < 10000)
         {
-            fprintf(stderr, ".%-16s : %4ld/%4ld", name, total_read,
+            fprintf(stderr, ".%-16s : %4lu/%4lu", name, total_read,
                     total_written);
         }
         else if (total_written < 1000000)
         {
-            fprintf(stderr, ".%-16s : %3ldk/%3ldk", name, total_read / 1000,
+            fprintf(stderr, ".%-16s : %3luk/%3luk", name, total_read / 1000,
                     total_written / 1000);
         }
         else
         {
-            fprintf(stderr, ".%-16s : %3ldM/%3ldM", name, total_read / 1000000,
+            fprintf(stderr, ".%-16s : %3luM/%3luM", name, total_read / 1000000,
                     total_written / 1000000);
         }
 
         *total_bufs += (end - buf) * sizeof(T);
         unsigned long nw = end - wr;
-        fprintf(stderr, " %6ld writable %c,", nw, (nw < min_write) ? '!' : ' ');
+        fprintf(stderr, " %6lu writable %c,", nw, (nw < min_write) ? '!' : ' ');
         T *rd = wr;
 
         for (int j = 0; j < nrd; ++j)


### PR DESCRIPTION
Fix printf format specifier mismatches identified by cppcheck

Update printf format strings where signed conversions were used with unsigned arguments.

While these mismatches are not common sources of failures, they can cause problems because printf-style functions use variadic arguments and rely on the format string matching the actual argument type. A mismatch can result in undefined behavior, incorrect output, or portability issues depending on the target platform and compiler ABI.

The changes update:
- %d conversions receiving unsigned int values to %u
- %ld conversions receiving unsigned long values to %lu

These fixes address cppcheck invalidPrintfArgType_sint warnings and ensure that the format specifiers match the types being passed to snprintf/fprintf.