### PR TITLE
Rate-limit FIFO overflow messages

### DIFF
--- a/sdrbase/dsp/datafifo.cpp
+++ b/sdrbase/dsp/datafifo.cpp
@@ -22,293 +22,293 @@
 
 void DataFifo::create(unsigned int s)
 {
-	m_size = 0;
-	m_fill = 0;
-	m_head = 0;
-	m_tail = 0;
+    m_size = 0;
+    m_fill = 0;
+    m_head = 0;
+    m_tail = 0;
 
-	m_data.resize(s);
-	m_size = m_data.size();
+    m_data.resize(s);
+    m_size = m_data.size();
 }
 
 void DataFifo::reset()
 {
-	QMutexLocker mutexLocker(&m_mutex);
-	m_suppressed = -1;
-	m_fill = 0;
-	m_head = 0;
-	m_tail = 0;
+    QMutexLocker mutexLocker(&m_mutex);
+    m_suppressed = -1;
+    m_fill = 0;
+    m_head = 0;
+    m_tail = 0;
 }
 
 DataFifo::DataFifo(QObject* parent) :
-	QObject(parent),
-	m_data(),
-	m_currentDataType(DataTypeI16)
+    QObject(parent),
+    m_data(),
+    m_currentDataType(DataTypeI16)
 {
-	setObjectName("DataFifo");
-	m_suppressed = -1;
-	m_size = 0;
-	m_fill = 0;
-	m_head = 0;
-	m_tail = 0;
+    setObjectName("DataFifo");
+    m_suppressed = -1;
+    m_size = 0;
+    m_fill = 0;
+    m_head = 0;
+    m_tail = 0;
 }
 
 DataFifo::DataFifo(int size, QObject* parent) :
-	QObject(parent),
-	m_data(),
-	m_currentDataType(DataTypeI16)
+    QObject(parent),
+    m_data(),
+    m_currentDataType(DataTypeI16)
 {
-	setObjectName("DataFifo");
-	m_suppressed = -1;
-	create(size);
+    setObjectName("DataFifo");
+    m_suppressed = -1;
+    create(size);
 }
 
 DataFifo::DataFifo(const DataFifo& other) :
     QObject(other.parent()),
     m_data(other.m_data),
-	m_currentDataType(DataTypeI16)
+    m_currentDataType(DataTypeI16)
 {
-	setObjectName("DataFifo");
-  	m_suppressed = -1;
-	m_size = m_data.size();
-	m_fill = 0;
-	m_head = 0;
-	m_tail = 0;
+    setObjectName("DataFifo");
+    m_suppressed = -1;
+    m_size = m_data.size();
+    m_fill = 0;
+    m_head = 0;
+    m_tail = 0;
 }
 
 DataFifo::~DataFifo()
 {
-	QMutexLocker mutexLocker(&m_mutex);
-	m_size = 0;
+    QMutexLocker mutexLocker(&m_mutex);
+    m_size = 0;
 }
 
 bool DataFifo::setSize(int size)
 {
-	QMutexLocker mutexLocker(&m_mutex);
-	create(size);
-	return m_data.size() == size;
+    QMutexLocker mutexLocker(&m_mutex);
+    create(size);
+    return m_data.size() == size;
 }
 
 unsigned int DataFifo::write(const quint8* data, unsigned int count, DataType dataType)
 {
-	QMutexLocker mutexLocker(&m_mutex);
+    QMutexLocker mutexLocker(&m_mutex);
 
-	if (dataType != m_currentDataType)
-	{
-		m_suppressed = -1;
-		m_fill = 0;
-		m_head = 0;
-		m_tail = 0;
-		m_currentDataType = dataType;
-	}
+    if (dataType != m_currentDataType)
+    {
+        m_suppressed = -1;
+        m_fill = 0;
+        m_head = 0;
+        m_tail = 0;
+        m_currentDataType = dataType;
+    }
 
-	unsigned int total;
-	unsigned int remaining;
-	unsigned int len;
-	const quint8* begin = (const quint8*) data;
-	//count /= sizeof(Sample);
+    unsigned int total;
+    unsigned int remaining;
+    unsigned int len;
+    const quint8* begin = (const quint8*) data;
+    //count /= sizeof(Sample);
 
-	total = std::min(count, m_size - m_fill);
+    total = std::min(count, m_size - m_fill);
 
     if (total < count)
     {
-		if (m_suppressed < 0)
+        if (m_suppressed < 0)
         {
-			m_suppressed = 0;
-			m_msgRateTimer.start();
-			qCritical("DataFifo::write: overflow - dropping %u samples (size=%u)", count - total, m_size);
-		}
+            m_suppressed = 0;
+            m_msgRateTimer.start();
+            qCritical("DataFifo::write: overflow - dropping %u samples (size=%u)", count - total, m_size);
+        }
         else
         {
-			if (m_msgRateTimer.elapsed() > 2500)
+            if (m_msgRateTimer.elapsed() > 2500)
             {
-				qCritical("DataFifo::write: %u messages dropped", m_suppressed);
-				qCritical("DataFifo::write: overflow - dropping %u samples (size=%u)", count - total, m_size);
-				m_suppressed = -1;
-			}
+                qCritical("DataFifo::write: %u messages dropped", m_suppressed);
+                qCritical("DataFifo::write: overflow - dropping %u samples (size=%u)", count - total, m_size);
+                m_suppressed = -1;
+            }
             else
             {
-				m_suppressed++;
-			}
-		}
-	}
+                m_suppressed++;
+            }
+        }
+    }
 
-	remaining = total;
+    remaining = total;
 
     while (remaining > 0)
     {
-		len = std::min(remaining, m_size - m_tail);
-		std::copy(begin, begin + len, m_data.begin() + m_tail);
-		m_tail += len;
-		m_tail %= m_size;
-		m_fill += len;
-		begin += len;
-		remaining -= len;
-	}
-
-	if (m_fill > 0) {
-		emit dataReady();
+        len = std::min(remaining, m_size - m_tail);
+        std::copy(begin, begin + len, m_data.begin() + m_tail);
+        m_tail += len;
+        m_tail %= m_size;
+        m_fill += len;
+        begin += len;
+        remaining -= len;
     }
 
