### PR TITLE
Fix cppcheck-reported function argument order mismatches

### DIFF
--- a/plugins/channelrx/radioastronomy/radioastronomygui.h
+++ b/plugins/channelrx/radioastronomy/radioastronomygui.h
@@ -687,7 +687,7 @@ private slots:
     void on_powerGaussianHPBW_valueChanged(double value);
 
     void plotPowerFiltered();
-    void addToPowerFilter(qreal y, qreal x);
+    void addToPowerFilter(qreal x, qreal y);
     void on_powerShowFiltered_clicked(bool checked=false);
     void on_powerFilter_currentIndexChanged(int index);
     void on_powerFilterN_valueChanged(int value);

--- a/plugins/feature/aprs/aprsgui.h
+++ b/plugins/feature/aprs/aprsgui.h
@@ -166,7 +166,7 @@ private:
     void removeFromMap(const QString& name);
     void blockApplySettings(bool block);
     void applySettings(bool force = false);
-    void displayTableSettings(QTableWidget *table, QMenu *menu, int *columnIndexes, int *columnSizes, int columns);
+    void displayTableSettings(QTableWidget *table, QMenu *menu, int *columnSizes, int *columnIndexes, int columns);
     bool filterStation(APRSStation *station);
     void filterStations();
     void displaySettings();


### PR DESCRIPTION
This PR fixes two function declarations where the argument order in the header files did not match the function definitions and call sites.

These issues were identified by cppcheck. Since the affected parameters have identical types (`qreal` and `int *` respectively), the compiler cannot detect these mismatches. Keeping declarations synchronized with definitions prevents confusion and avoids potential future misuse where arguments could silently be passed in the wrong order.

No functional behavior is changed; this is a consistency and maintainability fix.
