### PR TITLE
Fix cppcheck-reported out-of-bounds accesses

### DIFF
--- a/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrgui.cpp
@@ -394,7 +394,7 @@ void RTLSDRGui::on_ppm_valueChanged(int value)
 
 void RTLSDRGui::on_gain_valueChanged(int value)
 {
-	if (value > (int)m_gains.size()) {
+	if (value < 0 || value >= (int)m_gains.size()) {
 		return;
 	}
 

--- a/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
+++ b/plugins/samplesource/rtlsdr/rtlsdrinput.cpp
@@ -469,8 +469,10 @@ QString RTLSDRInput::getTunerName() const
 {
     const static QStringList names = {"Unknown", "E4000", "FC0012", "FC0013", "FC2580", "R820T", "R828D"};
 
-    if ((int) m_tunerType <= names.size()) {
-        return names[(int) m_tunerType];
+    const int tunerType = (int) m_tunerType;
+
+    if (tunerType >= 0 && tunerType < names.size()) {
+        return names[tunerType];
     } else {
         return names[0];
     }

--- a/sdrbase/dsp/scopevis.cpp
+++ b/sdrbase/dsp/scopevis.cpp
@@ -725,6 +725,12 @@ void ScopeVis::processTrace(const std::vector<ComplexVector::const_iterator>& vc
 
 bool ScopeVis::nextTrigger()
 {
+    if (m_triggerConditions.empty())
+    {
+        m_currentTriggerIndex = 0;
+        return false; // final
+    }
+
     TriggerCondition *triggerCondition = m_triggerConditions[m_currentTriggerIndex]; // current trigger condition
 
     if (triggerCondition->m_triggerData.m_triggerRepeat > 0)
@@ -740,12 +746,7 @@ bool ScopeVis::nextTrigger()
         }
     }
 
-    if (m_triggerConditions.size() == 0)
-    {
-        m_currentTriggerIndex = 0;
-        return false; // final
-    }
-    else if (m_currentTriggerIndex < m_triggerConditions.size() - 1) // check if next trigger is available
+    if (m_currentTriggerIndex < m_triggerConditions.size() - 1) // check if next trigger is available
     {
         m_currentTriggerIndex++;
         return true; // not final keep going

--- a/sdrbase/util/aprs.cpp
+++ b/sdrbase/util/aprs.cpp
@@ -953,7 +953,7 @@ bool APRSPacket::parseMessage(QString& info, int& idx)
         int i = 5;
         for (int j = 0; j < 8; j++)
         {
-            if (i >= m_message.length())
+            if (i < m_message.length())
                 m_telemetryBitSense[j] = m_message[i] == '1';
             else
                 m_telemetryBitSense[j] = true;

--- a/sdrbase/util/aprs.cpp
+++ b/sdrbase/util/aprs.cpp
@@ -724,28 +724,29 @@ bool APRSPacket::parseObject(QString& info, int& idx)
 
 bool APRSPacket::parseItem(QString& info, int& idx)
 {
-    if (info.length() < idx+3)
+    // Item names are 3-9 characters long and terminated by '!' or '_'
+    // Require the minimum 3-character name plus the terminator.
+    if (info.length() < (idx + 3 + 1))
         return false;
 
-    // Item names are 3-9 chars long, excluding ! or _
-    m_objectName = "";
-    int i;
-    for (i = 0; i < 10; i++)
+    m_objectName.clear();
+
+    for (int i = 0; (i < 9) && (idx < info.length()); ++i)
     {
-        if (info.length() >= idx)
-        {
-            QChar c = info[idx];
-            if (c == '!' || c == '_')
-                break;
-            else
-            {
-                m_objectName.append(c);
-                idx++;
-            }
-        }
+        const QChar c = info[idx];
+        if (c == '!' || c == '_')
+            break;
+
+        m_objectName.append(c);
+        ++idx;
     }
-    if (i == 11)
+
+    if (idx >= info.length())
         return false;
+
+    if (info[idx] != '!' && info[idx] != '_')
+        return false;
+
     if (info[idx] == '!')
         m_objectLive = true;
     else if (info[idx] == '_')


### PR DESCRIPTION
This PR addresses several cppcheck findings for potential out-of-bounds accesses across SDRangel components.

The fixes include:
- Validate RTL-SDR gain indices before accessing the gain table.
- Correct RTL-SDR tuner name lookup bounds checking to prevent indexing   past the end of the tuner name list.
- Check for an empty trigger list before accessing the current trigger   condition in the scope visualizer.
- Harden APRS Item Report parsing by validating item name boundaries and   the required terminator before indexing the input string.
- Fix the APRS BITS telemetry parser bounds check so truncated messages   continue to use the existing default bit sense behavior without   accessing beyond the end of the message.

These changes address real undefined behavior paths while preserving existing behavior for valid inputs. The reported issues were identified by cppcheck.