### PR TITLE
Fix Meshtastic interpolator bandwidth update

### DIFF
--- a/plugins/channelrx/demodmeshtastic/meshtasticdemodsink.cpp
+++ b/plugins/channelrx/demodmeshtastic/meshtasticdemodsink.cpp
@@ -1234,7 +1234,7 @@ void MeshtasticDemodSink::applyChannelSettings(int channelSampleRate, int bandwi
         const int targetFrameSyncRate = std::max(1, bandwidth * static_cast<int>(m_osFactor));
         // Keep the anti-alias/channel filter narrow around the configured LoRa bandwidth.
         // A too-wide cutoff destabilizes preamble bin tracking in DETECT.
-        m_interpolator.create(16, channelSampleRate, m_bandwidth / 1.9f);
+        m_interpolator.create(16, channelSampleRate, bandwidth / 1.9f);
         m_interpolatorDistance = (Real) channelSampleRate / (Real) targetFrameSyncRate;
         m_sampleDistanceRemain = 0;
         m_osCounter = 0;


### PR DESCRIPTION
`MeshtasticDemodSink::applyChannelSettings()` rebuilds the interpolator when the **channel sample rate** or **LoRa bandwidth** changes.

Previously, the interpolator cutoff was calculated using `m_bandwidth`, which still contains the previous bandwidth value at that point in the function. The new bandwidth is not assigned to `m_bandwidth` until later.

This fix changes the interpolator creation call to use the requested `bandwidth` argument directly, ensuring that the interpolator is configured for the new LoRa bandwidth.