-	return total;
+    if (m_fill > 0) {
+        emit dataReady();
+    }
+
+    return total;
 }
 
 unsigned int DataFifo::write(QByteArray::const_iterator begin, QByteArray::const_iterator end, DataType dataType)
 {
-	QMutexLocker mutexLocker(&m_mutex);
+    QMutexLocker mutexLocker(&m_mutex);
 
-	if (dataType != m_currentDataType)
-	{
-		m_suppressed = -1;
-		m_fill = 0;
-		m_head = 0;
-		m_tail = 0;
-		m_currentDataType = dataType;
-	}
+    if (dataType != m_currentDataType)
+    {
+        m_suppressed = -1;
+        m_fill = 0;
+        m_head = 0;
+        m_tail = 0;
+        m_currentDataType = dataType;
+    }
 
-	unsigned int count = end - begin;
-	unsigned int total;
-	unsigned int remaining;
-	unsigned int len;
+    unsigned int count = end - begin;
+    unsigned int total;
+    unsigned int remaining;
+    unsigned int len;
 
-	total = std::min(count, m_size - m_fill);
+    total = std::min(count, m_size - m_fill);
 
     if (total < count)
     {
-		if (m_suppressed < 0)
+        if (m_suppressed < 0)
         {
-			m_suppressed = 0;
-			m_msgRateTimer.start();
-			qCritical("DataFifo::write: overflow - dropping %u samples", count - total);
-		}
+            m_suppressed = 0;
+            m_msgRateTimer.start();
+            qCritical("DataFifo::write: overflow - dropping %u samples", count - total);
+        }
         else
         {
-			if (m_msgRateTimer.elapsed() > 2500)
+            if (m_msgRateTimer.elapsed() > 2500)
             {
-				qCritical("DataFifo::write: %u messages dropped", m_suppressed);
-				qCritical("DataFifo::write: overflow - dropping %u samples", count - total);
-				m_suppressed = -1;
-			}
+                qCritical("DataFifo::write: %u messages dropped", m_suppressed);
+                qCritical("DataFifo::write: overflow - dropping %u samples", count - total);
+                m_suppressed = -1;
+            }
             else
             {
-				m_suppressed++;
-			}
-		}
-	}
+                m_suppressed++;
+            }
+        }
+    }
 
-	remaining = total;
+    remaining = total;
 
     while (remaining > 0)
     {
-		len = std::min(remaining, m_size - m_tail);
-		std::copy(begin, begin + len, m_data.begin() + m_tail);
-		m_tail += len;
-		m_tail %= m_size;
-		m_fill += len;
-		begin += len;
-		remaining -= len;
-	}
-
-	if (m_fill > 0) {
-		emit dataReady();
+        len = std::min(remaining, m_size - m_tail);
+        std::copy(begin, begin + len, m_data.begin() + m_tail);
+        m_tail += len;
+        m_tail %= m_size;
+        m_fill += len;
+        begin += len;
+        remaining -= len;
     }
 
-	return total;
+    if (m_fill > 0) {
+        emit dataReady();
+    }
+
+    return total;
 }
 
 unsigned int DataFifo::read(QByteArray::iterator begin, QByteArray::iterator end, DataType& dataType)
 {
-	QMutexLocker mutexLocker(&m_mutex);
-	dataType = m_currentDataType;
-	unsigned int count = end - begin;
-	unsigned int total;
-	unsigned int remaining;
-	unsigned int len;
+    QMutexLocker mutexLocker(&m_mutex);
+    dataType = m_currentDataType;
+    unsigned int count = end - begin;
+    unsigned int total;
+    unsigned int remaining;
+    unsigned int len;
 
-	total = std::min(count, m_fill);
+    total = std::min(count, m_fill);
 
     if (total < count) {
-		qCritical("DataFifo::read: underflow - missing %u samples", count - total);
+        qCritical("DataFifo::read: underflow - missing %u samples", count - total);
     }
 
-	remaining = total;
+    remaining = total;
 
     while (remaining > 0)
     {
-		len = std::min(remaining, m_size - m_head);
-		std::copy(m_data.begin() + m_head, m_data.begin() + m_head + len, begin);
-		m_head += len;
-		m_head %= m_size;
-		m_fill -= len;
-		begin += len;
-		remaining -= len;
-	}
+        len = std::min(remaining, m_size - m_head);
+        std::copy(m_data.begin() + m_head, m_data.begin() + m_head + len, begin);
+        m_head += len;
+        m_head %= m_size;
+        m_fill -= len;
+        begin += len;
+        remaining -= len;
+    }
 
-	return total;
+    return total;
 }
 
 unsigned int DataFifo::readBegin(unsigned int count,
-	QByteArray::iterator* part1Begin, QByteArray::iterator* part1End,
-	QByteArray::iterator* part2Begin, QByteArray::iterator* part2End,
-	DataType& dataType)
+    QByteArray::iterator* part1Begin, QByteArray::iterator* part1End,
+    QByteArray::iterator* part2Begin, QByteArray::iterator* part2End,
+    DataType& dataType)
 {
-	QMutexLocker mutexLocker(&m_mutex);
-	dataType = m_currentDataType;
-	unsigned int total;
-	unsigned int remaining;
-	unsigned int len;
-	unsigned int head = m_head;
+    QMutexLocker mutexLocker(&m_mutex);
+    dataType = m_currentDataType;
+    unsigned int total;
+    unsigned int remaining;
+    unsigned int len;
+    unsigned int head = m_head;
 
-	total = std::min(count, m_fill);
+    total = std::min(count, m_fill);
 
     if (total < count) {
-		qCritical("DataFifo::readBegin: underflow - missing %u samples", count - total);
+        qCritical("DataFifo::readBegin: underflow - missing %u samples", count - total);
     }
 
-	remaining = total;
+    remaining = total;
 
     if (remaining > 0)
     {
-		len = std::min(remaining, m_size - head);
-		*part1Begin = m_data.begin() + head;
-		*part1End = m_data.begin() + head + len;
-		head += len;
-		head %= m_size;
-		remaining -= len;
-	}
+        len = std::min(remaining, m_size - head);
+        *part1Begin = m_data.begin() + head;
+        *part1End = m_data.begin() + head + len;
+        head += len;
+        head %= m_size;
+        remaining -= len;
+    }
     else
     {
-		*part1Begin = m_data.end();
-		*part1End = m_data.end();
-	}
+        *part1Begin = m_data.end();
+        *part1End = m_data.end();
+    }
 
     if (remaining > 0)
     {
-		len = std::min(remaining, m_size - head);
-		*part2Begin = m_data.begin() + head;
-		*part2End = m_data.begin() + head + len;
-	}
+        len = std::min(remaining, m_size - head);
+        *part2Begin = m_data.begin() + head;
+        *part2End = m_data.begin() + head + len;
+    }
     else
     {
-		*part2Begin = m_data.end();
-		*part2End = m_data.end();
-	}
+        *part2Begin = m_data.end();
+        *part2End = m_data.end();
+    }
 
-	return total;
+    return total;
 }
 
 unsigned int DataFifo::readCommit(unsigned int count)
 {
-	QMutexLocker mutexLocker(&m_mutex);
+    QMutexLocker mutexLocker(&m_mutex);
 
-	if (count > m_fill)
+    if (count > m_fill)
     {
-		qCritical("DataFifo::readCommit: cannot commit more than available samples");
-		count = m_fill;
-	}
+        qCritical("DataFifo::readCommit: cannot commit more than available samples");
+        count = m_fill;
+    }
 
     m_head = (m_head + count) % m_size;
