### PR TITLE
appbench, appsrv: Fix malformed QCoreApplication::applicationVersion()

### DIFF
--- a/appbench/main.cpp
+++ b/appbench/main.cpp
@@ -92,7 +92,7 @@ static int runQtApplication(int argc, char* argv[], qtwebapp::LoggerWithFile *lo
 #else
     qInfo("%s %s Qt %s %db DSP Rx:%db Tx:%db PID %lld",
           qPrintable(QCoreApplication::applicationName()),
-          qPrintable(QCoreApplication::>applicationVersion()),
+          qPrintable(QCoreApplication::applicationVersion()),
                      qPrintable(QString(QT_VERSION_STR)),
                      QT_POINTER_SIZE*8,
                      SDR_RX_SAMP_SZ,

--- a/appsrv/main.cpp
+++ b/appsrv/main.cpp
@@ -175,7 +175,7 @@ static int runQtApplication(int argc, char* argv[], qtwebapp::LoggerWithFile *lo
 #else
     qInfo("%s %s Qt %s %db DSP Rx:%db Tx:%db PID %lld",
           qPrintable(QCoreApplication::applicationName()),
-          qPrintable(QCoreApplication::>applicationVersion()),
+          qPrintable(QCoreApplication::applicationVersion()),
                      qPrintable(QString(QT_VERSION_STR)),
                      QT_POINTER_SIZE*8,
                      SDR_RX_SAMP_SZ,


### PR DESCRIPTION
Remove an inadvertent '>' character from the `QCoreApplication::applicationVersion()` call in the startup version logging for both `appbench` and `appsrv`.

This typo was identified by cppcheck during static analysis. Correcting the expression restores valid C++ syntax, allowing the applications to compile correctly and report their version information in the startup log.