### PR TITLE
Fix payload FEC status in Meshtastic soft decoder

### DIFF
--- a/plugins/channelrx/demodmeshtastic/meshtasticdemoddecoderlora.cpp
+++ b/plugins/channelrx/demodmeshtastic/meshtasticdemoddecoderlora.cpp
@@ -630,7 +630,7 @@ void MeshtasticDemodDecoderLoRa::decodeBytesSoft(
         symOfs += headerSymbols;
     }
 
-    const unsigned int payloadOnlyRowStart = 0U; // all rows in subsequent blocks are payload
+    const unsigned int payloadOnlyRowStart = 0U; // all rows in these blocks are payload
 
     while (symOfs + payloadBlockSymbols <= numSymbols)
     {
@@ -652,7 +652,8 @@ void MeshtasticDemodDecoderLoRa::decodeBytesSoft(
     const unsigned int nibbleOfs = hasHeader ? 5U : 0U;
     const unsigned int neededNibbles = nibbleOfs + dataByteLen * 2U;
 
-    if (nibbles.size() < neededNibbles) {
+    if (nibbles.size() < neededNibbles)
+    {
         earlyEOM = true;
         return;
     }

--- a/plugins/channelrx/demodmeshtastic/meshtasticdemoddecoderlora.cpp
+++ b/plugins/channelrx/demodmeshtastic/meshtasticdemoddecoderlora.cpp
@@ -432,6 +432,8 @@ void MeshtasticDemodDecoderLoRa::decodeBytesSoft(
 {
     payloadCRCStatus = false;
     payloadParityStatus = (int) MeshtasticDemodSettings::ParityUndefined;
+    bool error = false; // set if any payload codeword requires soft FEC correction
+    bool bad = false;   // set if any payload codeword has a structural decode failure
 
     if (inSymbols.size() < headerSymbols)
     {
@@ -542,7 +544,18 @@ void MeshtasticDemodDecoderLoRa::decodeBytesSoft(
         }
     }
 
-    auto decodeSoftBlock = [&llrs, spreadFactor](unsigned int symOfs, unsigned int cwLen, unsigned int sfApp, unsigned int crApp, std::vector<uint8_t>& nibbles) {
+    auto decodeSoftBlock = [
+        &llrs,
+        spreadFactor,
+        &error, &bad // accumulated payload FEC status
+    ](
+        unsigned int symOfs,
+        unsigned int cwLen,
+        unsigned int sfApp,
+        unsigned int crApp,
+        unsigned int payloadRowStart, // first row that contributes to payload FEC status
+        std::vector<uint8_t>& nibbles) {
+
         if (sfApp == 0U) {
             return false;
         }
@@ -569,8 +582,22 @@ void MeshtasticDemodDecoderLoRa::decodeBytesSoft(
             }
         }
 
-        for (unsigned int row = 0; row < sfApp; row++) {
-            nibbles.push_back(decodeCodewordSoft(deinterBin[row], crApp));
+        for (unsigned int row = 0; row < sfApp; row++)
+        {
+            if (row < payloadRowStart)
+            {
+                // Still in header, don't accumulate payload FEC
+                bool ignoredError = false;
+                bool ignoredBad = false;
+                nibbles.push_back(
+                    decodeCodewordSoft(deinterBin[row], crApp, ignoredError, ignoredBad));
+            }
+            else
+            {
+                // Payload row contributes to accumulated payload FEC status
+                nibbles.push_back(
+                    decodeCodewordSoft(deinterBin[row], crApp, error, bad));
+            }
         }
 
         return true;
@@ -587,7 +614,15 @@ void MeshtasticDemodDecoderLoRa::decodeBytesSoft(
             return;
         }
 
-        if (!decodeSoftBlock(symOfs, 8U, headerNbSymbolBits, 4U, nibbles)) {
+        const unsigned int payloadRowStart = headerCodewords; // payload starts after the 5 header codewords
+
+        if (!decodeSoftBlock(
+                symOfs,
+                headerSymbols,
+                headerNbSymbolBits,
+                headerParityBits,
+                payloadRowStart,
+                nibbles)) {
             earlyEOM = true;
             return;
         }
@@ -595,22 +630,29 @@ void MeshtasticDemodDecoderLoRa::decodeBytesSoft(
         symOfs += headerSymbols;
     }
 
+    const unsigned int payloadOnlyRowStart = 0U; // all rows in subsequent blocks are payload
+
     while (symOfs + payloadBlockSymbols <= numSymbols)
     {
-        if (!decodeSoftBlock(symOfs, payloadBlockSymbols, payloadNbSymbolBits, nbParityBits, nibbles)) {
+        if (!decodeSoftBlock(
+                symOfs,
+                payloadBlockSymbols,
+                payloadNbSymbolBits,
+                nbParityBits,
+                payloadOnlyRowStart,
+                nibbles)) {
             earlyEOM = true;
             return;
         }
 
         symOfs += payloadBlockSymbols;
     }
-
+        
     const unsigned int dataByteLen = packetLength + (hasCRC ? 2U : 0U);
     const unsigned int nibbleOfs = hasHeader ? 5U : 0U;
     const unsigned int neededNibbles = nibbleOfs + dataByteLen * 2U;
 
-    if (nibbles.size() < neededNibbles)
-    {
+    if (nibbles.size() < neededNibbles) {
         earlyEOM = true;
         return;
     }
@@ -626,6 +668,15 @@ void MeshtasticDemodDecoderLoRa::decodeBytesSoft(
 
     if (packetLength > 0U) {
         dewhitenPayloadBytes(bytes.data(), packetLength);
+    }
+
+    // Report accumulated payload FEC result independently of CRC
+    if (bad) {
+        payloadParityStatus = (int) MeshtasticDemodSettings::ParityError;
+    } else if (error) {
+        payloadParityStatus = (int) MeshtasticDemodSettings::ParityCorrected;
+    } else {
+        payloadParityStatus = (int) MeshtasticDemodSettings::ParityOK;
     }
 
     if (hasCRC)
@@ -648,11 +699,11 @@ void MeshtasticDemodDecoderLoRa::decodeBytesSoft(
     {
         payloadCRCStatus = true;
     }
-
+    
     inBytes.resize(packetLength);
     std::copy(bytes.begin(), bytes.begin() + packetLength, inBytes.begin());
 }
-
+    
 void MeshtasticDemodDecoderLoRa::getCodingMetrics(
     unsigned int payloadNbSymbolBits,
     unsigned int headerNbSymbolBits,

--- a/plugins/channelrx/demodmeshtastic/meshtasticdemoddecoderlora.h
+++ b/plugins/channelrx/demodmeshtastic/meshtasticdemoddecoderlora.h
@@ -277,8 +277,8 @@ private:
     static inline unsigned char decodeCodewordSoft(
         const std::vector<float>& codewordLLR,
         unsigned int crApp,
-        bool& error, // set if soft FEC changes a hard decision across payload codewords decoded so far
-        bool& bad)   // set on structural decode failure across payload codewords decoded so far
+        bool& error, // set if soft FEC changes a hard decision; caller may accumulate across codewords
+        bool& bad)   // set on structural decode failure; caller may accumulate across codewords
     {
         static const unsigned char cwLUT[16] = {
             0, 23, 45, 58, 78, 89, 99, 116,
@@ -300,7 +300,7 @@ private:
             bad = true; // insufficient LLR data: structural decode failure (later mapped to ParityError)
             return 0;
         }
-        
+
         const unsigned char *lut = (crApp == 1U) ? cwLUTCr5 : cwLUT;
         float bestScore = std::numeric_limits<float>::lowest();
         unsigned int bestIdx = 0U;
@@ -337,7 +337,7 @@ private:
                 ((selectedCW >> (cwLen - 1U - j)) & 0x1U) != 0U;
 
             if (hardBit != selectedBit) {
-                error = true; // soft FEC selected a different bit than the raw hard decision
+                error = true; // soft FEC changed one or more raw hard-decision bits
                 break;
             }
         }

--- a/plugins/channelrx/demodmeshtastic/meshtasticdemoddecoderlora.h
+++ b/plugins/channelrx/demodmeshtastic/meshtasticdemoddecoderlora.h
@@ -274,7 +274,11 @@ private:
         return static_cast<unsigned char>((nibbleBits[0] << 3) | (nibbleBits[1] << 2) | (nibbleBits[2] << 1) | nibbleBits[3]);
     }
 
-    static inline unsigned char decodeCodewordSoft(const std::vector<float>& codewordLLR, unsigned int crApp)
+    static inline unsigned char decodeCodewordSoft(
+        const std::vector<float>& codewordLLR,
+        unsigned int crApp,
+        bool& error, // set if soft FEC changes a hard decision across payload codewords decoded so far
+        bool& bad)   // set on structural decode failure across payload codewords decoded so far
     {
         static const unsigned char cwLUT[16] = {
             0, 23, 45, 58, 78, 89, 99, 116,
@@ -286,10 +290,17 @@ private:
         };
 
         if ((crApp < 1U) || (crApp > 4U)) {
+            bad = true; // invalid coding rate: structural decode failure
             return 0;
         }
 
         const unsigned int cwLen = 4U + crApp;
+
+        if (codewordLLR.size() < cwLen) {
+            bad = true; // insufficient LLR data: structural decode failure (later mapped to ParityError)
+            return 0;
+        }
+        
         const unsigned char *lut = (crApp == 1U) ? cwLUTCr5 : cwLUT;
         float bestScore = std::numeric_limits<float>::lowest();
         unsigned int bestIdx = 0U;
@@ -309,6 +320,25 @@ private:
             if (score > bestScore) {
                 bestScore = score;
                 bestIdx = n;
+            }
+        }
+
+        const unsigned char selectedCW =
+            static_cast<unsigned char>(lut[bestIdx] >> (8U - cwLen));
+
+        for (unsigned int j = 0; j < cwLen; j++)
+        {
+            if (codewordLLR[j] == 0.0f) {
+                continue; // no hard-decision preference for an exactly zero LLR
+            }
+
+            const bool hardBit = codewordLLR[j] > 0.0f;
+            const bool selectedBit =
+                ((selectedCW >> (cwLen - 1U - j)) & 0x1U) != 0U;
+
+            if (hardBit != selectedBit) {
+                error = true; // soft FEC selected a different bit than the raw hard decision
+                break;
             }
         }
 


### PR DESCRIPTION
Fixes payload FEC status reporting in the Meshtastic LoRa soft-decoding path.

decodeBytesSoft() previously left payloadParityStatus as ParityUndefined causing complete packets to report payload_fec: "n/a".

This change:
- reports soft FEC corrections by comparing the selected valid codeword against the raw hard decisions from the LLRs;
- accumulates FEC status only for PAYLOAD codewords, excluding the five explicit-header codewords;
- reports ParityOK, ParityCorrected, or ParityError independently of payload CRC status.

The existing soft-decision selection algorithm and CRC processing are unchanged.