-	m_fill -= count;
+    m_fill -= count;
 
-	return count;
+    return count;
 }

--- a/sdrbase/dsp/datafifo.cpp
+++ b/sdrbase/dsp/datafifo.cpp
@@ -35,6 +35,7 @@ void DataFifo::reset()
 {
     QMutexLocker mutexLocker(&m_mutex);
     m_suppressed = -1;
+    m_suppressedSamples = 0;
     m_fill = 0;
     m_head = 0;
     m_tail = 0;
@@ -47,6 +48,7 @@ DataFifo::DataFifo(QObject* parent) :
 {
     setObjectName("DataFifo");
     m_suppressed = -1;
+    m_suppressedSamples = 0;
     m_size = 0;
     m_fill = 0;
     m_head = 0;
@@ -60,6 +62,7 @@ DataFifo::DataFifo(int size, QObject* parent) :
 {
     setObjectName("DataFifo");
     m_suppressed = -1;
+    m_suppressedSamples = 0;
     create(size);
 }
 
@@ -70,6 +73,7 @@ DataFifo::DataFifo(const DataFifo& other) :
 {
     setObjectName("DataFifo");
     m_suppressed = -1;
+    m_suppressedSamples = 0;
     m_size = m_data.size();
     m_fill = 0;
     m_head = 0;
@@ -89,25 +93,63 @@ bool DataFifo::setSize(int size)
     return m_data.size() == size;
 }
 
+// Rate-limit overflow messages while continuing to report every overflow.
+// After an overflow, messages are suppressed for 2.5 seconds and the
+// accumulated loss is reported as a single message. A 2.5 second recovery
+// interval without further overflow is then required before immediate
+// reporting resumes.
 void DataFifo::logOverflow(unsigned int total, unsigned int count)
 {
-    unsigned int samplesDropped = count - total;
+    const bool hasOverflow = total < count;
+    const unsigned int dropped = count - total;
+
+    // m_suppressed: -1 = immediate reporting, 0+ = suppressed message count,
+    //               -2 = recovery monitoring
 
     if (m_suppressed == -1)
     {
-        m_suppressed = 0;
-        m_msgRateTimer.start();
-        qCritical("DataFifo::write: overflow - dropping %u samples (size=%u)", samplesDropped, m_size);
+        if (hasOverflow)
+        {
+            qCritical("DataFifo: overflow - dropped %u samples", dropped);
+
+            // The current overflow was already reported, so don't count it again.
+            m_suppressed = 0;
+            m_suppressedSamples = 0;
+            m_msgRateTimer.start();
+        }
     }
-    else if (m_msgRateTimer.elapsed() > 2500)
+    else if (m_suppressed == -2)
     {
-        qCritical("DataFifo::write: %u messages dropped", m_suppressed);
-        qCritical("DataFifo::write: overflow - dropping %u samples (size=%u)", samplesDropped, m_size);
-        m_suppressed = -1;
+        if (hasOverflow)
+        {
+            // Resume accumulation without restarting the recovery timer.
+            m_suppressed = 1;
+            m_suppressedSamples += dropped;
+        }
+        else if (m_msgRateTimer.elapsed() > 2500)
+        {
+            // No overflow for the recovery interval: resume immediate reporting.
+            m_suppressed = -1;
+        }
     }
-    else
+    else // m_suppressed >= 0
     {
-        m_suppressed++;
+        if (m_msgRateTimer.elapsed() > 2500)
+        {
+            if (m_suppressed)
+            {
+                qCritical("DataFifo: overflow - dropped %lld samples (%u event%s)",
+                    m_suppressedSamples, m_suppressed, m_suppressed > 1 ? "s" : "");
+            }
+            m_suppressed = -2;
+            m_suppressedSamples = 0;
+            m_msgRateTimer.restart();
+        }
+        else if (hasOverflow)
+        {
+            ++m_suppressed;
+            m_suppressedSamples += dropped;
+        }
     }
 }
 
@@ -118,6 +160,7 @@ unsigned int DataFifo::write(const quint8* data, unsigned int count, DataType da
     if (dataType != m_currentDataType)
     {
         m_suppressed = -1;
+        m_suppressedSamples = 0;
         m_fill = 0;
         m_head = 0;
         m_tail = 0;
@@ -164,6 +207,7 @@ unsigned int DataFifo::write(QByteArray::const_iterator begin, QByteArray::const
     if (dataType != m_currentDataType)
     {
         m_suppressed = -1;
+        m_suppressedSamples = 0;
         m_fill = 0;
         m_head = 0;
         m_tail = 0;

--- a/sdrbase/dsp/datafifo.cpp
+++ b/sdrbase/dsp/datafifo.cpp
@@ -89,6 +89,28 @@ bool DataFifo::setSize(int size)
     return m_data.size() == size;
 }
 
+void DataFifo::logOverflow(unsigned int total, unsigned int count)
+{
+    unsigned int samplesDropped = count - total;
+
+    if (m_suppressed == -1)
+    {
+        m_suppressed = 0;
+        m_msgRateTimer.start();
+        qCritical("DataFifo::write: overflow - dropping %u samples (size=%u)", samplesDropped, m_size);
+    }
+    else if (m_msgRateTimer.elapsed() > 2500)
+    {
+        qCritical("DataFifo::write: %u messages dropped", m_suppressed);
+        qCritical("DataFifo::write: overflow - dropping %u samples (size=%u)", samplesDropped, m_size);
+        m_suppressed = -1;
+    }
+    else
+    {
+        m_suppressed++;
+    }
+}
+
 unsigned int DataFifo::write(const quint8* data, unsigned int count, DataType dataType)
 {
     QMutexLocker mutexLocker(&m_mutex);
@@ -112,25 +134,7 @@ unsigned int DataFifo::write(const quint8* data, unsigned int count, DataType da
 
     if (total < count)
     {
-        if (m_suppressed < 0)
-        {
-            m_suppressed = 0;
-            m_msgRateTimer.start();
-            qCritical("DataFifo::write: overflow - dropping %u samples (size=%u)", count - total, m_size);
-        }
-        else
-        {
-            if (m_msgRateTimer.elapsed() > 2500)
-            {
-                qCritical("DataFifo::write: %u messages dropped", m_suppressed);
-                qCritical("DataFifo::write: overflow - dropping %u samples (size=%u)", count - total, m_size);
-                m_suppressed = -1;
-            }
-            else
-            {
-                m_suppressed++;
-            }
-        }
+        logOverflow(total, count);
     }
 
     remaining = total;
@@ -175,25 +179,7 @@ unsigned int DataFifo::write(QByteArray::const_iterator begin, QByteArray::const
 
     if (total < count)
     {
-        if (m_suppressed < 0)
-        {
-            m_suppressed = 0;
-            m_msgRateTimer.start();
-            qCritical("DataFifo::write: overflow - dropping %u samples", count - total);
-        }
-        else
-        {
-            if (m_msgRateTimer.elapsed() > 2500)
-            {
-                qCritical("DataFifo::write: %u messages dropped", m_suppressed);
-                qCritical("DataFifo::write: overflow - dropping %u samples", count - total);
-                m_suppressed = -1;
-            }
-            else
-            {
-                m_suppressed++;
-            }
-        }
+        logOverflow(total, count);
     }
 
     remaining = total;

--- a/sdrbase/dsp/datafifo.h
+++ b/sdrbase/dsp/datafifo.h
@@ -29,51 +29,51 @@
 #include "export.h"
 
 class SDRBASE_API DataFifo : public QObject {
-	Q_OBJECT
+    Q_OBJECT
 public:
-	enum DataType
-	{
-		DataTypeI16,  //!< 16 bit signed integer
-		DataTypeCI16  //!< Complex (i.e. Re, Im pair of) 16 bit signed integer
-	};
+    enum DataType
+    {
+        DataTypeI16,  //!< 16 bit signed integer
+        DataTypeCI16  //!< Complex (i.e. Re, Im pair of) 16 bit signed integer
+    };
 
-	DataFifo(QObject* parent = nullptr);
-	DataFifo(int size, QObject* parent = nullptr);
+    DataFifo(QObject* parent = nullptr);
+    DataFifo(int size, QObject* parent = nullptr);
     DataFifo(const DataFifo& other);
-	~DataFifo();
+    ~DataFifo();
 
-	bool setSize(int size);
+    bool setSize(int size);
     void reset();
-	inline unsigned int size() const { return m_size; }
-	inline unsigned int fill() { QMutexLocker mutexLocker(&m_mutex); unsigned int fill = m_fill; return fill; }
+    inline unsigned int size() const { return m_size; }
+    inline unsigned int fill() { QMutexLocker mutexLocker(&m_mutex); unsigned int fill = m_fill; return fill; }
 
-	unsigned int write(const quint8* data, unsigned int count, DataType dataType);
-	unsigned int write(QByteArray::const_iterator begin, QByteArray::const_iterator end, DataType dataType);
+    unsigned int write(const quint8* data, unsigned int count, DataType dataType);
+    unsigned int write(QByteArray::const_iterator begin, QByteArray::const_iterator end, DataType dataType);
 
-	unsigned int read(QByteArray::iterator begin, QByteArray::iterator end, DataType& dataType);
+    unsigned int read(QByteArray::iterator begin, QByteArray::iterator end, DataType& dataType);
 
-	unsigned int readBegin(unsigned int count,
-		QByteArray::iterator* part1Begin, QByteArray::iterator* part1End,
-		QByteArray::iterator* part2Begin, QByteArray::iterator* part2End,
-		DataType& daaType);
-	unsigned int readCommit(unsigned int count);
+    unsigned int readBegin(unsigned int count,
+        QByteArray::iterator* part1Begin, QByteArray::iterator* part1End,
+        QByteArray::iterator* part2Begin, QByteArray::iterator* part2End,
+        DataType& daaType);
+    unsigned int readCommit(unsigned int count);
 
 signals:
-	void dataReady();
+    void dataReady();
 
 private:
-	QElapsedTimer m_msgRateTimer;
-	int m_suppressed;
-	QByteArray m_data;
-	DataType m_currentDataType;
-	QRecursiveMutex m_mutex;
+    QElapsedTimer m_msgRateTimer;
+    int m_suppressed;
+    QByteArray m_data;
+    DataType m_currentDataType;
+    QRecursiveMutex m_mutex;
 
-	unsigned int m_size;
-	unsigned int m_fill;
-	unsigned int m_head;
-	unsigned int m_tail;
+    unsigned int m_size;
+    unsigned int m_fill;
+    unsigned int m_head;
+    unsigned int m_tail;
 
-	void create(unsigned int s);
+    void create(unsigned int s);
 };
 
 #endif // INCLUDE_DATAFIFO_H

--- a/sdrbase/dsp/datafifo.h
+++ b/sdrbase/dsp/datafifo.h
@@ -74,6 +74,7 @@ private:
     unsigned int m_tail;
 
     void create(unsigned int s);
+    void logOverflow(unsigned int total, unsigned int count);
 };
 
 #endif // INCLUDE_DATAFIFO_H

--- a/sdrbase/dsp/datafifo.h
+++ b/sdrbase/dsp/datafifo.h
@@ -64,6 +64,7 @@ signals:
 private:
     QElapsedTimer m_msgRateTimer;
     int m_suppressed;
+    qint64 m_suppressedSamples;
     QByteArray m_data;
     DataType m_currentDataType;
     QRecursiveMutex m_mutex;

--- a/sdrbase/dsp/samplesinkfifo.cpp
+++ b/sdrbase/dsp/samplesinkfifo.cpp
@@ -100,6 +100,30 @@ void SampleSinkFifo::setWrittenSignalRateDivider(unsigned int divider)
     m_writtenSignalRateDivider = divider;
 }
 
+void SampleSinkFifo::logOverflow(unsigned int total, unsigned int count)
+{
+    unsigned int samplesDropped = count - total;
+
+    if (m_suppressed == -1)
+    {
+        m_suppressed = 0;
+        m_msgRateTimer.start();
+        qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples", qPrintable(m_label), samplesDropped);
+        emit overflow(samplesDropped);
+    }
+    else if (m_msgRateTimer.elapsed() > 2500)
+    {
+        qCritical("SampleSinkFifo::write: (%s) %u messages dropped", qPrintable(m_label), m_suppressed);
+        qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples", qPrintable(m_label), samplesDropped);
+        emit overflow(samplesDropped);
+        m_suppressed = -1;
+    }
+    else
+    {
+        m_suppressed++;
+    }
+}
+
 unsigned int SampleSinkFifo::write(const quint8* data, unsigned int count)
 {
     QMutexLocker mutexLocker(&m_mutex);
@@ -118,29 +142,7 @@ unsigned int SampleSinkFifo::write(const quint8* data, unsigned int count)
 
     if (total < count)
     {
-        if (m_suppressed < 0)
-        {
-            m_suppressed = 0;
-            m_msgRateTimer.start();
-            qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
-                qPrintable(m_label), count - total);
-            emit overflow(count - total);
-        }
-        else
-        {
-            if (m_msgRateTimer.elapsed() > 2500)
-            {
-                qCritical("SampleSinkFifo::write: (%s) %u messages dropped", qPrintable(m_label), m_suppressed);
-                qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
-                    qPrintable(m_label), count - total);
-                emit overflow(count - total);
-                m_suppressed = -1;
-            }
-            else
-            {
-                m_suppressed++;
-            }
-        }
+        logOverflow(total, count);
     }
 
     remaining = total;
@@ -189,29 +191,7 @@ unsigned int SampleSinkFifo::write(SampleVector::const_iterator begin, SampleVec
 
     if (total < count)
     {
-        if (m_suppressed < 0)
-        {
-            m_suppressed = 0;
-            m_msgRateTimer.start();
-            qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
-                qPrintable(m_label), count - total);
-            emit overflow(count - total);
-        }
-        else
-        {
-            if (m_msgRateTimer.elapsed() > 2500)
-            {
-                qCritical("SampleSinkFifo::write: (%s) %u messages dropped", qPrintable(m_label), m_suppressed);
-                qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
-                    qPrintable(m_label), count - total);
-                emit overflow(count - total);
-                m_suppressed = -1;
-            }
-            else
-            {
-                m_suppressed++;
-            }
-        }
+        logOverflow(total, count);
     }
 
     remaining = total;

--- a/sdrbase/dsp/samplesinkfifo.cpp
+++ b/sdrbase/dsp/samplesinkfifo.cpp
@@ -25,336 +25,336 @@
 
 void SampleSinkFifo::create(unsigned int s)
 {
-	m_fill = 0;
-	m_head = 0;
-	m_tail = 0;
+    m_fill = 0;
+    m_head = 0;
+    m_tail = 0;
 
-	m_data.resize(s);
-	m_size = m_data.size();
+    m_data.resize(s);
+    m_size = m_data.size();
 }
 
 void SampleSinkFifo::reset()
 {
-	QMutexLocker mutexLocker(&m_mutex);
-	m_suppressed = -1;
-	m_fill = 0;
-	m_head = 0;
-	m_tail = 0;
+    QMutexLocker mutexLocker(&m_mutex);
+    m_suppressed = -1;
+    m_fill = 0;
+    m_head = 0;
+    m_tail = 0;
 }
 
 SampleSinkFifo::SampleSinkFifo(QObject* parent) :
-	QObject(parent),
-	m_data(),
-	m_total(0),
-	m_writtenSignalCount(0),
-	m_writtenSignalRateDivider(1)
+    QObject(parent),
+    m_data(),
+    m_total(0),
+    m_writtenSignalCount(0),
+    m_writtenSignalRateDivider(1)
 {
-	m_suppressed = -1;
-	m_size = 0;
-	m_fill = 0;
-	m_head = 0;
-	m_tail = 0;
+    m_suppressed = -1;
+    m_size = 0;
+    m_fill = 0;
+    m_head = 0;
+    m_tail = 0;
 }
 
 SampleSinkFifo::SampleSinkFifo(int size, QObject* parent) :
-	QObject(parent),
-	m_data(),
-	m_total(0),
-	m_writtenSignalCount(0),
-	m_writtenSignalRateDivider(1)
+    QObject(parent),
+    m_data(),
+    m_total(0),
+    m_writtenSignalCount(0),
+    m_writtenSignalRateDivider(1)
 {
-	m_suppressed = -1;
-	create(size);
+    m_suppressed = -1;
+    create(size);
 }
 
 SampleSinkFifo::SampleSinkFifo(const SampleSinkFifo& other) :
     QObject(other.parent()),
     m_data(other.m_data),
-	m_total(0),
-	m_writtenSignalCount(0),
-	m_writtenSignalRateDivider(1)
+    m_total(0),
+    m_writtenSignalCount(0),
+    m_writtenSignalRateDivider(1)
 {
-  	m_suppressed = -1;
-	m_size = m_data.size();
-	m_fill = 0;
-	m_head = 0;
-	m_tail = 0;
+    m_suppressed = -1;
+    m_size = m_data.size();
+    m_fill = 0;
+    m_head = 0;
+    m_tail = 0;
 }
 
 SampleSinkFifo::~SampleSinkFifo()
 {
-	QMutexLocker mutexLocker(&m_mutex);
-	m_size = 0;
+    QMutexLocker mutexLocker(&m_mutex);
+    m_size = 0;
 }
 
 bool SampleSinkFifo::setSize(int size)
 {
-	QMutexLocker mutexLocker(&m_mutex);
-	create(size);
-	return m_data.size() == (unsigned int)size;
+    QMutexLocker mutexLocker(&m_mutex);
+    create(size);
+    return m_data.size() == (unsigned int)size;
 }
 
 void SampleSinkFifo::setWrittenSignalRateDivider(unsigned int divider)
 {
-	QMutexLocker mutexLocker(&m_mutex);
-	m_writtenSignalRateDivider = divider;
+    QMutexLocker mutexLocker(&m_mutex);
+    m_writtenSignalRateDivider = divider;
 }
 
 unsigned int SampleSinkFifo::write(const quint8* data, unsigned int count)
 {
-	QMutexLocker mutexLocker(&m_mutex);
+    QMutexLocker mutexLocker(&m_mutex);
 
-	if (m_size == 0) {
-		return 0;
-	}
+    if (m_size == 0) {
+        return 0;
+    }
 
-	unsigned int total;
-	unsigned int remaining;
-	unsigned int len;
-	const Sample* begin = (const Sample*)data;
-	count /= sizeof(Sample);
+    unsigned int total;
+    unsigned int remaining;
+    unsigned int len;
+    const Sample* begin = (const Sample*)data;
+    count /= sizeof(Sample);
 
-	total = std::min(count, m_size - m_fill);
+    total = std::min(count, m_size - m_fill);
 
     if (total < count)
     {
-		if (m_suppressed < 0)
+        if (m_suppressed < 0)
         {
-			m_suppressed = 0;
-			m_msgRateTimer.start();
-			qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
-				qPrintable(m_label), count - total);
-			emit overflow(count - total);
-		}
+            m_suppressed = 0;
+            m_msgRateTimer.start();
+            qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
+                qPrintable(m_label), count - total);
+            emit overflow(count - total);
+        }
         else
         {
-			if (m_msgRateTimer.elapsed() > 2500)
+            if (m_msgRateTimer.elapsed() > 2500)
             {
-				qCritical("SampleSinkFifo::write: (%s) %u messages dropped", qPrintable(m_label), m_suppressed);
-				qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
-					qPrintable(m_label), count - total);
-				emit overflow(count - total);
-				m_suppressed = -1;
-			}
+                qCritical("SampleSinkFifo::write: (%s) %u messages dropped", qPrintable(m_label), m_suppressed);
+                qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
+                    qPrintable(m_label), count - total);
+                emit overflow(count - total);
+                m_suppressed = -1;
+            }
             else
             {
-				m_suppressed++;
-			}
-		}
-	}
+                m_suppressed++;
+            }
+        }
+    }
 
