### PR TITLE
vorlocalizer: Fix round robin plan sorting comparator

### DIFF
--- a/plugins/feature/vorlocalizer/vorlocalizerworker.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizerworker.cpp
@@ -652,7 +652,7 @@ void VorLocalizerWorker::getChannelsByDevice(
         bool operator()(const RRTurnPlan& a, const RRTurnPlan& b)
         {
             unsigned int nbChannelsA = a.m_channels.size();
-            unsigned int nbChannelsB = a.m_channels.size();
+            unsigned int nbChannelsB = b.m_channels.size();
 
             if (nbChannelsA == nbChannelsB) {
                 return a.m_bandwidth > b.m_bandwidth;


### PR DESCRIPTION
The channel count comparison in getChannelsByDevice() accidentally used the first plan's channel count for both operands. This caused the comparator to always treat the channel counts as equal and sort only by bandwidth.

Use the second plan's channel count when comparing RRTurnPlans so plans are ordered correctly by number of channels before applying the bandwidth tie-breaker.