### PR TITLE
Fix resource ownership and cleanup issues across several SDRangel components.

### DIFF
--- a/plugins/channelrx/chanalyzer/chanalyzersink.cpp
+++ b/plugins/channelrx/chanalyzer/chanalyzersink.cpp
@@ -41,6 +41,7 @@ ChannelAnalyzerSink::RRCHelper::RRCHelper(int flen) :
 ChannelAnalyzerSink::RRCHelper::~RRCHelper()
 {
     delete m_filterFIR;
+    delete m_filterFFT;
     delete[] m_buffer;
 }
 

--- a/plugins/channelrx/demoddatv/leansdr/dvbs2.h
+++ b/plugins/channelrx/demoddatv/leansdr/dvbs2.h
@@ -3292,6 +3292,12 @@ struct s2_fecdec_helper : runnable
     {
         free(command);
         killall(); // also deletes pools[mc][sf].procs if necessary
+        if (bitcount) {
+            delete bitcount;
+        }
+        if (errcount) {
+            delete errcount;
+        }
     }
 
     void run()

--- a/plugins/channelrx/demoddatv/leansdr/dvbs2.h
+++ b/plugins/channelrx/demoddatv/leansdr/dvbs2.h
@@ -2979,6 +2979,16 @@ struct s2_fecdec : runnable
         }
     }
 