-	remaining = total;
+    remaining = total;
 
     while (remaining > 0)
     {
-		len = std::min(remaining, m_size - m_tail);
-		std::copy(begin, begin + len, m_data.begin() + m_tail);
-		m_tail += len;
-		m_tail %= m_size;
-		m_fill += len;
-		begin += len;
-		remaining -= len;
-	}
-
-	if (m_fill > 0) {
-		emit dataReady();
+        len = std::min(remaining, m_size - m_tail);
+        std::copy(begin, begin + len, m_data.begin() + m_tail);
+        m_tail += len;
+        m_tail %= m_size;
+        m_fill += len;
+        begin += len;
+        remaining -= len;
     }
 
-	m_total += total;
+    if (m_fill > 0) {
+        emit dataReady();
+    }
 
-	if (++m_writtenSignalCount >= m_writtenSignalRateDivider)
-	{
-		emit written(m_total, MainCore::instance()->getElapsedNsecs());
-		m_total = 0;
-		m_writtenSignalCount = 0;
-	}
+    m_total += total;
 
-	return total;
+    if (++m_writtenSignalCount >= m_writtenSignalRateDivider)
+    {
+        emit written(m_total, MainCore::instance()->getElapsedNsecs());
+        m_total = 0;
+        m_writtenSignalCount = 0;
+    }
+
+    return total;
 }
 
 unsigned int SampleSinkFifo::write(SampleVector::const_iterator begin, SampleVector::const_iterator end)
 {
-	QMutexLocker mutexLocker(&m_mutex);
+    QMutexLocker mutexLocker(&m_mutex);
 
-	if (m_size == 0) {
-		return 0;
-	}
+    if (m_size == 0) {
+        return 0;
+    }
 
-	unsigned int count = end - begin;
-	unsigned int total;
-	unsigned int remaining;
-	unsigned int len;
+    unsigned int count = end - begin;
+    unsigned int total;
+    unsigned int remaining;
+    unsigned int len;
 
-	total = std::min(count, m_size - m_fill);
+    total = std::min(count, m_size - m_fill);
 
     if (total < count)
     {
-		if (m_suppressed < 0)
+        if (m_suppressed < 0)
         {
-			m_suppressed = 0;
-			m_msgRateTimer.start();
-			qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
-				qPrintable(m_label), count - total);
-			emit overflow(count - total);
-		}
+            m_suppressed = 0;
+            m_msgRateTimer.start();
+            qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
+                qPrintable(m_label), count - total);
+            emit overflow(count - total);
+        }
         else
         {
-			if (m_msgRateTimer.elapsed() > 2500)
+            if (m_msgRateTimer.elapsed() > 2500)
             {
-				qCritical("SampleSinkFifo::write: (%s) %u messages dropped", qPrintable(m_label), m_suppressed);
-				qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
-					qPrintable(m_label), count - total);
-				emit overflow(count - total);
-				m_suppressed = -1;
-			}
+                qCritical("SampleSinkFifo::write: (%s) %u messages dropped", qPrintable(m_label), m_suppressed);
+                qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples",
+                    qPrintable(m_label), count - total);
+                emit overflow(count - total);
+                m_suppressed = -1;
+            }
             else
             {
-				m_suppressed++;
-			}
-		}
-	}
+                m_suppressed++;
+            }
+        }
+    }
 
