### PR TITLE
Python Example: Update Python 2 syntax in Swagger example

### DIFF
--- a/swagger/sdrangel/examples/randomize_colors.py
+++ b/swagger/sdrangel/examples/randomize_colors.py
@@ -182,11 +182,11 @@ def main():
                 randomize_channels_colors(options, channels) # full randomization (identical to -Hsv)
         else:
             print("Error getting deviceset %d info. HTTP: %d" % (options.device_index, r.status_code))
-            print json.dumps(r.json(), indent=4, sort_keys=True)
+            print(json.dumps(r.json(), indent=4, sort_keys=True))
 
     except Exception as ex:
         tb = traceback.format_exc()
-        print >> sys.stderr, tb
+        print(tb, file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update the legacy randomize_colors.py Swagger example to use Python 3 print syntax. The Python 2 print statements prevented [Bandit](https://github.com/pycqa/bandit) from parsing the file during [Codacy](https://www.codacy.com/) analysis and caused the analysis step to fail.

Verified that all Python files in the repository compile successfully with Python 3.

Tested with:
```shell
   for f in $(find ./ -name "*.py") ; do echo $f ; python3 -m py_compile "$f" 2>&1 ; echo ; done
```