### PR TITLE
Update rtl-sdr version

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -27,7 +27,7 @@ set(MIRISDR_TAG "v2.0.0")
 set(LIBSIGMF_TAG "new-namespaces")
 
 set(PTHREADS4W_TAG "Version-2-11-0-release")
-set(RTLSDR_TAG "v2.0.1")
+set(RTLSDR_TAG "v2.0.3")
 set(RTLSDR_UDEV OFF)
 set(SOAPYSDR_TAG "1667b4e6301d7ad47b340dcdcd6e9969bf57d843")
 set(SOAPYSDR_SDRPLAY_TAG "soapy-sdrplay-0.2.0")

--- a/flatpak/org.sdrangel.SDRangel.yaml
+++ b/flatpak/org.sdrangel.SDRangel.yaml
@@ -380,9 +380,8 @@ modules:
       - -Wno-dev
     sources:
       - type: git
-        url: https://github.com/steve-m/librtlsdr.git
-        # latest master for 2.0.2 versioning fix
-        commit: ae0dd6d4f09088d13500a854091b45ad281ca4f0
+        url: https://github.com/osmocom/rtl-sdr.git
+        commit: 797f8143266d983c56d8f35d2d442527529dd8a5
 
   - name: plutosdr
     buildsystem: cmake-ninja

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -524,7 +524,7 @@ parts:
         plugin: cmake
         source: https://github.com/osmocom/rtl-sdr.git
         source-type: git
-        source-commit: 420086af84d7eaaf98ff948cd11fea2cae71734a
+        source-commit: 797f8143266d983c56d8f35d2d442527529dd8a5
         build-packages:
             - libusb-1.0-0-dev
         cmake-parameters:


### PR DESCRIPTION
Latest 2.0.3 release brings RTL-SDR Blog V4L support and other improvements.