-	remaining = total;
+    remaining = total;
 
     while (remaining > 0)
     {
-		len = std::min(remaining, m_size - m_tail);
-		std::copy(begin, begin + len, m_data.begin() + m_tail);
-		m_tail += len;
-		m_tail %= m_size;
-		m_fill += len;
-		begin += len;
-		remaining -= len;
-	}
-
-	if (m_fill > 0) {
-		emit dataReady();
+        len = std::min(remaining, m_size - m_tail);
+        std::copy(begin, begin + len, m_data.begin() + m_tail);
+        m_tail += len;
+        m_tail %= m_size;
+        m_fill += len;
+        begin += len;
+        remaining -= len;
     }
 
-	m_total += total;
+    if (m_fill > 0) {
+        emit dataReady();
+    }
 
-	if (++m_writtenSignalCount >= m_writtenSignalRateDivider)
-	{
-		emit written(m_total, MainCore::instance()->getElapsedNsecs());
-		m_total = 0;
-		m_writtenSignalCount = 0;
-	}
+    m_total += total;
 
-	return total;
+    if (++m_writtenSignalCount >= m_writtenSignalRateDivider)
+    {
+        emit written(m_total, MainCore::instance()->getElapsedNsecs());
+        m_total = 0;
+        m_writtenSignalCount = 0;
+    }
+
+    return total;
 }
 
 unsigned int SampleSinkFifo::read(SampleVector::iterator begin, SampleVector::iterator end)
 {
-	QMutexLocker mutexLocker(&m_mutex);
+    QMutexLocker mutexLocker(&m_mutex);
 
-	if (m_size == 0) {
-		return 0;
-	}
-
-	unsigned int count = end - begin;
-	unsigned int total;
-	unsigned int remaining;
-	unsigned int len;
-
-	total = std::min(count, m_fill);
-
-    if (total < count)
-	{
-		qCritical("SampleSinkFifo::read: (%s) underflow - missing %u samples",
-			qPrintable(m_label), count - total);
-		emit underflow(count - total);
+    if (m_size == 0) {
+        return 0;
     }
 
-	remaining = total;
+    unsigned int count = end - begin;
+    unsigned int total;
+    unsigned int remaining;
+    unsigned int len;
+
+    total = std::min(count, m_fill);
+
+    if (total < count)
+    {
+        qCritical("SampleSinkFifo::read: (%s) underflow - missing %u samples",
+            qPrintable(m_label), count - total);
+        emit underflow(count - total);
+    }
+
+    remaining = total;
 
     while (remaining > 0)
     {
-		len = std::min(remaining, m_size - m_head);
-		std::copy(m_data.begin() + m_head, m_data.begin() + m_head + len, begin);
-		m_head += len;
-		m_head %= m_size;
-		m_fill -= len;
-		begin += len;
-		remaining -= len;
-	}
+        len = std::min(remaining, m_size - m_head);
+        std::copy(m_data.begin() + m_head, m_data.begin() + m_head + len, begin);
+        m_head += len;
+        m_head %= m_size;
+        m_fill -= len;
+        begin += len;
+        remaining -= len;
+    }
 
-	return total;
+    return total;
 }
 
 unsigned int SampleSinkFifo::readBegin(unsigned int count,
-	SampleVector::iterator* part1Begin, SampleVector::iterator* part1End,
-	SampleVector::iterator* part2Begin, SampleVector::iterator* part2End)
+    SampleVector::iterator* part1Begin, SampleVector::iterator* part1End,
+    SampleVector::iterator* part2Begin, SampleVector::iterator* part2End)
 {
-	QMutexLocker mutexLocker(&m_mutex);
+    QMutexLocker mutexLocker(&m_mutex);
 
-	if (m_size == 0) {
-		return 0;
-	}
-
-	unsigned int total;
-	unsigned int remaining;
-	unsigned int len;
-	unsigned int head = m_head;
-
-	total = std::min(count, m_fill);
-
-    if (total < count)
-	{
-		qCritical("SampleSinkFifo::readBegin: (%s) underflow - missing %u samples",
-			qPrintable(m_label), count - total);
-		emit underflow(count - total);
+    if (m_size == 0) {
+        return 0;
     }
 
-	remaining = total;
+    unsigned int total;
+    unsigned int remaining;
+    unsigned int len;
+    unsigned int head = m_head;
+
+    total = std::min(count, m_fill);
+
+    if (total < count)
+    {
+        qCritical("SampleSinkFifo::readBegin: (%s) underflow - missing %u samples",
+            qPrintable(m_label), count - total);
+        emit underflow(count - total);
+    }
+
+    remaining = total;
 
     if (remaining > 0)
     {
-		len = std::min(remaining, m_size - head);
-		*part1Begin = m_data.begin() + head;
-		*part1End = m_data.begin() + head + len;
-		head += len;
-		head %= m_size;
-		remaining -= len;
-	}
+        len = std::min(remaining, m_size - head);
+        *part1Begin = m_data.begin() + head;
+        *part1End = m_data.begin() + head + len;
+        head += len;
+        head %= m_size;
+        remaining -= len;
+    }
     else
     {
-		*part1Begin = m_data.end();
-		*part1End = m_data.end();
-	}
+        *part1Begin = m_data.end();
+        *part1End = m_data.end();
+    }
 
     if (remaining > 0)
     {
-		len = std::min(remaining, m_size - head);
-		*part2Begin = m_data.begin() + head;
-		*part2End = m_data.begin() + head + len;
-	}
+        len = std::min(remaining, m_size - head);
+        *part2Begin = m_data.begin() + head;
+        *part2End = m_data.begin() + head + len;
+    }
     else
     {
-		*part2Begin = m_data.end();
-		*part2End = m_data.end();
-	}
+        *part2Begin = m_data.end();
+        *part2End = m_data.end();
+    }
 
