### PR TITLE
valuedialz: Fix signed/unsigned conversion when editing negative values

### DIFF
--- a/sdrgui/gui/valuedialz.cpp
+++ b/sdrgui/gui/valuedialz.cpp
@@ -647,14 +647,13 @@ void ValueDialZ::keyPressEvent(QKeyEvent* value)
         }
 
         int d = c.toLatin1() - '0';
-        quint64 e = findExponent(m_cursor);
-        quint64 value = abs(m_value);
-        int sign = m_value < 0 ? -1 : 1;
-        quint64 v = (value / e) % 10;
+        qint64 e = static_cast<qint64>(findExponent(m_cursor));
+        qint64 value = qAbs(m_value);
+        qint64 v = (value / e) % 10;
 
         v = value - v * e;
         v += d * e;
-        setValue(sign*v);
+        setValue(m_value < 0 ? -v : v);
         m_cursor++;
 
         if ((m_text[m_cursor] == m_groupSeparator) || (m_text[m_cursor] == m_decSeparator)) {


### PR DESCRIPTION
Fix a signed/unsigned arithmetic issue in ValueDialZ::keyPressEvent() reported by cppcheck.

The digit editing code used quint64 intermediates together with a signed sign value:

    int sign = m_value < 0 ? -1 : 1;
    setValue(sign * v);

When editing negative values, the signed -1 was converted to an unsigned value before multiplication, causing the result to wrap instead of producing a negative value.

Use qint64 intermediates for the digit manipulation and apply the existing sign explicitly when updating the value. This preserves correct behavior when editing negative values and avoids the unintended unsigned conversion.