### PR TITLE
Fix ADS-B decoder issues found from AddressSanitizer (ASAN) 

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemod.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemod.cpp
@@ -57,7 +57,8 @@ ADSBDemod::ADSBDemod(DeviceAPI *devieAPI) :
         m_centerFrequency(0),
         m_targetAzElValid(false),
         m_targetAzimuth(0.0f),
-        m_targetElevation(0.0f)
+        m_targetElevation(0.0f),
+        m_targetRange(0.0f)
 {
     qDebug("ADSBDemod::ADSBDemod");
     setObjectName(m_channelId);

--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -7553,6 +7553,10 @@ void ADSBDemodGUI::removeAircraft(QHash<int, Aircraft *>::iterator& i, Aircraft 
         m_adsbDemod->clearTarget();
         m_trackAircraft = nullptr;
     }
+    if (m_highlightAircraft == aircraft)
+    {
+        highlightAircraft(nullptr);
+    }
 
     // Remove map model
     m_aircraftModel.removeAircraft(aircraft);

--- a/plugins/channelrx/demodadsb/adsbdemodgui.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.cpp
@@ -1545,6 +1545,14 @@ void ADSBDemodGUI::sendToMap(Aircraft *aircraft, QList<SWGSDRangel::SWGMapAnimat
             messageQueue->push(msg);
         }
     }
+    else
+    {
+        // mapPipes.size() == 0
+        for (auto animation : *animations) {
+            delete animation;
+        }
+        delete animations;
+    }
 }
 
 // Find aircraft with icao, or create if it doesn't exist

--- a/plugins/channelrx/demodadsb/adsbdemodgui.h
+++ b/plugins/channelrx/demodadsb/adsbdemodgui.h
@@ -526,7 +526,8 @@ public:
         colorRole = Qt::UserRole + 2,
     };
 
-    AircraftPathModel(AircraftModel *aircraftModel, Aircraft *aircraft) :
+    AircraftPathModel(AircraftModel *aircraftModel, Aircraft *aircraft, QObject *parent) :
+        QAbstractListModel(parent),
         m_aircraftModel(aircraftModel),
         m_aircraft(aircraft),
         m_paths(0),
@@ -595,7 +596,7 @@ public:
     Q_INVOKABLE void addAircraft(Aircraft *aircraft) {
         beginInsertRows(QModelIndex(), rowCount(), rowCount());
         m_aircrafts.append(aircraft);
-        m_pathModels.append(new AircraftPathModel(this, aircraft));
+        m_pathModels.append(new AircraftPathModel(this, aircraft, this));
         endInsertRows();
     }
 

--- a/plugins/channelrx/demodadsb/adsbdemodsink.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodsink.cpp
@@ -137,7 +137,7 @@ void ADSBDemodSink::processOneSample(Real magsq)
         m_bufferDateTimeValid[m_writeBuffer] = true;
 
         // Make sure timestamps from different buffers are in order, even if we receive samples faster than real time
-        const qint64 samplesPerSecondMSec = ADS_B_BITS_PER_SECOND * m_settings.m_samplesPerBit / 1000;
+        const qint64 samplesPerSecondMSec = qint64(ADS_B_BITS_PER_SECOND) * m_settings.m_samplesPerBit / 1000;
         const qint64 offsetMSec = m_bufferSize / samplesPerSecondMSec;
         m_minFirstSampleDateTime = dateTime.addMSecs(offsetMSec);
     }

--- a/plugins/channelrx/demodadsb/adsbdemodsinkworker.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodsinkworker.cpp
@@ -693,7 +693,7 @@ void ADSBDemodSinkWorker::handleInputMessages()
 
 QDateTime ADSBDemodSinkWorker::rxDateTime(int firstIdx, int readBuffer) const
 {
-    const qint64 samplesPerSecondMSec = ADS_B_BITS_PER_SECOND * m_settings.m_samplesPerBit / 1000;
+    const qint64 samplesPerSecondMSec = qint64(ADS_B_BITS_PER_SECOND) * m_settings.m_samplesPerBit / 1000;
     const qint64 offsetMSec = (firstIdx - m_sink->m_samplesPerFrame - 1) / samplesPerSecondMSec;
     return m_sink->m_bufferFirstSampleDateTime[readBuffer].addMSecs(offsetMSec);
 }

--- a/plugins/channelrx/demodadsb/adsbdemodsinkworker.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodsinkworker.cpp
@@ -324,6 +324,7 @@ void ADSBDemodSinkWorker::run()
         // chip+ indexes are 0, 2, 7, 9
         Real preambleCorrelationOnes = 0.0;
         Real preambleCorrelationZeros = 0.0;
