### PR TITLE
fix undefined behavior related to left-shifting negative values, as reported by cppcheck.

### DIFF
--- a/plugins/channelrx/demoddatv/leansdr/discrmath.h
+++ b/plugins/channelrx/demoddatv/leansdr/discrmath.h
@@ -24,6 +24,7 @@
 #pragma GCC diagnostic ignored "-Wshift-negative-value"
 
 #include  <cstddef>
+#include <type_traits>
 
 namespace leansdr
 {
@@ -223,6 +224,11 @@ bitvect<T, N> operator*(bitvect<T, N> a, const bitvect<T, NB> &b)
 template <typename Te, int N, Te ALPHA, Te TRUNCP>
 struct gf2n
 {
+    // Field elements are represented as packed polynomial coefficients:
+    // bit i corresponds to the coefficient of X^i. Unsigned storage is
+    // required so bit operations have well-defined behavior.
+    static_assert(std::is_unsigned_v<Te>, "Te must be unsigned");
+
     typedef Te element;
     static const Te alpha = ALPHA;
     gf2n()
@@ -236,9 +242,14 @@ struct gf2n
             lut_exp[i] = alpha_i;                  // ALPHA^i
             lut_exp[((1 << N) - 1) + i] = alpha_i; // Wrap to avoid modulo 2^N-1
             lut_log[alpha_i] = i;
-            bool overflow = alpha_i & (1 << (N - 1));
+            // Multiplication by ALPHA=[X] shifts the polynomial left by one.
+            // If the X^(N-1) coefficient was set, the shift will overflow and
+            // the generator polynomial must be applied modulo P(X).
+            bool overflow = alpha_i & (static_cast<Te>(1) << (N - 1));
             alpha_i *= 2;                // Multiply by alpha=[X] i.e. increase degrees
-            alpha_i &= ~((~(Te)0) << N); // In case Te is wider than N bits
+            // Keep only the lowest N bits. This removes the X^N term and
+            // higher bits before applying the generator polynomial reduction.
+            alpha_i &= static_cast<Te>((static_cast<Te>(1) << N) - 1);
             if (overflow)
                 alpha_i ^= TRUNCP; // Modulo P iteratively
         }

--- a/sdrbase/util/simpleserializer.cpp
+++ b/sdrbase/util/simpleserializer.cpp
@@ -392,7 +392,7 @@ returnDefault:
 bool SimpleDeserializer::readS64(quint32 id, qint64* result, qint64 def) const
 {
 	uint readOfs;
-	qint64 tmp;
+	quint64 tmp;
 	Elements::const_iterator it = m_elements.constFind(id);
 	if(it == m_elements.constEnd())
 		goto returnDefault;
@@ -406,10 +406,10 @@ bool SimpleDeserializer::readS64(quint32 id, qint64* result, qint64 def) const
 	for(uint i = 0; i < it->length; i++) {
 		quint8 byte = readByte(&readOfs);
 		if((i == 0) && (byte & 0x80))
-			tmp = -1;
+			tmp = 0xFFFFFFFFFFFFFFFFULL;
 		tmp = (tmp << 8) | byte;
 	}
-	*result = tmp;
+	*result = static_cast<qint64>(tmp);
 	return true;
 
 returnDefault:

--- a/sdrbase/util/simpleserializer.cpp
+++ b/sdrbase/util/simpleserializer.cpp
@@ -340,7 +340,7 @@ setInvalid:
 bool SimpleDeserializer::readS32(quint32 id, qint32* result, qint32 def) const
 {
 	uint readOfs;
-	qint32 tmp;
+	quint32 tmp;
 	Elements::const_iterator it = m_elements.constFind(id);
 	if(it == m_elements.constEnd())
 		goto returnDefault;
@@ -354,10 +354,10 @@ bool SimpleDeserializer::readS32(quint32 id, qint32* result, qint32 def) const
 	for(uint i = 0; i < it->length; i++) {
 		quint8 byte = readByte(&readOfs);
 		if((i == 0) && (byte & 0x80))
-			tmp = -1;
+			tmp = 0xFFFFFFFF;
 		tmp = (tmp << 8) | byte;
 	}
-	*result = tmp;
+	*result = static_cast<qint32>(tmp);
 	return true;
 
 returnDefault:


### PR DESCRIPTION
This PR addresses several undefined behavior issues reported by cppcheck related to signed left-shift operations.

The changes ensure that bit manipulation is performed using unsigned types where appropriate, preserving the existing behavior while making the implementation well-defined. In addition, the GF(2<sup>N</sup>) implementation now explicitly documents and enforces its assumption that field elements are represented using unsigned storage.

* Resolves cppcheck warnings about undefined left-shift operations.
* Preserves existing serialization/deserialization and finite field arithmetic behavior.
* Makes the code's assumptions about unsigned bit manipulation explicit.
* Improves readability by documenting the intent behind the bit-level operations.
