### PR TITLE
channel: fix bandwidth index validation

### DIFF
--- a/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
+++ b/plugins/channelrx/demodchirpchat/chirpchatdemodgui.cpp
@@ -188,7 +188,7 @@ void ChirpChatDemodGUI::on_BW_valueChanged(int value)
         m_settings.m_bandwidthIndex = ChirpChatDemodSettings::nbBandwidths - 1;
     }
 
-	int thisBW = ChirpChatDemodSettings::bandwidths[value];
+	int thisBW = ChirpChatDemodSettings::bandwidths[m_settings.m_bandwidthIndex];
 	ui->BWText->setText(QString("%1 Hz").arg(thisBW));
 	m_channelMarker.setBandwidth(thisBW);
 	ui->glSpectrum->setSampleRate(thisBW);

--- a/plugins/channeltx/modchirpchat/chirpchatmodgui.cpp
+++ b/plugins/channeltx/modchirpchat/chirpchatmodgui.cpp
@@ -163,7 +163,7 @@ void ChirpChatModGUI::on_bw_valueChanged(int value)
         m_settings.m_bandwidthIndex = ChirpChatModSettings::nbBandwidths - 1;
     }
 
-	int thisBW = ChirpChatModSettings::bandwidths[value];
+	int thisBW = ChirpChatModSettings::bandwidths[m_settings.m_bandwidthIndex];
 	ui->bwText->setText(QString("%1 Hz").arg(thisBW));
 	m_channelMarker.setBandwidth(thisBW);
 

--- a/plugins/channeltx/modmeshcore/meshcoremodgui.cpp
+++ b/plugins/channeltx/modmeshcore/meshcoremodgui.cpp
@@ -462,7 +462,7 @@ void MeshcoreModGUI::on_bw_valueChanged(int value)
         m_settings.m_bandwidthIndex = MeshcoreModSettings::nbBandwidths - 1;
     }
 
-	int thisBW = MeshcoreModSettings::bandwidths[value];
+	int thisBW = MeshcoreModSettings::bandwidths[m_settings.m_bandwidthIndex];
 	ui->bwText->setText(QString("%1 Hz").arg(thisBW));
 	m_channelMarker.setBandwidth(thisBW);
 

--- a/plugins/channeltx/modmeshtastic/meshtasticmodgui.cpp
+++ b/plugins/channeltx/modmeshtastic/meshtasticmodgui.cpp
@@ -451,7 +451,7 @@ void MeshtasticModGUI::on_bw_valueChanged(int value)
         m_settings.m_bandwidthIndex = MeshtasticModSettings::nbBandwidths - 1;
     }
 
-	int thisBW = MeshtasticModSettings::bandwidths[value];
+	int thisBW = MeshtasticModSettings::bandwidths[m_settings.m_bandwidthIndex];
 	ui->bwText->setText(QString("%1 Hz").arg(thisBW));
 	m_channelMarker.setBandwidth(thisBW);
 


### PR DESCRIPTION
Use the validated bandwidth index when accessing bandwidth tables in the ChirpChat, MeshCore, and Meshtastic channel GUIs. The previous code used the raw UI value after clamping it into m_bandwidthIndex, allowing negative or out-of-range array accesses.

Found by cppcheck.