+        Real preambleCorrelation = 0.0;
         for (int i = 0; i < samplesPerChip; i++)
         {
             preambleCorrelationOnes  += m_sink->m_sampleBuffer[readBuffer][startIdx +  0*samplesPerChip + i];
@@ -362,7 +363,11 @@ void ADSBDemodSinkWorker::run()
         // The threshold accounts for the different number of zeros and ones in the preamble
         // If the sum of ones is exactly 0, it's probably no signal
 
-        Real preambleCorrelation = preambleCorrelationOnes/preambleCorrelationZeros; // without one/zero ratio correction
+        if (preambleCorrelationZeros != 0.0)
+        {
+            // without one/zero ratio correction
+            preambleCorrelation = preambleCorrelationOnes/preambleCorrelationZeros;
+        }
 
         if ((preambleCorrelation > m_correlationThresholdLinear) && (preambleCorrelationOnes != 0.0f))
         {

--- a/plugins/channelrx/demodadsb/adsbdemodworker.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodworker.cpp
@@ -58,10 +58,15 @@ void ADSBBeastServer::send(const char *data, int length)
 
 void ADSBBeastServer::close()
 {
-    for (auto client : m_clients) {
+    const auto clients = m_clients;
+    m_clients.clear();
+
+    for (auto client : clients) {
+        client->disconnect(this);
+        client->close();
         client->deleteLater();
     }
-    m_clients.clear();
+
     QTcpServer::close();
 }
 
@@ -74,9 +79,12 @@ void ADSBBeastServer::readClient()
 void ADSBBeastServer::discardClient()
 {
     qDebug() << "ADSBBeastServer client disconnected";
+
     QTcpSocket *socket = (QTcpSocket*)sender();
-    socket->deleteLater();
-    m_clients.removeAll(socket);
+    if (socket) {
+        m_clients.removeAll(socket);
+        socket->deleteLater();
+    }
 }
 
 ADSBDemodWorker::ADSBDemodWorker() :
@@ -97,6 +105,14 @@ ADSBDemodWorker::ADSBDemodWorker() :
 
 ADSBDemodWorker::~ADSBDemodWorker()
 {
+    m_heartbeatTimer.stop();
+
+    m_beastServer.close();
+
+    if (m_socket.state() != QAbstractSocket::UnconnectedState) {
+        m_socket.close();
+    }
+
     m_inputMessageQueue.clear();
 }
 

--- a/sdrbase/util/osndb.cpp
+++ b/sdrbase/util/osndb.cpp
@@ -53,6 +53,8 @@ OsnDB::OsnDB(QObject *parent) :
 OsnDB::~OsnDB()
 {
     disconnect(&m_dlm, &HttpDownloadManager::downloadComplete, this, &OsnDB::downloadFinished);
+    AircraftInformation::cleanupFlagIcons();
+    AircraftInformation::cleanupAirlineIcons();
 }
 
 void OsnDB::downloadAircraftInformation()
@@ -731,3 +733,18 @@ QIcon *AircraftInformation::getFlagIcon(const QString &country)
     }
 }
 
+void AircraftInformation::cleanupFlagIcons()
+{
+    for (auto icon : m_flagIcons) {
+        delete icon;
+    }
+    m_flagIcons.clear();
+}
+
+void AircraftInformation::cleanupAirlineIcons()
+{
+    for (auto icon : m_airlineIcons) {
+        delete icon;
+    }
+    m_airlineIcons.clear();
+}

--- a/sdrbase/util/osndb.h
+++ b/sdrbase/util/osndb.h
@@ -85,6 +85,8 @@ struct SDRBASE_API AircraftInformation {
 
     // Try to find an flag logo based on a country
     static QIcon *getFlagIcon(const QString &country);
+    static void cleanupFlagIcons();
+    static void cleanupAirlineIcons();
 
     static QString resourcePathToURL(const QString &path);
 

--- a/sdrbase/util/ourairportsdb.cpp
+++ b/sdrbase/util/ourairportsdb.cpp
@@ -129,7 +129,11 @@ void OurAirportsDB::readDB()
     if (!m_airportsById || (airportDBModifiedDateTime > m_modifiedDateTime))
     {
         // Using shared pointer, so old object, if it exists, will be deleted, when no longer user
-        m_airportsById = QSharedPointer<QHash<int, AirportInformation *>>(OurAirportsDB::readAirportsDB(getAirportDBFilename()));
+        m_airportsById = QSharedPointer<QHash<int, AirportInformation *>>(OurAirportsDB::readAirportsDB(getAirportDBFilename()),
+            [](QHash<int, AirportInformation *> *airportInfo) {
+                qDeleteAll(*airportInfo);
+                delete airportInfo;
+            });
         if (m_airportsById != nullptr)
         {
             OurAirportsDB::readFrequenciesDB(getAirportFrequenciesDBFilename(), m_airportsById.get());

--- a/sdrbase/util/planespotters.cpp
+++ b/sdrbase/util/planespotters.cpp
@@ -46,6 +46,7 @@ PlaneSpotters::~PlaneSpotters()
         &PlaneSpotters::handleReply
     );
     delete m_networkManager;
+    qDeleteAll(m_photos);
 }
 
 void PlaneSpotters::getAircraftPhoto(const QString& icao)


### PR DESCRIPTION
Run the ADS-B decoder under AddressSanitizer (ASAN) for an extended period and fix memory leaks and lifetime issues identified during the test.

The decoder was exercised continuously while processing ADS-B traffic, allowing ASAN to identify issues that are not necessarily apparent during short runs or normal operation.

## Fixes

* Fix ADS-B map animation leaks when no map pipe is available.
* Clear the highlighted aircraft reference before removing an aircraft. (this is likely the issue pointed out by some in #2789)
* Clean up `AirportInformation` objects when the OurAirports database is   released.
* Clean up cached flag and airline icons when `OsnDB` is destroyed.
* Clean up cached PlaneSpotters aircraft photos during destruction.
* Harden ADS-B Beast server client cleanup during shutdown.
* Remove stale Beast client pointers before deferred socket deletion.
* Make ADS-B worker shutdown explicitly stop the heartbeat timer, close network resources, and clear the input message queue.

The Beast server changes also ensure that deferred `QObject` deletion is retained while preventing sockets scheduled for deletion from remaining in the active client list.

## Testing

The ADS-B decoder was run under ASAN for an extended period while processing live ADS-B traffic. The reported leaks and lifetime issues found during this testing were investigated and addressed.

The cleanup changes ensure that dynamically allocated ADS-B data, database objects, cached resources, and network objects have explicit and deterministic ownership/lifetime handling.

It may not fix it all - but it fixed all I found. I will bolt in some of the other sanitizers later, and see if I can find anything more.