### PR TITLE
Eliminate the possibilities of accessing buffers with negative indexes

### DIFF
--- a/ft8/ft4.cpp
+++ b/ft8/ft4.cpp
@@ -1495,15 +1495,14 @@ std::vector<std::vector<float>> FT4::soft_c2m(const FFTEngine::ffts_t &c103) con
 
         // choose the phase that has the lowest total distance to other
         // phases. like median but avoids -pi..pi wrap-around.
-        int n = v.size();
-        int best = -1;
-        float best_score = 0;
-        for (int i = 0; i < n; i++)
-
+        const size_t n = v.size();
+        size_t best = 0;
+        float best_score = std::numeric_limits<float>::infinity();
+        for (size_t i = 0; i < n; i++)
         {
             float score = 0;
 
-            for (int j = 0; j < n; j++)
+            for (size_t j = 0; j < n; j++)
             {
                 if (i == j) {
                     continue;
@@ -1518,7 +1517,7 @@ std::vector<std::vector<float>> FT4::soft_c2m(const FFTEngine::ffts_t &c103) con
                 score += d;
             }
 
-            if (best == -1 || score < best_score)
+            if (score < best_score)
             {
                 best = i;
                 best_score = score;

--- a/ft8/ft8.cpp
+++ b/ft8/ft8.cpp
@@ -1562,7 +1562,7 @@ std::vector<std::vector<float>> FT8::soft_c2m(const FFTEngine::ffts_t &c79) cons
     {
         m79[si].resize(8);
         float mx = -std::numeric_limits<float>::infinity();
-        float mx_phase;
+        float mx_phase = 0;
 
         for (int bi = 0; bi < 8; bi++)
         {
@@ -1602,15 +1602,14 @@ std::vector<std::vector<float>> FT8::soft_c2m(const FFTEngine::ffts_t &c79) cons
 
         // choose the phase that has the lowest total distance to other
         // phases. like median but avoids -pi..pi wrap-around.
-        int n = v.size();
-        int best = -1;
-        float best_score = 0;
-        for (int i = 0; i < n; i++)
-
+        const size_t n = v.size();
+        size_t best = 0;
+        float best_score = std::numeric_limits<float>::infinity();
+        for (size_t i = 0; i < n; i++)
         {
             float score = 0;
 
-            for (int j = 0; j < n; j++)
+            for (size_t j = 0; j < n; j++)
             {
                 if (i == j) {
                     continue;
@@ -1625,7 +1624,7 @@ std::vector<std::vector<float>> FT8::soft_c2m(const FFTEngine::ffts_t &c79) cons
                 score += d;
             }
 
-            if (best == -1 || score < best_score)
+            if (score < best_score)
             {
                 best = i;
                 best_score = score;

--- a/plugins/channelrx/freqscanner/freqscanner.cpp
+++ b/plugins/channelrx/freqscanner/freqscanner.cpp
@@ -523,10 +523,11 @@ void FreqScanner::processScanResults(const QDateTime& fftStartTime, const QList<
                     else // TABLE_ORDER
                     {
                         // Find first frequency in list above threshold
-                        for (int i = 0; i < m_scanResults.size(); i++)
+                        const size_t n = m_scanResults.size();
+                        for (size_t i = 0; i < n; i++)
                         {
-                            int j = m_settings.m_voiceSquelchType == FreqScannerSettings::VoiceSquelchType::VoiceLsb ?
-                                m_scanResults.size()-1 - i : i;
+                            const size_t j = m_settings.m_voiceSquelchType == FreqScannerSettings::VoiceSquelchType::VoiceLsb ?
+                                n - 1 - i : i;
 
                             if (lockDeviceFrequency && !isInCurrentScanRange(m_scanResults[j].m_frequency)) {
                                 continue;


### PR DESCRIPTION
Fix two issues where index calculations could potentially (but not likely) result in a negative value being used to access a container.

FT8/FT4
The phase selection logic used `-1` as a sentinel value for the best phase index. The sentinel is moved from the index to the score by initializing the best score to positive infinity. This ensures the best index is always a valid container index and eliminates the possibility of accessing data with an index of `-1`.

FreqScanner
The reverse scan index calculation could potentially produce `-1` when using signed indices. The calculation is changed to use `size_t`, ensuring the resulting index remains a valid unsigned container index and cannot become negative.

These changes eliminate potential invalid container accesses identified by cppcheck.
