### PR TITLE
Fix data races identified by ThreadSanitizer

### DIFF
--- a/plugins/channelrx/demodadsb/adsbdemodsink.cpp
+++ b/plugins/channelrx/demodadsb/adsbdemodsink.cpp
@@ -121,10 +121,14 @@ void ADSBDemodSink::feed(const SampleVector::const_iterator& begin, const Sample
 
 void ADSBDemodSink::processOneSample(Real magsq)
 {
-    m_magsqSum += magsq;
-    if (magsq > m_magsqPeak)
-        m_magsqPeak = magsq;
-    m_magsqCount++;
+    {
+        QMutexLocker locker(&m_magsqMutex);
+
+        m_magsqSum += magsq;
+        if (magsq > m_magsqPeak)
+           m_magsqPeak = magsq;
+        m_magsqCount++;
+    }
     m_sampleBuffer[m_writeBuffer][m_writeIdx] = magsq;
     m_writeIdx++;
     if (!m_bufferDateTimeValid[m_writeBuffer])

--- a/plugins/channelrx/demodadsb/adsbdemodsink.h
+++ b/plugins/channelrx/demodadsb/adsbdemodsink.h
@@ -35,6 +35,8 @@ public:
 
     void getMagSqLevels(double& avg, double& peak, int& nbSamples)
     {
+        QMutexLocker locker(&m_magsqMutex);
+
         if (m_magsqCount > 0)
         {
             m_magsq = m_magsqSum / m_magsqCount;
@@ -106,6 +108,8 @@ private:
     double m_magsqPeak;
     int  m_magsqCount;
     MagSqLevelsStore m_magSqLevelStore;
+
+    QMutex m_magsqMutex;
 
     MessageQueue *m_messageQueueToGUI;
     MessageQueue *m_messageQueueToWorker;

--- a/plugins/samplemimo/plutosdrmimo/plutosdrmithread.h
+++ b/plugins/samplemimo/plutosdrmimo/plutosdrmithread.h
@@ -21,6 +21,7 @@
 #ifndef _PLUTOSDR_PLUTOSDRMITHREAD_H_
 #define _PLUTOSDR_PLUTOSDRMITHREAD_H_
 
+#include <atomic>
 #include <QThread>
 #include <QMutex>
 #include <QWaitCondition>
@@ -53,7 +54,7 @@ signals:
 private:
     QMutex m_startWaitMutex;
     QWaitCondition m_startWaiter;
-    bool m_running;
+    std::atomic_bool m_running;
 
     DevicePlutoSDRBox *m_plutoBox;
     qint16 *m_buf[2]; //!< one buffer per I/Q channel

--- a/plugins/samplemimo/plutosdrmimo/plutosdrmothread.h
+++ b/plugins/samplemimo/plutosdrmimo/plutosdrmothread.h
@@ -21,6 +21,7 @@
 #ifndef _PLUTOSDR_PLUTOSDRMOTHREAD_H_
 #define _PLUTOSDR_PLUTOSDRMOTHREAD_H_
 
+#include <atomic>
 #include <QThread>
 #include <QMutex>
 #include <QWaitCondition>
@@ -52,7 +53,7 @@ signals:
 private:
     QMutex m_startWaitMutex;
     QWaitCondition m_startWaiter;
-    bool m_running;
+    std::atomic_bool m_running;
 
     DevicePlutoSDRBox *m_plutoBox;
     qint16 *m_buf[2]; //!< one buffer per I/Q channel

--- a/plugins/samplesink/plutosdroutput/plutosdroutputthread.h
+++ b/plugins/samplesink/plutosdroutput/plutosdroutputthread.h
@@ -21,6 +21,7 @@
 #ifndef PLUGINS_SAMPLESOURCE_PLUTOSDROUTPUT_PLUTOSDROUTPUTTHREAD_H_
 #define PLUGINS_SAMPLESOURCE_PLUTOSDROUTPUT_PLUTOSDROUTPUTTHREAD_H_
 
+#include <atomic>
 #include <QThread>
 #include <QMutex>
 #include <QWaitCondition>
@@ -51,7 +52,7 @@ signals:
 private:
     QMutex m_startWaitMutex;
     QWaitCondition m_startWaiter;
-    bool m_running;
+    std::atomic_bool m_running;
 
     DevicePlutoSDRBox *m_plutoBox;
     int16_t *m_buf;                 //!< holds I+Q values of each sample from device

--- a/plugins/samplesource/plutosdrinput/plutosdrinputthread.h
+++ b/plugins/samplesource/plutosdrinput/plutosdrinputthread.h
@@ -21,6 +21,7 @@
 #ifndef PLUGINS_SAMPLESOURCE_PLUTOSDRINPUT_PLUTOSDRINPUTTHREAD_H_
 #define PLUGINS_SAMPLESOURCE_PLUTOSDRINPUT_PLUTOSDRINPUTTHREAD_H_
 
+#include <atomic>
 #include <QThread>
 #include <QMutex>
 #include <QWaitCondition>
@@ -53,7 +54,7 @@ signals:
 private:
     QMutex m_startWaitMutex;
     QWaitCondition m_startWaiter;
-    bool m_running;
+    std::atomic_bool m_running;
 
     DevicePlutoSDRBox *m_plutoBox;
     int16_t *m_buf;               //!< holds I+Q values of each sample from device

--- a/sdrbase/dsp/dspdevicesinkengine.h
+++ b/sdrbase/dsp/dspdevicesinkengine.h
@@ -22,6 +22,7 @@
 #ifndef SDRBASE_DSP_DSPDEVICESINKENGINE_H_
 #define SDRBASE_DSP_DSPDEVICESINKENGINE_H_
 
+#include <atomic>
 #include <QObject>
 #include <QTimer>
 #include <QMutex>
@@ -83,7 +84,7 @@ private:
 
 	MessageQueue m_inputMessageQueue;  //<! Input message queue. Post here.
 
-	State m_state;
+	std::atomic<State> m_state;
 
 	QString m_errorMessage;
 	QString m_deviceDescription;

--- a/sdrgui/gui/glspectrumview.h
+++ b/sdrgui/gui/glspectrumview.h
@@ -26,6 +26,7 @@
 #ifndef INCLUDE_GLSPECTRUMVIEW_H
 #define INCLUDE_GLSPECTRUMVIEW_H
 
+#include <atomic>
 #include <QTimer>
 #include <QMutex>
 #include <QOpenGLBuffer>
@@ -431,7 +432,7 @@ private:
     QMatrix4x4 m_glHistogramSpectrumMatrix;
     QMatrix4x4 m_glHistogramBoxMatrix;
     bool m_displayHistogram;
-    bool m_displayChanged;
+    std::atomic_bool m_displayChanged;
     bool m_displaySourceOrSink;
     int m_displayStreamIndex;
     float m_frequencyZoomFactor;


### PR DESCRIPTION
ThreadSanitizer instruments memory accesses and reports conflicting accesses that occur between threads without a recognized happens-before relationship. This makes it particularly useful for finding races that may not reproduce reliably under normal execution.

The TSan run identified several real races in SDRangel's multithreaded code. The affected variables were reviewed and synchronized where appropriate using `std::atomic` or `QMutex`.

### Issues identified and fixed

* **PlutoSDR thread running state**

  `PlutoSDRInputThread::m_running` was accessed by both the thread controlling the worker and the worker executing `run()`. Making the variable atomic removes the unsynchronized accesses used to start, stop, and monitor the worker thread.
  This is likely an issue in all hardware radios, and after we see that this doesn't cause any negative side effects, all implementations that do similar things should be updated.

* **GL spectrum display state**

  `GLSpectrumView::m_displayChanged` was accessed from multiple execution contexts without synchronization. Making the flag atomic removes the reported data race.

* **ADS-B magnitude statistics**

  `ADSBDemodSink::m_magsqSum`, `m_magsqPeak`, and `m_magsqCount` were updated by the sample processing path while being read by the GUI path. A mutex now protects both access paths.

* **DSP device sink engine state**

  `DSPDeviceSinkEngine::m_state` was written by the engine's state transition code while being read through `state()` by other users of the engine. Making the state atomic removes the unsynchronized read/write access reported by TSan.

### Future work

Not every TSan report represented a defect in SDRangel itself. Several reports were traced into Qt, GLib, DBus, and other synchronization or system-library code. (because TSan needs to be turned on for everything - which is a giant pain to set up). I'm investigating augmenting sdrangel-docker to help developers use this tooling more often (because it's pretty awesome).