-	return total;
+    return total;
 }
 
 unsigned int SampleSinkFifo::readCommit(unsigned int count)
 {
-	QMutexLocker mutexLocker(&m_mutex);
+    QMutexLocker mutexLocker(&m_mutex);
 
-	if (m_size == 0) {
-		return 0;
-	}
+    if (m_size == 0) {
+        return 0;
+    }
 
-	if (count > m_fill)
+    if (count > m_fill)
     {
-		qCritical("SampleSinkFifo::readCommit: (%s) cannot commit more than available samples", qPrintable(m_label));
-		count = m_fill;
-	}
+        qCritical("SampleSinkFifo::readCommit: (%s) cannot commit more than available samples", qPrintable(m_label));
+        count = m_fill;
+    }
 
     m_head = (m_head + count) % m_size;
-	m_fill -= count;
+    m_fill -= count;
 
-	return count;
+    return count;
 }
 
 unsigned int SampleSinkFifo::getSizePolicy(unsigned int sampleRate)

--- a/sdrbase/dsp/samplesinkfifo.cpp
+++ b/sdrbase/dsp/samplesinkfifo.cpp
@@ -37,6 +37,7 @@ void SampleSinkFifo::reset()
 {
     QMutexLocker mutexLocker(&m_mutex);
     m_suppressed = -1;
+    m_suppressedSamples = 0;
     m_fill = 0;
     m_head = 0;
     m_tail = 0;
@@ -50,6 +51,7 @@ SampleSinkFifo::SampleSinkFifo(QObject* parent) :
     m_writtenSignalRateDivider(1)
 {
     m_suppressed = -1;
+    m_suppressedSamples = 0;
     m_size = 0;
     m_fill = 0;
     m_head = 0;
@@ -64,6 +66,7 @@ SampleSinkFifo::SampleSinkFifo(int size, QObject* parent) :
     m_writtenSignalRateDivider(1)
 {
     m_suppressed = -1;
+    m_suppressedSamples = 0;
     create(size);
 }
 
@@ -75,6 +78,7 @@ SampleSinkFifo::SampleSinkFifo(const SampleSinkFifo& other) :
     m_writtenSignalRateDivider(1)
 {
     m_suppressed = -1;
+    m_suppressedSamples = 0;
     m_size = m_data.size();
     m_fill = 0;
     m_head = 0;
@@ -100,27 +104,69 @@ void SampleSinkFifo::setWrittenSignalRateDivider(unsigned int divider)
     m_writtenSignalRateDivider = divider;
 }
 
+// Rate-limit overflow messages while continuing to report every overflow.
+// After an overflow, messages are suppressed for 2.5 seconds and the
+// accumulated loss is reported as a single message. A 2.5 second recovery
+// interval without further overflow is then required before immediate
+// reporting resumes.
 void SampleSinkFifo::logOverflow(unsigned int total, unsigned int count)
 {
-    unsigned int samplesDropped = count - total;
+    const bool hasOverflow = total < count;
+    const unsigned int dropped = count - total;
+
+    if (hasOverflow)
+    {
+        emit overflow(dropped);
+    }
+
+    // m_suppressed: -1 = immediate reporting, 0+ = suppressed message count,
+    //               -2 = recovery monitoring
 
     if (m_suppressed == -1)
     {
-        m_suppressed = 0;
-        m_msgRateTimer.start();
-        qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples", qPrintable(m_label), samplesDropped);
-        emit overflow(samplesDropped);
+        if (hasOverflow)
+        {
+            qCritical("SampleSinkFifo: (%s) overflow - dropped %u samples",
+               qPrintable(m_label), dropped);
+
+            // The current overflow was already reported, so don't count it again.
+            m_suppressed = 0;
+            m_suppressedSamples = 0;
+            m_msgRateTimer.start();
+        }
     }
-    else if (m_msgRateTimer.elapsed() > 2500)
+    else if (m_suppressed == -2)
     {
-        qCritical("SampleSinkFifo::write: (%s) %u messages dropped", qPrintable(m_label), m_suppressed);
-        qCritical("SampleSinkFifo::write: (%s) overflow - dropping %u samples", qPrintable(m_label), samplesDropped);
-        emit overflow(samplesDropped);
-        m_suppressed = -1;
+        if (hasOverflow)
+        {
+            // Resume accumulation without restarting the recovery timer.
+            m_suppressed = 1;
+            m_suppressedSamples += dropped;
+        }
+        else if (m_msgRateTimer.elapsed() > 2500)
+        {
+            // No overflow for the recovery interval: resume immediate reporting.
+            m_suppressed = -1;
+        }
     }
-    else
+    else // m_suppressed >= 0
     {
-        m_suppressed++;
+        if (m_msgRateTimer.elapsed() > 2500)
+        {
+            if (m_suppressed)
+            {
+                qCritical("SampleSinkFifo: (%s) overflow - dropped %lld samples (%u event%s)",
+                    qPrintable(m_label), m_suppressedSamples, m_suppressed, m_suppressed > 1 ? "s" : "");
+            }
+            m_suppressed = -2;
+            m_suppressedSamples = 0;
+            m_msgRateTimer.restart();
+        }
+        else if (hasOverflow)
+        {
+            ++m_suppressed;
+            m_suppressedSamples += dropped;
+        }
     }
 }
 
@@ -140,7 +186,7 @@ unsigned int SampleSinkFifo::write(const quint8* data, unsigned int count)
 
     total = std::min(count, m_size - m_fill);
 
-    if (total < count)
+    if (m_suppressed != -1 || total < count)
     {
         logOverflow(total, count);
     }
@@ -189,7 +235,7 @@ unsigned int SampleSinkFifo::write(SampleVector::const_iterator begin, SampleVec
 
     total = std::min(count, m_size - m_fill);
 
-    if (total < count)
+    if (m_suppressed != -1 || total < count)
     {
         logOverflow(total, count);
     }

--- a/sdrbase/dsp/samplesinkfifo.h
+++ b/sdrbase/dsp/samplesinkfifo.h
@@ -33,6 +33,7 @@ class SDRBASE_API SampleSinkFifo : public QObject {
 private:
     QElapsedTimer m_msgRateTimer;
     int m_suppressed;
+    qint64 m_suppressedSamples;
     SampleVector m_data;
     int m_total;
     unsigned int m_writtenSignalCount;

--- a/sdrbase/dsp/samplesinkfifo.h
+++ b/sdrbase/dsp/samplesinkfifo.h
@@ -46,6 +46,7 @@ private:
     QString m_label;
 
     void create(unsigned int s);
+    void logOverflow(unsigned int total, unsigned int count);
 
 public:
     SampleSinkFifo(QObject* parent = nullptr);

--- a/sdrbase/dsp/samplesinkfifo.h
+++ b/sdrbase/dsp/samplesinkfifo.h
@@ -28,54 +28,54 @@
 #include "export.h"
 
 class SDRBASE_API SampleSinkFifo : public QObject {
-	Q_OBJECT
+    Q_OBJECT
 
 private:
-	QElapsedTimer m_msgRateTimer;
-	int m_suppressed;
-	SampleVector m_data;
-	int m_total;
-	unsigned int m_writtenSignalCount;
-	unsigned int m_writtenSignalRateDivider;
-	QRecursiveMutex m_mutex;
+    QElapsedTimer m_msgRateTimer;
+    int m_suppressed;
+    SampleVector m_data;
+    int m_total;
+    unsigned int m_writtenSignalCount;
+    unsigned int m_writtenSignalRateDivider;
+    QRecursiveMutex m_mutex;
 
-	unsigned int m_size;
-	unsigned int m_fill;
-	unsigned int m_head;
-	unsigned int m_tail;
-	QString m_label;
+    unsigned int m_size;
+    unsigned int m_fill;
+    unsigned int m_head;
+    unsigned int m_tail;
+    QString m_label;
 
-	void create(unsigned int s);
+    void create(unsigned int s);
 
 public:
-	SampleSinkFifo(QObject* parent = nullptr);
-	SampleSinkFifo(int size, QObject* parent = nullptr);
+    SampleSinkFifo(QObject* parent = nullptr);
+    SampleSinkFifo(int size, QObject* parent = nullptr);
     SampleSinkFifo(const SampleSinkFifo& other);
-	~SampleSinkFifo();
+    ~SampleSinkFifo();
 
-	bool setSize(int size);
+    bool setSize(int size);
     void reset();
-	void setWrittenSignalRateDivider(unsigned int divider);
-	inline unsigned int size() { QMutexLocker mutexLocker(&m_mutex); unsigned int size = m_size; return size; }
-	inline unsigned int fill() { QMutexLocker mutexLocker(&m_mutex); unsigned int fill = m_fill; return fill; }
+    void setWrittenSignalRateDivider(unsigned int divider);
+    inline unsigned int size() { QMutexLocker mutexLocker(&m_mutex); unsigned int size = m_size; return size; }
+    inline unsigned int fill() { QMutexLocker mutexLocker(&m_mutex); unsigned int fill = m_fill; return fill; }
 
-	unsigned int write(const quint8* data, unsigned int count);
-	unsigned int write(SampleVector::const_iterator begin, SampleVector::const_iterator end);
+    unsigned int write(const quint8* data, unsigned int count);
+    unsigned int write(SampleVector::const_iterator begin, SampleVector::const_iterator end);
 
-	unsigned int read(SampleVector::iterator begin, SampleVector::iterator end);
+    unsigned int read(SampleVector::iterator begin, SampleVector::iterator end);
 
-	unsigned int readBegin(unsigned int count,
-		SampleVector::iterator* part1Begin, SampleVector::iterator* part1End,
-		SampleVector::iterator* part2Begin, SampleVector::iterator* part2End);
-	unsigned int readCommit(unsigned int count);
-	void setLabel(const QString& label) { m_label = label; }
+    unsigned int readBegin(unsigned int count,
+        SampleVector::iterator* part1Begin, SampleVector::iterator* part1End,
+        SampleVector::iterator* part2Begin, SampleVector::iterator* part2End);
+    unsigned int readCommit(unsigned int count);
+    void setLabel(const QString& label) { m_label = label; }
     static unsigned int getSizePolicy(unsigned int sampleRate);
 
 signals:
-	void dataReady();
-	void written(int nsamples, qint64 timestamp);
-	void overflow(int nsamples);
-	void underflow(int nsamples);
+    void dataReady();
+    void written(int nsamples, qint64 timestamp);
+    void overflow(int nsamples);
+    void underflow(int nsamples);
 };
 
 #endif // INCLUDE_SAMPLEFIFO_H


### PR DESCRIPTION
Improve overflow diagnostics in DataFifo and SampleSinkFifo without changing FIFO overflow handling or signaling behavior.

FIFO overflows can occur repeatedly when a consumer cannot keep up with the incoming data rate. Logging every overflow can flood the application logs and obscure other messages, while providing little additional information about the underlying problem.

Refactor the common overflow handling into dedicated helper functions so DataFifo and SampleSinkFifo use consistent logging and rate-limiting behavior. Include the FIFO size in DataFifo overflow messages to provide additional diagnostic information.

Rate-limit overflow messages while continuing to report every overflow through the SampleSinkFifo signal. During the suppression interval, accumulate the number of dropped samples and overflow events and report them as a single aggregate message.

After an aggregate report, require a quiet recovery interval before resuming immediate overflow reporting. This limits log volume while retaining useful information about the severity and duration of FIFO overruns.

Also normalize whitespace in the affected files.

There are no changes to FIFO data handling or overflow signaling. The changes are limited to overflow diagnostics, logging behavior, and code organization.