+    ~s2_fecdec()
+    {
+        if (bitcount) {
+            delete bitcount;
+        }
+        if (errcount) {
+            delete errcount;
+        }
+    }
+
     void run()
     {
         while (in.readable() >= 1 && out.writable() >= 1 &&

--- a/plugins/channelrx/demoddatv/leansdr/dvbs2.h
+++ b/plugins/channelrx/demoddatv/leansdr/dvbs2.h
@@ -4080,6 +4080,16 @@ struct s2_deframer : runnable
     {
     }
 
+    ~s2_deframer()
+    {
+        if (state_out) {
+            delete state_out;
+        }
+        if (locktime_out) {
+            delete locktime_out;
+        }
+    }
+
     void run()
     {
         while (in.readable() >= 1 && out.writable() >= MAX_TS_PER_BBFRAME &&

--- a/plugins/channelrx/freqscanner/freqscanner.cpp
+++ b/plugins/channelrx/freqscanner/freqscanner.cpp
@@ -1301,11 +1301,7 @@ void FreqScanner::webapiFormatChannelSettings(
     }
     if (channelSettingsKeys.contains("frequencies") || force) {
         QList<SWGSDRangel::SWGFreqScannerFrequency *> *frequencies = createFrequencyList(settings);
-        if (swgFreqScannerSettings->getFrequencies()) {
-            *swgFreqScannerSettings->getFrequencies() = *frequencies;
-        } else {
-            swgFreqScannerSettings->setFrequencies(frequencies);
-        }
+        swgFreqScannerSettings->setFrequencies(frequencies);
     }
 
     if (channelSettingsKeys.contains("rgbColor") || force) {

--- a/plugins/channelrx/radioastronomy/radioastronomyworker.cpp
+++ b/plugins/channelrx/radioastronomy/radioastronomyworker.cpp
@@ -42,6 +42,16 @@ RadioAstronomyWorker::RadioAstronomyWorker(RadioAstronomy* radioAstronomy) :
 RadioAstronomyWorker::~RadioAstronomyWorker()
 {
     m_inputMessageQueue.clear();
+
+    for (int i = 0; i < RADIOASTRONOMY_SENSORS; i++)
+    {
+        if (m_session[i] != VI_NULL)
+        {
+            m_visa.close(m_session[i]);
+            m_session[i] = VI_NULL;
+        }
+    }
+
     m_visa.closeDefault();
 }
 

--- a/plugins/channeltx/udpsource/udpsourceudphandler.cpp
+++ b/plugins/channeltx/udpsource/udpsourceudphandler.cpp
@@ -223,9 +223,11 @@ void UDPSourceUDPHandler::advanceReadPointer(int nbBytes)
                 float dd = d - m_d; // derivative
                 float c = (d / 15.0) + (dd / 20.0); // damping and scaling
                 c = c < -0.05 ? -0.05 : c > 0.05 ? 0.05 : c; // limit
-                UDPSourceMessages::MsgSampleRateCorrection *msg = UDPSourceMessages::MsgSampleRateCorrection::create(c, d);
 
                 if (m_autoRWBalance && m_feedbackMessageQueue) {
+                    // create and immediately transfer ownership to queue
+                    UDPSourceMessages::MsgSampleRateCorrection *msg =
+                            UDPSourceMessages::MsgSampleRateCorrection::create(c, d);
                     m_feedbackMessageQueue->push(msg);
                 }
 

--- a/plugins/feature/map/mapitem.h
+++ b/plugins/feature/map/mapitem.h
@@ -78,6 +78,12 @@ public:
     {
         update(mapItem);
     }
+
+    ~ObjectMapItem()
+    {
+        delete m_aircraftState;
+    }
+
     void update(SWGSDRangel::SWGMapItem *mapItem) override;
 
 protected:

--- a/plugins/feature/vorlocalizer/vorlocalizerworker.cpp
+++ b/plugins/feature/vorlocalizer/vorlocalizerworker.cpp
@@ -752,5 +752,7 @@ void VorLocalizerWorker::rrNextTurn()
 
     if (m_msgQueueToFeature) {
         m_msgQueueToFeature->push(msg);
+    } else {
+        delete msg;
     }
 }

--- a/sdrbase/util/visa.cpp
+++ b/sdrbase/util/visa.cpp
@@ -33,6 +33,9 @@ VISA::VISA() :
     viClose(nullptr),
     viPrintf(nullptr),
     viScanf(nullptr),
+    viFindRsrc(nullptr),
+    viFindNext(nullptr),
+    visaLibrary(nullptr),
     m_available(false)
 {
 #ifdef _MSC_VER
@@ -59,6 +62,14 @@ VISA::VISA() :
     else
     {
         qDebug() << "VISA::VISA: Unable to load " << visaName;
+    }
+}
+
+VISA::~VISA()
+{
+    if (visaLibrary && (m_defaultRM == 0)) {
+        libraryClose(visaLibrary);
+        visaLibrary = nullptr;
     }
 }
 
@@ -267,6 +278,11 @@ void *VISA::libraryFunc(void *library, const char *function)
     return GetProcAddress ((HMODULE)library, function);
 }
 
+void VISA::libraryClose(void *library)
+{
+    FreeLibrary((HMODULE)library);
+}
+
 #else
 
 void *VISA::libraryOpen(const char *filename)
@@ -277,6 +293,11 @@ void *VISA::libraryOpen(const char *filename)
 void *VISA::libraryFunc(void *library, const char *function)
 {
     return dlsym (library, function);
+}
+
+void VISA::libraryClose(void *library)
+{
+    dlclose(library);
 }
 
 #endif

--- a/sdrbase/util/visa.h
+++ b/sdrbase/util/visa.h
@@ -74,6 +74,7 @@ public:
     ViStatus (*viFindNext) (ViSession vi, ViChar desc[]);
 
     VISA();
+    ~VISA();
 
     ViSession openDefault();
     void closeDefault();
@@ -100,6 +101,7 @@ protected:
 
     void *libraryOpen(const char *filename);
     void *libraryFunc(void *library, const char *function);
+    void libraryClose(void *library);
 };
 
 #endif // INCLUDE_VISA_H


### PR DESCRIPTION
* Release dynamically allocated LeanSDR pipe writers when their owning DVB-S2 decoder and deframer are destroyed.
* Properly close VISA sessions and unload the dynamically loaded VISA library during cleanup.
* Avoid creating sample-rate correction messages when they cannot be queued.
* Release the FFT-based RRC filter when `RRCHelper` is destroyed.
* Release aircraft state owned by `ObjectMapItem`.
* Transfer newly created frequency lists directly to `SWGFreqScannerSettings` without leaving the allocation unowned.
* Release VOR service report messages when the feature message queue is unavailable.

These changes ensure dynamically allocated resources have a corresponding owner and cleanup path, and avoid allocations when ownership cannot be transferred.

The changes address resource leak findings reported by Coverity.
