### PR TITLE
fix uninit struct members

### DIFF
--- a/plugins/channelrx/freqscanner/freqscannersettings.h
+++ b/plugins/channelrx/freqscanner/freqscannersettings.h
@@ -32,8 +32,8 @@ class ChannelAPI;
 struct FreqScannerSettings
 {
     struct FrequencySettings {
-        qint64 m_frequency;
-        bool m_enabled;
+        qint64 m_frequency = 0;
+        bool m_enabled = true;
         QString m_notes;
         QString m_threshold;        // QStrings used, as we allow "" for no setting
         QString m_channel;

--- a/sdrbase/util/nasaglobalimagery.h
+++ b/sdrbase/util/nasaglobalimagery.h
@@ -58,7 +58,7 @@ public:
         QString m_descriptionURL;
         QDateTime m_startDate;
         QDateTime m_endDate;
-        bool m_ongoing;
+        bool m_ongoing = false;
         QString m_layerPeriod;
         QString m_layerGroup;
     };

--- a/sdrbase/util/sdrangelserverlist.h
+++ b/sdrbase/util/sdrangelserverlist.h
@@ -18,6 +18,7 @@
 #ifndef INCLUDE_SDRANGELSERVERLIST_H
 #define INCLUDE_SDRANGELSERVERLIST_H
 
+#include <limits>
 #include <QtCore>
 #include <QTimer>
 
@@ -36,25 +37,25 @@ public:
 
     struct SDRangelServer {
         QString m_address;
-        quint16 m_port;
+        quint16 m_port = 0;
         QString m_protocol;
-        qint64 m_minFrequency;
-        qint64 m_maxFrequency;
-        int m_maxSampleRate;
+        qint64 m_minFrequency = 0;
+        qint64 m_maxFrequency = std::numeric_limits<qint64>::max();
+        int m_maxSampleRate = std::numeric_limits<int>::max();
         QString m_device;
         QString m_antenna;
-        bool m_remoteControl;
+        bool m_remoteControl = false;
         QString m_stationName;
         QString m_location;
-        float m_latitude;
-        float m_longitude;
-        float m_altitude;
-        bool m_isotropic;
-        float m_azimuth;
-        float m_elevation;
-        int m_clients;
-        int m_maxClients;
-        int m_timeLimit;        // In minutes
+        float m_latitude = 0.0f;
+        float m_longitude = 0.0f;
+        float m_altitude = 0.0f;
+        bool m_isotropic = false;
+        float m_azimuth = 0.0f;
+        float m_elevation = 0.0f;
+        int m_clients = 0;
+        int m_maxClients = 4;
+        int m_timeLimit = 0;        // In minutes
     };
 
     SDRangelServerList();

--- a/sdrbase/util/spyserverlist.h
+++ b/sdrbase/util/spyserverlist.h
@@ -18,6 +18,7 @@
 #ifndef INCLUDE_SPYSERVERLIST_H
 #define INCLUDE_SPYSERVERLIST_H
 
+#include <limits>
 #include <QtCore>
 #include <QTimer>
 
@@ -37,17 +38,17 @@ public:
     struct SpyServer {
         QString m_generalDescription;
         QString m_deviceType;
-        QString m_streamingHost; // IP address
-        int m_streamingPort;    // IP port
-        int m_currentClientCount;
-        int m_maxClients;
+        QString m_streamingHost;    // IP address
+        int m_streamingPort = 0;    // IP port
+        int m_currentClientCount = 0;
+        int m_maxClients = 0;
         QString m_antennaType;
-        float m_latitude;
-        float m_longitude;
-        qint64 m_minimumFrequency;
-        qint64 m_maximumFrequency;
-        bool m_fullControlAllowed;
-        bool m_online;
+        float m_latitude = 0.0f;
+        float m_longitude = 0.0f;
+        qint64 m_minimumFrequency = 0;
+        qint64 m_maximumFrequency = std::numeric_limits<qint64>::max();
+        bool m_fullControlAllowed = false;
+        bool m_online = false;
     };
 
     SpyServerList();


### PR DESCRIPTION
Initialize primitive struct members with safe default values to prevent undefined behavior when objects are default-constructed and optional fields are not populated.

This change addresses cppcheck warnings for uninitialized struct members in several areas where objects are populated from optional JSON/settings data.

Updated structures:
- `FreqScannerSettings::FrequencySettings`
- `NASAGlobalImagery::Layer`
- `SDRangelServerList::SDRangelServer`
- `SpyServerList::SpyServer`

Added in-class initializers for primitive members so that partially populated objects always have deterministic values before being copied or consumed.

These changes are intended to only initialize previously undefined values. Existing JSON/settings values continue to take precedence when provided. Review of the default choices is appreciated, especially for fields where missing data now receives a defined value.