### PR TITLE
AIS: fix missing comma in aids-to-navigation type table

### DIFF
--- a/sdrbase/util/ais.cpp
+++ b/sdrbase/util/ais.cpp
@@ -689,7 +689,7 @@ QString AISAidsToNavigationReport::toString()
         "Beacon, Preferred channel starboard hand",
         "Beacon, Isolated danger",
         "Beacon, Safe water",
-        "Beacon, Special mark"
+        "Beacon, Special mark",
         "Cardinal mark N",
         "Cardinal mark E",
         "Cardinal mark S",


### PR DESCRIPTION
The AtoN type table in `AISAidsToNavigationReport::toString` has no comma between entries 19 and 20:

```cpp
"Beacon, Special mark"
"Cardinal mark N",
```

The two literals concatenate into one entry, so the list holds 31 strings for a 5-bit type field. Types 20 to 30 show the label belonging to the next type up, and type 31 (Light vessel/LANBY/Rigs) indexes past the end of the QStringList.

To show it I built ais.cpp standalone against Qt6Core with a small driver that packs a message 21 per ITU-R M.1371 and runs it through `AISMessage::decode`. On current master:

```
aton type code 19 -> Lat: 0° Lon: 0° Name: TEST ATON Type: Beacon, Special markCardinal mark N
aton type code 20 -> Lat: 0° Lon: 0° Name: TEST ATON Type: Cardinal mark E
aton type code 24 -> Lat: 0° Lon: 0° Name: TEST ATON Type: Starboard hand mark
aton type code 30 -> Lat: 0° Lon: 0° Name: TEST ATON Type: Light vessel/LANBY/Rigs
aton type code 31 -> Aborted (core dumped)
```

The abort on 31 is the QList bounds assert:

```
#6  QList<QString>::at (this=0x7fffffffd940, i=31) at qtcore/qlist.h:513
#8  AISAidsToNavigationReport::toString () at sdrbase/util/ais.cpp:710
```

A release build compiles the assert out and reads past the array instead.

With the comma restored:

```
aton type code 19 -> Lat: 0° Lon: 0° Name: TEST ATON Type: Beacon, Special mark
aton type code 20 -> Lat: 0° Lon: 0° Name: TEST ATON Type: Cardinal mark N
aton type code 24 -> Lat: 0° Lon: 0° Name: TEST ATON Type: Port hand mark
aton type code 30 -> Lat: 0° Lon: 0° Name: TEST ATON Type: Special mark
aton type code 31 -> Lat: 0° Lon: 0° Name: TEST ATON Type: Light vessel/LANBY/Rigs
```

which matches the type table at https://gpsd.gitlab.io/gpsd/AIVDM.html that ais.cpp already references.
