### PR TITLE
Fix QT_NMEA_SERIAL_PORT on Qt 6

### DIFF
--- a/sdrbase/maincore.cpp
+++ b/sdrbase/maincore.cpp
@@ -21,6 +21,7 @@
 #include <QCoreApplication>
 #include <QString>
 #include <QDebug>
+#include <QVariant>
 #include <QGeoPositionInfoSource>
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
 #include <QPermissions>
@@ -443,10 +444,52 @@ void MainCore::requestPermissions()
     requestLocationPermission(); // This requests microphone and camera permissions as well
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+namespace {
+
+QGeoPositionInfoSource *createNmeaPositionSource(QObject *parent)
+{
+    const QString serialPort = qEnvironmentVariable("QT_NMEA_SERIAL_PORT");
+
+    if (serialPort.isEmpty()) {
+        return nullptr;
+    }
+
+    QVariantMap parameters;
+    parameters.insert(QStringLiteral("nmea.source"), QStringLiteral("serial:") + serialPort);
+
+    bool baudRateValid = false;
+    const int baudRate = qEnvironmentVariableIntValue("QT_NMEA_SERIAL_BAUD_RATE", &baudRateValid);
+
+    if (baudRateValid && (baudRate > 0)) {
+        parameters.insert(QStringLiteral("nmea.baudrate"), baudRate);
+    }
+
+    QGeoPositionInfoSource *positionSource = QGeoPositionInfoSource::createSource(
+        QStringLiteral("nmea"), parameters, parent);
+
+    if (!positionSource) {
+        qWarning() << "MainCore::initPosition: No NMEA position source for serial port" << serialPort;
+    }
+
+    return positionSource;
+}
+
+}
+#endif
+
 // Position can take a while to determine, so we start updates at program startup
 void MainCore::initPosition()
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    m_positionSource = createNmeaPositionSource(this);
+
+    if (!m_positionSource) {
+        m_positionSource = QGeoPositionInfoSource::createDefaultSource(this);
+    }
+#else
     m_positionSource = QGeoPositionInfoSource::createDefaultSource(this);
+#endif
     if (m_positionSource)
     {
         qDebug() << "MainCore::initPosition: Using position source" << m_positionSource->sourceName();

--- a/sdrbase/maincore.cpp
+++ b/sdrbase/maincore.cpp
@@ -456,8 +456,14 @@ QGeoPositionInfoSource *createNmeaPositionSource(QObject *parent)
     }
 
     QVariantMap parameters;
-    parameters.insert(QStringLiteral("nmea.source"), QStringLiteral("serial:") + serialPort);
+    QString source = serialPort;
 
+    if (!source.startsWith(QStringLiteral("serial:"), Qt::CaseInsensitive) &&
+        !source.startsWith(QStringLiteral("file:"), Qt::CaseInsensitive)) {
+        source.prepend(QStringLiteral("serial:"));
+    }
+
+    parameters.insert(QStringLiteral("nmea.source"), source);
     bool baudRateValid = false;
     const int baudRate = qEnvironmentVariableIntValue("QT_NMEA_SERIAL_BAUD_RATE", &baudRateValid);
 
@@ -469,7 +475,7 @@ QGeoPositionInfoSource *createNmeaPositionSource(QObject *parent)
         QStringLiteral("nmea"), parameters, parent);
 
     if (!positionSource) {
-        qWarning() << "MainCore::initPosition: No NMEA position source for serial port" << serialPort;
+        qWarning() << "MainCore::createNmeaPositionSource: Failed to create NMEA position source for QT_NMEA_SERIAL_PORT =" << serialPort;
     }
 
     return positionSource;


### PR DESCRIPTION
On Qt 6 the documented QT_NMEA_SERIAL_PORT variable has no effect: Qt 5's serialnmea
plugin read it itself, but the nmea plugin that replaced it takes the port as a plugin
parameter and otherwise only auto-detects two USB vendor IDs (0x67b GlobalSat, 0xe8d
Qstarz). Any other receiver just logs "nmea: No known GPS device found." — a u-blox
(0x1546) is never picked up.

Since initPosition() calls createDefaultSource(), there is currently no way to tell the
plugin which port to use. This passes nmea.source (and nmea.baudrate) to
createSource("nmea", ...) when QT_NMEA_SERIAL_PORT is set, and falls back to
createDefaultSource() when it isn't, so Android, CoreLocation and GeoClue are unaffected.
As a side effect QT_NMEA_SERIAL_BAUD_RATE now works on Windows and macOS too.