### PR TITLE
sdrbench: fix RRC and FFT test file handling

### DIFF
--- a/sdrbench/test_fftrrc.cpp
+++ b/sdrbench/test_fftrrc.cpp
@@ -29,15 +29,28 @@ void MainBench::testFFTRRCFilter()
 
     qDebug() << "MainBench::testFFTRRCFilter: filter created";
     FILE *fd_filter = fopen("test_rrc_filter.txt", "w");
+    if (!fd_filter)
+    {
+        qWarning() << "MainBench::testFFTRRCFilter: failed to open test_rrc_filter.txt : "
+                   << strerror(errno);
+        return;
+    }
 
     for (int i = 0; i < RRC_FFT_SIZE; i++) {
-        fprintf(fd_filter, "%f\n", std::abs(filter.getFilter()[i]));
+        fprintf(fd_filter, "%f\n", static_cast<double>(std::abs(filter.getFilter()[i])));
     }
     qDebug() << "MainBench::testFFTRRCFilter: filter coefficients written to test_rrc_filter.txt";
     fclose(fd_filter);
 
     qDebug() << "MainBench::testFFTRRCFilter: running filter";
     FILE *fd = fopen("test_rrc.txt", "w");
+    if (!fd)
+    {
+        qWarning() << "MainBench::testFFTRRCFilter: failed to open test_rrc.txt : "
+                   << strerror(errno);
+        return;
+    }
+
     int outLen = 0;
 
     for (int i = 0; i < 5000; i++)

--- a/sdrbench/test_firrrc.cpp
+++ b/sdrbench/test_firrrc.cpp
@@ -27,15 +27,27 @@ void MainBench::testFIRRRCFilter()
 
     qDebug() << "MainBench::testFIRRRCFilter: filter created";
     FILE *fd_filter = fopen("test_rrc_filter.txt", "w");
+    if (!fd_filter)
+    {
+        qWarning() << "MainBench::testFIRRRCFilter: failed to open test_rrc_filter.txt : "
+                   << strerror(errno);
+        return;
+    }
     const std::vector<float>& taps = filter.getTaps();
     for (auto tap : taps) {
-        fprintf(fd_filter, "%f\n", std::abs(tap));
+        fprintf(fd_filter, "%f\n", static_cast<double>(std::abs(tap)));
     }
     qDebug() << "MainBench::testFIRRRCFilter: filter coefficients written to test_rrc_filter.txt";
     fclose(fd_filter);
 
     qDebug() << "MainBench::testFIRRRCFilter: running filter";
     FILE *fd = fopen("test_rrc.txt", "w");
+    if (!fd)
+    {
+        qWarning() << "MainBench::testFIRRRCFilter: failed to open test_rrc.txt : "
+                   << strerror(errno);
+        return;
+    }
 
     for (int i = 0; i < 1000; i++)
     {


### PR DESCRIPTION
Address cppcheck warnings by checking fopen() results before using the returned file handles and reporting the underlying error on failure.

This prevents null file handles from being passed to fprintf() and fclose(), avoiding a potential crash when test output files cannot be created.

Explicitly convert RRC filter coefficients to double for fprintf() to match the %f format specifier.